### PR TITLE
Pin postcss >=8.5.10 via override to clear XSS advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -301,30 +301,6 @@
       "license": "Apache-2.0",
       "peer": true
     },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.0.tgz",
-      "integrity": "sha512-55coeOFKHv1ywEcUXJtWU5f+Jr/W5tZDvZig8DLKSwUN1JpROQ4rk/SNOQiFWmaR/VKF4zuFyW1B8JduOSv6Pg==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
-    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -4524,6 +4500,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6473,34 +6450,6 @@
         "sass": {
           "optional": true
         }
-      }
-    },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
       }
     },
     "node_modules/node-exports-info": {

--- a/package.json
+++ b/package.json
@@ -35,5 +35,8 @@
     "tailwindcss": "^4",
     "tsx": "^4.22.4",
     "typescript": "^5"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
## What

Adds a root `package.json` override forcing `postcss ^8.5.10` (resolves to 8.5.15) across the dependency tree.

## Why

Next 16.2.9 bundles `postcss@8.4.31`, flagged by [GHSA-qx2v-qp2m-jg93](https://github.com/advisories/GHSA-qx2v-qp2m-jg93) (XSS via unescaped `</style>` in CSS stringify output). The override deduplicates postcss to a patched version everywhere (both Next's bundled copy and `@tailwindcss/postcss`).

This clears 1 of the 4 open Dependabot alerts on the v2 root. All four are dev/build-time only — none ship to operator phones at runtime.

## What's left (not in this PR)

The remaining 3 alerts are `esbuild`, pulled in transitively by `drizzle-kit@0.31.10` (already latest) via the deprecated `@esbuild-kit/*` packages and drizzle-kit's own `esbuild@^0.25.4`. They're **accepted, not fixed**: the patched `esbuild@0.28.1` violates both pinned ranges and breaks drizzle-kit's migration tooling, and the advisory's attack vector (an exposed esbuild dev server) doesn't apply to one-shot transform usage. These should clear on their own once drizzle-kit drops `@esbuild-kit/*` (merged upstream into `tsx`).

## Verification

- `npm run build` — clean
- `npx drizzle-kit generate --help` — OK (DB tooling unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)