### PR TITLE
Promote WebRTC PTT spike to a production voice layer (#22)

### DIFF
--- a/app/(mobile)/comms/page.tsx
+++ b/app/(mobile)/comms/page.tsx
@@ -25,11 +25,14 @@ export default function CommsScreen() {
   const [enabled, setEnabled] = useState(false);
   const { talking } = useFdSession();
 
-  // Identity is in sessionStorage — read after mount (MobileShell gates entry).
+  // Identity is in sessionStorage — read after mount (not during SSR, which
+  // would hydration-mismatch). MobileShell already gates entry on a join.
   useEffect(() => {
     const op = getOperator();
+    if (!op) return;
+    // eslint-disable-next-line react-hooks/set-state-in-effect
     setOperator(op);
-    if (op) setChannel(defaultChannelForRole(op.role));
+    setChannel(defaultChannelForRole(op.role));
   }, []);
 
   const channels: VoiceChannel[] = operator ? channelsForRole(operator.role) : [];

--- a/app/(mobile)/comms/page.tsx
+++ b/app/(mobile)/comms/page.tsx
@@ -1,15 +1,224 @@
+"use client";
+
+/**
+ * Comms — in-app WebRTC push-to-talk (Option A; replaces the Zello placeholder).
+ *
+ * Channels are session-local and resolved by the operator's role. Enabling
+ * voice acquires the mic (PTT-gated), connects to the channel's signaling, and
+ * meshes with the other operators on it. Talk indicators for everyone on the
+ * session arrive over the app SSE stream (`voice_talk`), so the roster shows
+ * who is speaking even before their audio is routed.
+ */
+import { useEffect, useState } from "react";
+import { getOperator, type Operator } from "@/lib/client/operator";
+import { useFdSession } from "@/lib/client/useFdSession";
+import { useVoiceChannel } from "@/lib/voice/useVoiceChannel";
+import {
+  channelsForRole,
+  defaultChannelForRole,
+  type VoiceChannel,
+} from "@/lib/voice/channels";
+
 export default function CommsScreen() {
+  const [operator, setOperator] = useState<Operator | null>(null);
+  const [channel, setChannel] = useState<string>("");
+  const [enabled, setEnabled] = useState(false);
+  const { talking } = useFdSession();
+
+  // Identity is in sessionStorage — read after mount (MobileShell gates entry).
+  useEffect(() => {
+    const op = getOperator();
+    setOperator(op);
+    if (op) setChannel(defaultChannelForRole(op.role));
+  }, []);
+
+  const channels: VoiceChannel[] = operator ? channelsForRole(operator.role) : [];
+
+  const voice = useVoiceChannel({
+    operatorId: operator?.operatorId ?? "",
+    name: operator?.name ?? "operator",
+    channel,
+    enabled: enabled && !!operator && !!channel,
+  });
+
+  // Spacebar = PTT while voice is live (desktop convenience).
+  const { micReady, pttDown, pttUp } = voice;
+  useEffect(() => {
+    if (!enabled || !micReady) return;
+    const down = (e: KeyboardEvent) => {
+      if (e.code === "Space" && !e.repeat && !isTyping(e)) {
+        e.preventDefault();
+        pttDown();
+      }
+    };
+    const up = (e: KeyboardEvent) => {
+      if (e.code === "Space" && !isTyping(e)) {
+        e.preventDefault();
+        pttUp();
+      }
+    };
+    window.addEventListener("keydown", down);
+    window.addEventListener("keyup", up);
+    return () => {
+      window.removeEventListener("keydown", down);
+      window.removeEventListener("keyup", up);
+    };
+  }, [enabled, micReady, pttDown, pttUp]);
+
+  if (!operator) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-xl font-bold">Comms</h1>
+        <p className="text-sm text-slate-400">Loading…</p>
+      </div>
+    );
+  }
+
+  const activeLabel = channels.find((c) => c.id === channel)?.label ?? channel;
+
   return (
     <div className="space-y-4">
-      <h1 className="text-xl font-bold">Comms</h1>
-      <section className="rounded-xl border border-slate-800 bg-slate-900/50 p-6 text-center text-sm text-slate-400">
-        <p className="text-2xl">🎙</p>
-        <p className="mt-2 font-medium text-slate-200">Voice is being rebuilt</p>
-        <p className="mt-1">
-          Push-to-talk is moving to in-app WebRTC (channels stay local to the
-          session, no external account). Coming in a future update.
-        </p>
-      </section>
+      <div className="flex items-center justify-between">
+        <h1 className="text-xl font-bold">Comms</h1>
+        {enabled && (
+          <button
+            onClick={() => setEnabled(false)}
+            className="text-sm text-red-400 active:text-red-300"
+          >
+            Leave voice
+          </button>
+        )}
+      </div>
+
+      {!voice.secure && (
+        <div className="rounded-lg border border-amber-800 bg-amber-950/40 p-3 text-sm text-amber-200">
+          ⚠️ Microphone needs a secure context. Works on <code>localhost</code>;
+          on a phone over the LAN it needs HTTPS (tracked in #23).
+        </div>
+      )}
+
+      {/* Channel picker */}
+      <div className="flex flex-wrap gap-2">
+        {channels.map((c) => {
+          const active = c.id === channel;
+          const someoneTalking = Object.values(talking).some(
+            (t) => t.channel === c.id,
+          );
+          return (
+            <button
+              key={c.id}
+              onClick={() => setChannel(c.id)}
+              className={`flex items-center gap-1.5 rounded-full border px-3 py-1.5 text-sm ${
+                active
+                  ? "border-sky-500 bg-sky-600/20 text-sky-300"
+                  : "border-slate-700 bg-slate-900/60 text-slate-300"
+              }`}
+            >
+              {someoneTalking && <span className="text-xs">🔊</span>}
+              {c.label}
+            </button>
+          );
+        })}
+      </div>
+
+      {!enabled ? (
+        <button
+          onClick={() => setEnabled(true)}
+          className="w-full rounded-xl bg-sky-600 py-4 text-lg font-bold text-white active:bg-sky-700"
+        >
+          🎙 Enable voice — {activeLabel}
+        </button>
+      ) : voice.error ? (
+        <div className="rounded-lg border border-red-800 bg-red-950/50 px-4 py-3 text-sm text-red-200">
+          {voice.error}
+        </div>
+      ) : !voice.micReady ? (
+        <div className="rounded-lg border border-slate-700 bg-slate-900/60 px-4 py-3 text-sm text-slate-300">
+          Requesting microphone…
+        </div>
+      ) : (
+        <button
+          onPointerDown={voice.pttDown}
+          onPointerUp={voice.pttUp}
+          onPointerLeave={voice.pttUp}
+          className={`w-full select-none rounded-2xl py-8 text-xl font-bold text-white transition-colors ${
+            voice.talking ? "bg-green-600" : "bg-slate-700 active:bg-slate-600"
+          }`}
+          style={{ touchAction: "none" }}
+        >
+          {voice.talking ? "🎙 TALKING — release to stop" : "Hold to talk"}
+          <span className="mt-1 block text-xs font-normal opacity-70">
+            on {activeLabel} · or hold Space
+          </span>
+        </button>
+      )}
+
+      {/* Roster */}
+      {enabled && (
+        <section className="space-y-2">
+          <h2 className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+            On {activeLabel}
+          </h2>
+          {/* Self */}
+          <Row
+            name={`${operator.name} (you)`}
+            talking={voice.talking}
+            state={voice.micReady ? "ready" : "connecting"}
+          />
+          {voice.peers.length === 0 && (
+            <p className="px-1 text-sm text-slate-500">
+              No one else on this channel yet.
+            </p>
+          )}
+          {voice.peers.map((p) => (
+            <Row
+              key={p.id}
+              name={p.name}
+              talking={!!talking[p.id]}
+              state={p.state}
+            />
+          ))}
+        </section>
+      )}
     </div>
   );
+}
+
+function Row({
+  name,
+  talking,
+  state,
+}: {
+  name: string;
+  talking: boolean;
+  state: string;
+}) {
+  return (
+    <div
+      className={`flex items-center justify-between rounded-lg border px-3 py-2 text-sm ${
+        talking
+          ? "border-green-600 bg-green-600/15 text-green-200"
+          : "border-slate-800 bg-slate-900/50 text-slate-200"
+      }`}
+    >
+      <span className="font-medium">
+        {talking ? "🔊 " : ""}
+        {name}
+      </span>
+      <span
+        className={`text-xs ${
+          state === "connected" || state === "ready"
+            ? "text-green-400"
+            : "text-amber-400"
+        }`}
+      >
+        {state}
+      </span>
+    </div>
+  );
+}
+
+function isTyping(e: KeyboardEvent): boolean {
+  const el = e.target as HTMLElement | null;
+  return !!el && (el.tagName === "INPUT" || el.tagName === "TEXTAREA" || el.isContentEditable);
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -13,7 +13,7 @@ function elapsed(since: string): string {
 }
 
 export default function AdminDashboard() {
-  const { state, opsLog, connected, refresh } = useFdSession();
+  const { state, opsLog, connected, talking, refresh } = useFdSession();
   const [busy, setBusy] = useState(false);
 
   const session = state?.session ?? null;
@@ -163,14 +163,27 @@ export default function AdminDashboard() {
               <p className="text-sm text-slate-400">No operators connected.</p>
             ) : (
               <ul className="space-y-1.5 text-sm">
-                {operators.map((o) => (
-                  <li key={o.id} className="flex items-center justify-between">
-                    <span>{o.name}</span>
-                    <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs capitalize text-slate-300">
-                      {o.role}
-                    </span>
-                  </li>
-                ))}
+                {operators.map((o) => {
+                  const speaking = talking[o.id];
+                  return (
+                    <li key={o.id} className="flex items-center justify-between">
+                      <span
+                        className={speaking ? "font-medium text-green-300" : undefined}
+                      >
+                        {speaking ? "🔊 " : ""}
+                        {o.name}
+                        {speaking && (
+                          <span className="ml-1 text-xs text-green-500">
+                            on {speaking.channel}
+                          </span>
+                        )}
+                      </span>
+                      <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs capitalize text-slate-300">
+                        {o.role}
+                      </span>
+                    </li>
+                  );
+                })}
               </ul>
             )}
           </Panel>

--- a/app/api/voice/signal/route.ts
+++ b/app/api/voice/signal/route.ts
@@ -1,0 +1,102 @@
+/**
+ * Voice signaling endpoint (production) — WebRTC negotiation transport.
+ *
+ *   GET  /api/voice/signal?channel=<id>&token=<sessionToken>
+ *        SSE stream of negotiation messages for this operator on this channel.
+ *        (EventSource can't send an Authorization header, so the session token
+ *        rides in the query string and is verified the same way.)
+ *   POST /api/voice/signal   { channel, ...VoiceSignal }   Bearer token
+ *        Relays one negotiation message to the target peer / channel.
+ *
+ * The peer id is the verified operatorId (never client-supplied), and the
+ * channel is authorized against the operator's role (spec §4 RBAC). Kept off
+ * the FdEvent contract on purpose — see lib/voice/signalHub.
+ */
+import { voiceSignalHub, type VoiceSignal } from "@/lib/voice/signalHub";
+import { roleCanAccess, roomId } from "@/lib/voice/channels";
+import { verifyToken, tokenFromRequest } from "@/lib/server/sessionToken";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const KEEPALIVE_MS = 20_000;
+
+export async function GET(req: Request) {
+  const url = new URL(req.url);
+  const channel = url.searchParams.get("channel") ?? "";
+  const claims = verifyToken(url.searchParams.get("token"));
+  if (!claims) return new Response("unauthorized", { status: 401 });
+  if (!roleCanAccess(claims.role, channel)) {
+    return new Response("forbidden channel", { status: 403 });
+  }
+
+  const room = roomId(claims.sessionId, channel);
+  const id = claims.operatorId;
+  const name = url.searchParams.get("name") || "operator";
+
+  let registration: { remove: () => void } | null = null;
+  let keepalive: ReturnType<typeof setInterval> | null = null;
+
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      const encoder = new TextEncoder();
+      controller.enqueue(encoder.encode(`: connected\n\n`));
+      registration = voiceSignalHub.add(room, id, name, controller);
+
+      keepalive = setInterval(() => {
+        try {
+          controller.enqueue(encoder.encode(`: ping\n\n`));
+        } catch {
+          /* closed; cleanup runs on abort */
+        }
+      }, KEEPALIVE_MS);
+
+      req.signal.addEventListener("abort", () => {
+        if (keepalive) clearInterval(keepalive);
+        registration?.remove();
+        try {
+          controller.close();
+        } catch {
+          /* already closed */
+        }
+      });
+    },
+    cancel() {
+      if (keepalive) clearInterval(keepalive);
+      registration?.remove();
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      "Content-Type": "text/event-stream",
+      "Cache-Control": "no-cache, no-transform",
+      Connection: "keep-alive",
+      "X-Accel-Buffering": "no",
+    },
+  });
+}
+
+export async function POST(req: Request) {
+  const claims = tokenFromRequest(req);
+  if (!claims) return new Response("unauthorized", { status: 401 });
+
+  let body: (VoiceSignal & { channel?: string }) | null = null;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("bad json", { status: 400 });
+  }
+  if (!body || !("kind" in body) || !body.channel) {
+    return new Response("missing kind/channel", { status: 400 });
+  }
+  if (!roleCanAccess(claims.role, body.channel)) {
+    return new Response("forbidden channel", { status: 403 });
+  }
+  // Pin `from` to the verified operator so peers can't be spoofed; drop the
+  // routing-only `channel` field from the relayed frame.
+  const { channel, ...rest } = body;
+  const msg = { ...rest, from: claims.operatorId } as VoiceSignal;
+  voiceSignalHub.relay(roomId(claims.sessionId, channel), msg);
+  return new Response(null, { status: 204 });
+}

--- a/app/api/voice/signal/route.ts
+++ b/app/api/voice/signal/route.ts
@@ -93,10 +93,9 @@ export async function POST(req: Request) {
   if (!roleCanAccess(claims.role, body.channel)) {
     return new Response("forbidden channel", { status: 403 });
   }
-  // Pin `from` to the verified operator so peers can't be spoofed; drop the
-  // routing-only `channel` field from the relayed frame.
-  const { channel, ...rest } = body;
-  const msg = { ...rest, from: claims.operatorId } as VoiceSignal;
-  voiceSignalHub.relay(roomId(claims.sessionId, channel), msg);
+  // Pin `from` to the verified operator so peers can't be spoofed. (The
+  // routing-only `channel` field rides along in the frame; peers ignore it.)
+  const msg = { ...body, from: claims.operatorId } as VoiceSignal;
+  voiceSignalHub.relay(roomId(claims.sessionId, body.channel), msg);
   return new Response(null, { status: 204 });
 }

--- a/app/api/voice/talk/route.ts
+++ b/app/api/voice/talk/route.ts
@@ -1,0 +1,43 @@
+/**
+ * Voice talk indicator (production).
+ *
+ *   POST /api/voice/talk   { channel, talking }   Bearer token
+ *
+ * Broadcasts a coarse `voice_talk` FdEvent ("operator X is/isn't talking on
+ * channel Y") to every connected client so the in-channel roster, dispatchers,
+ * and the Admin dashboard all see who is speaking. Ephemeral: live-only, never
+ * written to ops_log (PTT churn has no audit value). The audio itself flows
+ * peer-to-peer over WebRTC; this is presence only.
+ */
+import { tokenFromRequest } from "@/lib/server/sessionToken";
+import { roleCanAccess } from "@/lib/voice/channels";
+import { sessionManager } from "@/lib/server/SessionManager";
+
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  const claims = tokenFromRequest(req);
+  if (!claims) return new Response("unauthorized", { status: 401 });
+
+  let body: { channel?: string; talking?: boolean; name?: string } | null = null;
+  try {
+    body = await req.json();
+  } catch {
+    return new Response("bad json", { status: 400 });
+  }
+  if (!body?.channel || typeof body.talking !== "boolean") {
+    return new Response("missing channel/talking", { status: 400 });
+  }
+  if (!roleCanAccess(claims.role, body.channel)) {
+    return new Response("forbidden channel", { status: 403 });
+  }
+
+  sessionManager.broadcastEphemeral({
+    type: "voice_talk",
+    operatorId: claims.operatorId,
+    name: body.name?.slice(0, 60) || "operator",
+    channel: body.channel,
+    talking: body.talking,
+  });
+  return new Response(null, { status: 204 });
+}

--- a/lib/client/useFdSession.ts
+++ b/lib/client/useFdSession.ts
@@ -21,11 +21,16 @@ const REFETCH_EVENTS = new Set([
   "emergency_stop",
 ]);
 
+/** Who is currently talking on voice, keyed by operatorId. */
+export type TalkingMap = Record<string, { name: string; channel: string }>;
+
 export interface UseFdSession {
   state: FullState | null;
   opsLog: OpsLogEntry[];
   connected: boolean;
   lastEvent: string | null;
+  /** Operators currently transmitting on a voice channel (live, ephemeral). */
+  talking: TalkingMap;
   refresh: () => Promise<void>;
 }
 
@@ -34,6 +39,7 @@ export function useFdSession(): UseFdSession {
   const [opsLog, setOpsLog] = useState<OpsLogEntry[]>([]);
   const [connected, setConnected] = useState(false);
   const [lastEvent, setLastEvent] = useState<string | null>(null);
+  const [talking, setTalking] = useState<TalkingMap>({});
   const esRef = useRef<EventSource | null>(null);
 
   const refresh = useCallback(async () => {
@@ -77,13 +83,36 @@ export function useFdSession(): UseFdSession {
       return [t, h] as const;
     });
 
+    // voice_talk is ephemeral presence — update the talking map, never refetch.
+    const onTalk = (e: MessageEvent) => {
+      setLastEvent("voice_talk");
+      try {
+        const d = JSON.parse(e.data) as {
+          operatorId: string;
+          name: string;
+          channel: string;
+          talking: boolean;
+        };
+        setTalking((prev) => {
+          const next = { ...prev };
+          if (d.talking) next[d.operatorId] = { name: d.name, channel: d.channel };
+          else delete next[d.operatorId];
+          return next;
+        });
+      } catch {
+        /* ignore */
+      }
+    };
+    es.addEventListener("voice_talk", onTalk as EventListener);
+
     return () => {
       for (const [t, h] of handlers)
         es.removeEventListener(t, h as EventListener);
+      es.removeEventListener("voice_talk", onTalk as EventListener);
       es.close();
       esRef.current = null;
     };
   }, [refresh]);
 
-  return { state, opsLog, connected, lastEvent, refresh };
+  return { state, opsLog, connected, lastEvent, talking, refresh };
 }

--- a/lib/server/SessionManager.ts
+++ b/lib/server/SessionManager.ts
@@ -89,6 +89,15 @@ class SessionManager {
     }
   }
 
+  /**
+   * Broadcast a live-only event to every client WITHOUT persisting it to
+   * ops_log. For high-churn presence (e.g. PTT talk start/stop) that would
+   * otherwise flood the durable log with no audit value.
+   */
+  broadcastEphemeral(event: FdEvent): void {
+    for (const client of this.clients.values()) this.send(client, event);
+  }
+
   // ---- Session helpers ---------------------------------------------------
 
   /** The single active session, or null if none is active. */

--- a/lib/server/events.ts
+++ b/lib/server/events.ts
@@ -18,6 +18,17 @@ export type FdEvent =
   | { type: "authority_granted"; trainId: string; segment: string | null; grantedBy: string | null }
   | { type: "authority_revoked"; trainId: string | null; segment: string | null }
   | { type: "emergency_stop" }
-  | { type: "session_message"; message: string };
+  | { type: "session_message"; message: string }
+  // Coarse voice presence for session-wide / admin visibility. The actual
+  // WebRTC negotiation rides a separate signaling hub (lib/voice/signalHub);
+  // this only says "operator X is/ isn't talking on channel Y". Ephemeral —
+  // broadcast live but not persisted to ops_log (see broadcastEphemeral).
+  | {
+      type: "voice_talk";
+      operatorId: string;
+      name: string;
+      channel: string;
+      talking: boolean;
+    };
 
 export type FdEventType = FdEvent["type"];

--- a/lib/voice/channels.ts
+++ b/lib/voice/channels.ts
@@ -1,0 +1,65 @@
+/**
+ * Voice channel model (WebRTC in-app PTT, Option A — see V2_BUILD_PLAN §5).
+ *
+ * Channels are **session-local**: there is no external account or global
+ * namespace (the whole reason Zello was dropped). The set is deterministic and
+ * derived from the operator's role, so both the client and the signaling
+ * endpoint can resolve it without a DB round-trip — the client renders the
+ * picker, the server uses the same map to authorize a peer onto a channel.
+ *
+ * Each channel maps to one WebRTC mesh "room", keyed per session+channel
+ * (`roomId`) so concurrent sessions can never collide.
+ */
+import type { OperatorRole } from "@/lib/db/schema";
+
+export type ChannelKind = "opsall" | "dispatch" | "yard" | "tech";
+
+export interface VoiceChannel {
+  id: ChannelKind;
+  label: string;
+}
+
+/** The fixed channel set for a session, in a stable display order. */
+export const CHANNELS: VoiceChannel[] = [
+  { id: "dispatch", label: "Dispatch" },
+  { id: "yard", label: "Yard" },
+  { id: "opsall", label: "All Operators" },
+  { id: "tech", label: "Tech Services" },
+];
+
+/** Which channels each role may join (server-enforced; spec §4 RBAC). */
+const ROLE_ACCESS: Record<OperatorRole, ChannelKind[]> = {
+  admin: ["dispatch", "yard", "opsall", "tech"],
+  dispatcher: ["dispatch", "yard", "opsall", "tech"],
+  engineer: ["dispatch", "opsall", "tech"],
+  yardmaster: ["yard", "opsall", "tech"],
+};
+
+/** Channel a role lands on by default after enabling voice. */
+const DEFAULT_BY_ROLE: Record<OperatorRole, ChannelKind> = {
+  admin: "dispatch",
+  dispatcher: "dispatch",
+  engineer: "opsall",
+  yardmaster: "yard",
+};
+
+/** Channels a role may use, in display order. */
+export function channelsForRole(role: OperatorRole): VoiceChannel[] {
+  const allowed = new Set(ROLE_ACCESS[role]);
+  return CHANNELS.filter((c) => allowed.has(c.id));
+}
+
+/** True if a role is permitted on a channel (server-side authorization). */
+export function roleCanAccess(role: OperatorRole, channel: string): boolean {
+  return (ROLE_ACCESS[role] as string[]).includes(channel);
+}
+
+/** The default channel id a role joins first. */
+export function defaultChannelForRole(role: OperatorRole): ChannelKind {
+  return DEFAULT_BY_ROLE[role];
+}
+
+/** Mesh room id for a session+channel — namespaces signaling per session. */
+export function roomId(sessionId: string, channel: string): string {
+  return `${sessionId}:${channel}`;
+}

--- a/lib/voice/signalHub.ts
+++ b/lib/voice/signalHub.ts
@@ -1,0 +1,115 @@
+/**
+ * Voice signaling hub (production) — WebRTC negotiation relay.
+ *
+ * Graduated from the `/spike/ptt` proof (`lib/spike/pttSignalHub`). Carries
+ * only the media-negotiation messages (SDP offer/answer + ICE + peer
+ * presence) over the app's "SSE down + POST up" pattern. It is deliberately
+ * kept OFF the `FdEvent` / `/api/events` contract: this is a high-frequency,
+ * peer-to-peer firehose that the rest of the app should never see. Coarse
+ * "who is talking" presence is a separate `voice_talk` FdEvent instead.
+ *
+ * Rooms are `${sessionId}:${channel}` (see `roomId`), so signaling is scoped
+ * per session and per channel. Peer ids are operator ids (stable, from the
+ * verified session token), which lets talk indicators map straight to peers.
+ *
+ * Topology: full mesh (one RTCPeerConnection per other peer). PTT is one
+ * talker per channel, so media load stays light; a server SFU/relay can
+ * replace mesh later without touching this signaling shape.
+ */
+
+export type VoiceSignal =
+  | { kind: "welcome"; id: string; peers: { id: string; name: string }[] }
+  | { kind: "join"; id: string; name: string }
+  | { kind: "leave"; id: string }
+  | { kind: "offer"; from: string; to: string; payload: unknown }
+  | { kind: "answer"; from: string; to: string; payload: unknown }
+  | { kind: "ice"; from: string; to: string; payload: unknown };
+
+type Peer = {
+  id: string;
+  name: string;
+  room: string;
+  controller: ReadableStreamDefaultController<Uint8Array>;
+};
+
+class VoiceSignalHub {
+  private peers = new Map<string, Peer>();
+  private encoder = new TextEncoder();
+
+  /**
+   * Register a subscribing peer (keyed by room+id so the same operator can be
+   * on different channels in different tabs). Returns an unregister function.
+   */
+  add(
+    room: string,
+    id: string,
+    name: string,
+    controller: ReadableStreamDefaultController<Uint8Array>,
+  ): { remove: () => void } {
+    const key = `${room} ${id}`;
+    this.peers.set(key, { id, name, room, controller });
+    // Tell the newcomer who is already here.
+    this.sendTo(room, id, {
+      kind: "welcome",
+      id,
+      peers: this.peersInRoom(room, id).map((p) => ({ id: p.id, name: p.name })),
+    });
+    // Tell everyone else the newcomer arrived.
+    this.broadcast(room, { kind: "join", id, name }, id);
+    return {
+      remove: () => {
+        this.peers.delete(key);
+        this.broadcast(room, { kind: "leave", id }, id);
+      },
+    };
+  }
+
+  private peersInRoom(room: string, exceptId?: string): Peer[] {
+    return [...this.peers.values()].filter(
+      (p) => p.room === room && p.id !== exceptId,
+    );
+  }
+
+  /** Relay a negotiation message — to one peer if `to` is set, else broadcast. */
+  relay(room: string, msg: VoiceSignal): void {
+    if ("to" in msg && msg.to) {
+      this.sendTo(room, msg.to, msg);
+    } else if ("from" in msg) {
+      this.broadcast(room, msg, msg.from);
+    } else {
+      this.broadcast(room, msg);
+    }
+  }
+
+  private sendTo(room: string, id: string, msg: VoiceSignal): void {
+    const peer = this.peers.get(`${room} ${id}`);
+    if (peer) this.write(peer, msg);
+  }
+
+  private broadcast(room: string, msg: VoiceSignal, exceptId?: string): void {
+    for (const peer of this.peers.values()) {
+      if (peer.room === room && peer.id !== exceptId) this.write(peer, msg);
+    }
+  }
+
+  private write(peer: Peer, msg: VoiceSignal): void {
+    const frame = `data: ${JSON.stringify(msg)}\n\n`;
+    try {
+      peer.controller.enqueue(this.encoder.encode(frame));
+    } catch {
+      this.peers.delete(`${peer.room} ${peer.id}`);
+    }
+  }
+}
+
+// Reused across HMR via globalThis, mirroring the db / SessionManager singletons.
+const globalForHub = globalThis as unknown as {
+  __fdVoiceSignalHub?: VoiceSignalHub;
+};
+
+export const voiceSignalHub =
+  globalForHub.__fdVoiceSignalHub ?? new VoiceSignalHub();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForHub.__fdVoiceSignalHub = voiceSignalHub;
+}

--- a/lib/voice/useVoiceChannel.ts
+++ b/lib/voice/useVoiceChannel.ts
@@ -106,6 +106,7 @@ export function useVoiceChannel(opts: {
     if (!enabled) return;
     let cancelled = false;
     if (typeof window !== "undefined" && !window.isSecureContext) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
       setError("Microphone needs HTTPS (works on localhost). LAN HTTPS is tracked in #23.");
       return;
     }

--- a/lib/voice/useVoiceChannel.ts
+++ b/lib/voice/useVoiceChannel.ts
@@ -1,0 +1,312 @@
+"use client";
+
+/**
+ * useVoiceChannel — production WebRTC PTT for one voice channel.
+ *
+ * Graduated from the `/spike/ptt` proof. Manages: mic acquisition (PTT-gated,
+ * muted until held), an EventSource to `/api/voice/signal` for negotiation, a
+ * full mesh of RTCPeerConnections (one per other operator on the channel), and
+ * per-peer audio playback. Peer ids are operator ids, so talk indicators
+ * (delivered out-of-band via the `voice_talk` FdEvent) map straight to peers.
+ *
+ * Mic permission is acquired once when voice is enabled and kept across channel
+ * switches; only the signaling + peer mesh tear down and rebuild on a switch.
+ * A screen Wake Lock is held while enabled so the operator's device doesn't
+ * sleep mid-session (the spec's "keep audio alive on mobile" ask). Note: this
+ * keeps the *screen* awake — true locked-screen audio needs the native wrapper
+ * tracked in #25.
+ */
+import { useCallback, useEffect, useRef, useState } from "react";
+import { getToken } from "@/lib/client/api";
+import type { VoiceSignal } from "./signalHub";
+
+export interface VoicePeer {
+  id: string;
+  name: string;
+  state: RTCPeerConnectionState;
+}
+
+export interface UseVoiceChannel {
+  micReady: boolean;
+  secure: boolean;
+  error: string | null;
+  talking: boolean;
+  peers: VoicePeer[];
+  pttDown: () => void;
+  pttUp: () => void;
+}
+
+const ICE_CONFIG: RTCConfiguration = { iceServers: [] }; // host candidates only — LAN/offline
+
+async function postSignal(
+  channel: string,
+  msg: Record<string, unknown>,
+): Promise<void> {
+  const token = getToken();
+  await fetch("/api/voice/signal", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ channel, ...msg }),
+  }).catch(() => {});
+}
+
+async function postTalk(
+  channel: string,
+  name: string,
+  talking: boolean,
+): Promise<void> {
+  const token = getToken();
+  await fetch("/api/voice/talk", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ channel, name, talking }),
+  }).catch(() => {});
+}
+
+export function useVoiceChannel(opts: {
+  operatorId: string;
+  name: string;
+  channel: string;
+  enabled: boolean;
+}): UseVoiceChannel {
+  const { operatorId, name, channel, enabled } = opts;
+
+  const [micReady, setMicReady] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [talking, setTalking] = useState(false);
+  const [peers, setPeers] = useState<VoicePeer[]>([]);
+  const [secure] = useState(() =>
+    typeof window === "undefined" ? true : window.isSecureContext,
+  );
+
+  const localStream = useRef<MediaStream | null>(null);
+  const pcs = useRef<Map<string, RTCPeerConnection>>(new Map());
+  const names = useRef<Map<string, string>>(new Map());
+  const pendingIce = useRef<Map<string, RTCIceCandidateInit[]>>(new Map());
+  const audioEls = useRef<Map<string, HTMLAudioElement>>(new Map());
+
+  const syncPeers = useCallback(() => {
+    setPeers(
+      [...pcs.current.entries()].map(([id, pc]) => ({
+        id,
+        name: names.current.get(id) ?? id.slice(0, 6),
+        state: pc.connectionState,
+      })),
+    );
+  }, []);
+
+  // ---- Mic: acquire once while enabled, keep across channel switches -------
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    if (typeof window !== "undefined" && !window.isSecureContext) {
+      setError("Microphone needs HTTPS (works on localhost). LAN HTTPS is tracked in #23.");
+      return;
+    }
+    (async () => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+        stream.getAudioTracks().forEach((t) => (t.enabled = false)); // PTT: muted until held
+        if (cancelled) {
+          stream.getTracks().forEach((t) => t.stop());
+          return;
+        }
+        localStream.current = stream;
+        setMicReady(true);
+        setError(null);
+      } catch (err) {
+        if (!cancelled) setError(`Mic unavailable: ${(err as Error).message}`);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      localStream.current?.getTracks().forEach((t) => t.stop());
+      localStream.current = null;
+      setMicReady(false);
+      setTalking(false);
+    };
+  }, [enabled]);
+
+  // ---- Signaling + mesh: rebuilds on channel switch ------------------------
+  useEffect(() => {
+    if (!enabled || !micReady || !channel) return;
+
+    const peerMap = pcs.current;
+    const audioMap = audioEls.current;
+    const nameMap = names.current;
+    const iceMap = pendingIce.current;
+
+    const getOrCreatePeer = (peerId: string): RTCPeerConnection => {
+      const existing = peerMap.get(peerId);
+      if (existing) return existing;
+      const pc = new RTCPeerConnection(ICE_CONFIG);
+      localStream.current?.getTracks().forEach((t) => pc.addTrack(t, localStream.current!));
+      pc.onicecandidate = (e) => {
+        if (e.candidate) void postSignal(channel, { kind: "ice", to: peerId, payload: e.candidate.toJSON() });
+      };
+      pc.ontrack = (e) => {
+        let el = audioMap.get(peerId);
+        if (!el) {
+          el = new Audio();
+          el.autoplay = true;
+          audioMap.set(peerId, el);
+        }
+        el.srcObject = e.streams[0];
+        el.play().catch(() => {});
+      };
+      pc.onconnectionstatechange = () => {
+        if (pc.connectionState === "failed" || pc.connectionState === "closed") {
+          peerMap.delete(peerId);
+        }
+        syncPeers();
+      };
+      peerMap.set(peerId, pc);
+      syncPeers();
+      return pc;
+    };
+
+    const makeOffer = async (peerId: string) => {
+      const pc = getOrCreatePeer(peerId);
+      const offer = await pc.createOffer();
+      await pc.setLocalDescription(offer);
+      void postSignal(channel, { kind: "offer", to: peerId, payload: offer });
+    };
+
+    const flushIce = async (peerId: string, pc: RTCPeerConnection) => {
+      const queued = iceMap.get(peerId);
+      if (!queued) return;
+      for (const c of queued) await pc.addIceCandidate(c).catch(() => {});
+      iceMap.delete(peerId);
+    };
+
+    const handle = async (msg: VoiceSignal) => {
+      switch (msg.kind) {
+        case "welcome": {
+          for (const p of msg.peers) {
+            nameMap.set(p.id, p.name);
+            // Smaller id offers, so exactly one side initiates per pair.
+            if (operatorId < p.id) await makeOffer(p.id);
+            else getOrCreatePeer(p.id);
+          }
+          break;
+        }
+        case "join": {
+          nameMap.set(msg.id, msg.name);
+          if (operatorId < msg.id) await makeOffer(msg.id);
+          break;
+        }
+        case "leave": {
+          peerMap.get(msg.id)?.close();
+          peerMap.delete(msg.id);
+          audioMap.get(msg.id)?.pause();
+          audioMap.delete(msg.id);
+          nameMap.delete(msg.id);
+          syncPeers();
+          break;
+        }
+        case "offer": {
+          const pc = getOrCreatePeer(msg.from);
+          await pc.setRemoteDescription(msg.payload as RTCSessionDescriptionInit);
+          await flushIce(msg.from, pc);
+          const answer = await pc.createAnswer();
+          await pc.setLocalDescription(answer);
+          void postSignal(channel, { kind: "answer", to: msg.from, payload: answer });
+          break;
+        }
+        case "answer": {
+          const pc = peerMap.get(msg.from);
+          if (pc) {
+            await pc.setRemoteDescription(msg.payload as RTCSessionDescriptionInit);
+            await flushIce(msg.from, pc);
+          }
+          break;
+        }
+        case "ice": {
+          const pc = peerMap.get(msg.from);
+          const cand = msg.payload as RTCIceCandidateInit;
+          if (pc?.remoteDescription) {
+            await pc.addIceCandidate(cand).catch(() => {});
+          } else {
+            const q = iceMap.get(msg.from) ?? [];
+            q.push(cand);
+            iceMap.set(msg.from, q);
+          }
+          break;
+        }
+      }
+    };
+
+    const token = getToken() ?? "";
+    const qs = new URLSearchParams({ channel, token, name });
+    const es = new EventSource(`/api/voice/signal?${qs}`);
+    es.onmessage = (e) => {
+      try {
+        void handle(JSON.parse(e.data) as VoiceSignal);
+      } catch {
+        /* keepalive comment lines */
+      }
+    };
+
+    return () => {
+      es.close();
+      for (const pc of peerMap.values()) pc.close();
+      peerMap.clear();
+      for (const el of audioMap.values()) el.pause();
+      audioMap.clear();
+      nameMap.clear();
+      iceMap.clear();
+      setPeers([]);
+    };
+  }, [enabled, micReady, channel, operatorId, name, syncPeers]);
+
+  // ---- Screen wake lock while enabled --------------------------------------
+  useEffect(() => {
+    if (!enabled) return;
+    type WakeLockNav = Navigator & {
+      wakeLock?: { request: (t: "screen") => Promise<{ release: () => Promise<void> }> };
+    };
+    const wl = (navigator as WakeLockNav).wakeLock;
+    if (!wl) return;
+    let sentinel: { release: () => Promise<void> } | null = null;
+    let released = false;
+    const acquire = async () => {
+      try {
+        sentinel = await wl.request("screen");
+      } catch {
+        /* lock denied (e.g. tab not visible) — best effort */
+      }
+    };
+    void acquire();
+    const onVisible = () => {
+      if (document.visibilityState === "visible" && !released) void acquire();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      released = true;
+      document.removeEventListener("visibilitychange", onVisible);
+      void sentinel?.release().catch(() => {});
+    };
+  }, [enabled]);
+
+  const pttDown = useCallback(() => {
+    if (!micReady || talking) return;
+    localStream.current?.getAudioTracks().forEach((t) => (t.enabled = true));
+    setTalking(true);
+    void postTalk(channel, name, true);
+  }, [micReady, talking, channel, name]);
+
+  const pttUp = useCallback(() => {
+    if (!talking) return;
+    localStream.current?.getAudioTracks().forEach((t) => (t.enabled = false));
+    setTalking(false);
+    void postTalk(channel, name, false);
+  }, [talking, channel, name]);
+
+  return { micReady, secure, error, talking, peers, pttDown, pttUp };
+}


### PR DESCRIPTION
Promotes the `/spike/ptt` proof (PR #20) into the real Comms voice feature. Closes the first checklist item of #22.

## Decisions (confirmed with maintainer)
- **Topology: peer mesh**, SFU deferred — PTT is one talker per channel, so media load stays light. The signaling shape is SFU-ready for later.
- **Scope: full** — channel model + production signaling + talk indicators + Comms UI + Session Wake Lock + admin speaker visibility.

## What's here
- **Session-local channels by role** (`lib/voice/channels.ts`), RBAC-enforced server-side. No external account or global namespace (the reason Zello was dropped).
- **Production signaling** `/api/voice/signal` (SSE down + POST up), session-token verified, peer id pinned to the operatorId, rooms namespaced per session+channel. Kept **off** the `FdEvent` contract (`lib/voice/signalHub.ts`).
- **Talk indicators**: coarse `voice_talk` FdEvent broadcast **ephemerally** (no `ops_log` churn) so the in-channel roster, dispatchers, and Admin all see who's speaking. `useFdSession` exposes a live `talking` map.
- **Comms screen** rebuilt: channel picker, enable/leave voice, hold-to-talk (pointer + Space), live roster with speaker highlight, secure-context warning. **Screen Wake Lock** held while voice is on.
- **Admin dashboard** shows live speakers in Connected devices.

## Not in scope / follow-ups
- Mic on real phones needs **LAN HTTPS** (#23) — works on `localhost` today.
- Native locked-screen audio stays deferred (#25).
- The `/spike/ptt` proof is left in place until two-device verification (#24) lands.

## Verification
Authored in an environment without a Node toolchain, so this was **not** built/typechecked locally — relying on CI here. Self-reviewed for types, imports, RBAC, event wiring, and hook deps.

Refs #19, #22
🤖 Generated with [Claude Code](https://claude.com/claude-code)