### PR TITLE
Clear stuck voice talk indicator on disconnect

### DIFF
--- a/app/api/voice/signal/route.ts
+++ b/app/api/voice/signal/route.ts
@@ -15,6 +15,7 @@
 import { voiceSignalHub, type VoiceSignal } from "@/lib/voice/signalHub";
 import { roleCanAccess, roomId } from "@/lib/voice/channels";
 import { verifyToken, tokenFromRequest } from "@/lib/server/sessionToken";
+import { sessionManager } from "@/lib/server/SessionManager";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -36,6 +37,26 @@ export async function GET(req: Request) {
 
   let registration: { remove: () => void } | null = null;
   let keepalive: ReturnType<typeof setInterval> | null = null;
+  let cleanedUp = false;
+
+  // Runs once when the operator's signaling connection drops (tab closed,
+  // navigated away, network died). Besides unregistering from the mesh, it
+  // clears any stuck talk indicator: if the tab dies mid-PTT the client never
+  // sends its talk-stop, so leaving the channel must implicitly stop talking.
+  // Idempotent on clients (clearing an already-clear entry is a no-op).
+  const cleanup = () => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    if (keepalive) clearInterval(keepalive);
+    registration?.remove();
+    sessionManager.broadcastEphemeral({
+      type: "voice_talk",
+      operatorId: id,
+      name,
+      channel,
+      talking: false,
+    });
+  };
 
   const stream = new ReadableStream<Uint8Array>({
     start(controller) {
@@ -52,8 +73,7 @@ export async function GET(req: Request) {
       }, KEEPALIVE_MS);
 
       req.signal.addEventListener("abort", () => {
-        if (keepalive) clearInterval(keepalive);
-        registration?.remove();
+        cleanup();
         try {
           controller.close();
         } catch {
@@ -62,8 +82,7 @@ export async function GET(req: Request) {
       });
     },
     cancel() {
-      if (keepalive) clearInterval(keepalive);
-      registration?.remove();
+      cleanup();
     },
   });
 


### PR DESCRIPTION
Fixes the stuck `voice_talk` presence indicator: when an operator's tab dies mid-PTT, the client never sends its talk-stop, so they showed as transmitting forever in other operators' Comms rosters and the Admin dashboard.

## Fix
At the signaling layer — the only place disconnect is reliably detected. When an operator's `/api/voice/signal` SSE connection drops (`req.signal` abort or stream `cancel`), the server broadcasts `voice_talk` with `talking:false` for them: leaving the channel implicitly stops talking. The abort/cancel teardown is folded into one guarded `cleanup()` that runs exactly once (also de-dupes the prior double "leave" broadcast).

## Why not "clear on operator_left" (the originally-suggested fix)
`operator_left` is never emitted — there is no `/api/session/leave` route, and the client "Leave" only clears `sessionStorage` locally. So clearing on it would fix nothing. The signaling drop is the dependable signal, and the route already has the verified `operatorId` + `channel` in scope (no deviceId->operatorId mapping needed).

## Verification
- CI (lint, types, build) here.
- Logic: clearing is idempotent on the client (delete of an absent key is a no-op), and SSE in-order delivery means a late `talking:true` cannot arrive after the disconnect `false`.
- I could NOT run the live two-device test (no local Node toolchain in this environment). Suggested manual check: two clients on one channel, hold PTT on one, kill that tab without releasing, confirm the other client + Admin clear the indicator within a few seconds.

Refs #22
