### PR TITLE
docs: setup README + multi-device testing guide; fix stale .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,22 +1,27 @@
 # Free Dispatcher — copy to .env.local (gitignored) and fill in.
+# Next.js loads .env.local automatically for both `dev` and `start`.
 
-# Set only on the host/server machine; omit on mobile clients.
+# ---- Host / server ---------------------------------------------------------
+# Set ONLY on the event host machine (the laptop running the server). It turns
+# on mDNS advertisement and unlocks the Admin console. Omit it on phones — they
+# are plain clients that join over the network.
 SERVER_MODE=true
+
+# Port the Next.js server listens on (default 3000).
 # PORT=3000
 
-# ---- Zello voice (free consumer tier) ------------------------------------
-# Developer keys from https://developers.zello.com (free Zello account).
-# These sign short-lived RS256 tokens server-side so the client can connect to
-# the Zello Channel API. Keep them ONLY here in .env.local — never commit.
-# If you rotated your key, paste the NEW issuer + private key below.
-ZELLO_ISSUER=
-# Single line with literal \n between key lines, OR a real multi-line value.
-ZELLO_PRIVATE_KEY=
+# ---- Security --------------------------------------------------------------
+# HMAC secret used to sign session tokens issued on join. The default is an
+# insecure dev value; set a real random string on the host for an actual event
+# (e.g. `openssl rand -hex 32`). Only the host needs this.
+# FD_TOKEN_SECRET=
 
-# Optional: instead of self-signing, point at a self-hosted token-server.
-# NEXT_PUBLIC_TOKEN_SERVER_URL=http://localhost:3001
+# ---- Local database --------------------------------------------------------
+# Embedded PGlite data directory (fully offline; created on first migrate).
+# FD_DB_DIR=./.data/freedispatcher
 
-# ---- WiThrottle monitor (optional) ---------------------------------------
+# ---- WiThrottle monitor (optional) ----------------------------------------
+# Point at a JMRI / DCC-EX WiThrottle server to auto-detect loco acquisition.
 # NEXT_PUBLIC_WITHROTTLE_HOST=192.168.1.10
 # NEXT_PUBLIC_WITHROTTLE_PORT=12090
 # WITHROTTLE_ENABLED=false

--- a/README.md
+++ b/README.md
@@ -1,36 +1,101 @@
-This is a [Next.js](https://nextjs.org) project bootstrapped with [`create-next-app`](https://nextjs.org/docs/app/api-reference/cli/create-next-app).
+# Free Dispatcher
 
-## Getting Started
+Train operations for modular Free-moN sessions — a **browser-only, local-first**
+dispatch tool. One laptop runs the host; operators join from their phones over
+the venue Wi-Fi (no app install, no cloud, no internet required for core
+dispatch).
 
-First, run the development server:
+- **Host:** Next.js (App Router) + an embedded Postgres (PGlite) database, all
+  in-process — nothing to install or start beyond the app itself.
+- **Clients:** any phone/tablet/laptop browser on the same LAN. Join by mDNS
+  auto-discovery, QR code, or a typed URL.
+- **Realtime:** Server-Sent Events. **RBAC:** Admin / Dispatcher / Engineer /
+  Yardmaster, enforced server-side.
+- **Voice:** in-app WebRTC push-to-talk with session-local channels (see
+  [Comms / voice](#comms--voice-push-to-talk)).
+
+The full design rationale and phase history is in
+[`docs/V2_BUILD_PLAN.md`](docs/V2_BUILD_PLAN.md).
+
+---
+
+## Quick start (single machine)
+
+Requires **Node.js 20+** and npm.
 
 ```bash
-npm run dev
-# or
-yarn dev
-# or
-pnpm dev
-# or
-bun dev
+npm install
+cp .env.example .env.local      # then edit (see Configuration below)
+npm run db:migrate              # create the local PGlite database
+npm run db:seed                 # optional: demo session + trains
+npm run dev                     # http://localhost:3000
 ```
 
-Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+Open <http://localhost:3000>:
 
-You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
+- **Admin console** → `/admin` (host only — needs `SERVER_MODE=true`)
+- **Join as operator** → `/join`
 
-This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
+On `localhost` everything works, **including the microphone** (it's a secure
+context). To use voice from another device you need HTTPS — see
+[Multi-device testing](docs/MULTI_DEVICE_TESTING.md).
 
-## Learn More
+---
 
-To learn more about Next.js, take a look at the following resources:
+## Configuration
 
-- [Next.js Documentation](https://nextjs.org/docs) - learn about Next.js features and API.
-- [Learn Next.js](https://nextjs.org/learn) - an interactive Next.js tutorial.
+Copy `.env.example` to `.env.local` (gitignored) and set values. All are
+read server-side; Next.js loads `.env.local` for both `dev` and `start`.
 
-You can check out [the Next.js GitHub repository](https://github.com/vercel/next.js) - your feedback and contributions are welcome!
+| Variable | Where | Purpose |
+| --- | --- | --- |
+| `SERVER_MODE` | host only | `true` enables mDNS advertisement + the Admin console. Omit on client devices. |
+| `PORT` | host | Server port (default `3000`). |
+| `FD_TOKEN_SECRET` | host | HMAC secret for session tokens. Default is insecure — set a random value for real events (`openssl rand -hex 32`). |
+| `FD_DB_DIR` | host | PGlite data directory (default `./.data/freedispatcher`). |
+| `NEXT_PUBLIC_WITHROTTLE_HOST` / `_PORT` / `WITHROTTLE_ENABLED` | host | Optional JMRI / DCC-EX WiThrottle monitor. |
 
-## Deploy on Vercel
+---
 
-The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
+## Scripts
 
-Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+| Command | Does |
+| --- | --- |
+| `npm run dev` | Dev server (HTTP) at `http://localhost:3000`. |
+| `npm run dev:https` | Dev server over **HTTPS** with a Next-generated self-signed cert — needed to test the microphone from another device. See the testing guide. |
+| `npm run build` / `npm start` | Production build / serve. |
+| `npm run lint` | ESLint. |
+| `npm run db:generate` | Generate a Drizzle migration from schema changes. |
+| `npm run db:migrate` | Apply migrations to the local DB. |
+| `npm run db:seed` | Seed a demo session. |
+
+---
+
+## How a session works
+
+1. **Host** sets `SERVER_MODE=true`, runs the server, opens `/admin`, and
+   **creates a session** (Admin → Session). Only one session is active at a time.
+2. **Operators** open the host URL on their device, go to `/join`, pick a role
+   and a name, and land on their role's home screen.
+3. The host's Admin header shows the **join URL + QR code** (`/api/server-info`)
+   so operators can scan to connect.
+
+### Comms / voice (push-to-talk)
+
+- Channels are **session-local** and filtered by role (Dispatch, Yard, All
+  Operators, Tech) — no external account, no global namespace.
+- On the Comms screen: tap **Enable voice**, pick a channel, then **hold to
+  talk** (or hold `Space` on a laptop). Other operators on the channel — and the
+  Admin dashboard — see who's transmitting live.
+- **The mic requires a secure context.** It works on `localhost`; on any other
+  device it needs HTTPS. See
+  [`docs/MULTI_DEVICE_TESTING.md`](docs/MULTI_DEVICE_TESTING.md).
+
+---
+
+## Documentation
+
+- [Multi-device testing guide](docs/MULTI_DEVICE_TESTING.md) — run the host,
+  join phones, and the HTTPS options for testing voice across devices.
+- [v2 build plan](docs/V2_BUILD_PLAN.md) — architecture, decisions, phase log.
+- [Git LFS guide](docs/GIT_LFS_GUIDE.md).

--- a/docs/MULTI_DEVICE_TESTING.md
+++ b/docs/MULTI_DEVICE_TESTING.md
@@ -1,0 +1,148 @@
+# Multi-device testing
+
+How to run Free Dispatcher on a host laptop and join it from real phones on the
+same Wi-Fi — including the HTTPS setup needed to test **voice (push-to-talk)**
+across devices.
+
+> **TL;DR**
+> - Everything *except the microphone* works over plain HTTP on the LAN today.
+> - The mic (`getUserMedia`) needs a **secure context**. That's free on
+>   `localhost`, but any other device needs **HTTPS**. Use
+>   `npm run dev:https` for a quick test (tap through the cert warning), or
+>   [mkcert](#option-b--mkcert-trusted-lan-cert-no-warnings) for a clean LAN
+>   cert with no warnings.
+
+---
+
+## 1. Prerequisites
+
+- **One host machine** (laptop) with Node.js 20+.
+- **Test devices** (phones/tablets/another laptop) on the **same Wi-Fi/LAN** as
+  the host.
+- A network that lets devices talk to each other. Guest/"client isolation"
+  Wi-Fi blocks this — use a normal home/club network or a dedicated router.
+- mDNS auto-discovery is a bonus, not required; the **QR code / typed URL**
+  always works (some mesh Wi-Fi blocks mDNS).
+
+---
+
+## 2. Start the host
+
+```bash
+npm install
+cp .env.example .env.local        # set SERVER_MODE=true (already the default)
+npm run db:migrate
+npm run db:seed                   # demo session + trains to test against
+npm run dev                       # HTTP — fine for everything but the mic
+```
+
+- Make sure **`SERVER_MODE=true`** is in `.env.local` (enables Admin + mDNS).
+- Next prints a **Network:** URL like `http://192.168.1.23:3000` — that's the
+  host's LAN address. The Admin header also shows it as a **QR code**
+  (served by `GET /api/server-info`).
+- **Firewall:** the first time the server binds, Windows/macOS may prompt to
+  allow Node on the network — **allow it on private networks**, or devices
+  can't reach the host.
+
+Find the host IP manually if needed: `ipconfig` (Windows) / `ipconfig getifaddr en0` (macOS).
+
+---
+
+## 3. Join from a device
+
+On each phone, open the host URL (e.g. `http://192.168.1.23:3000`):
+
+1. Scan the **QR** in the Admin header, or type the URL.
+2. Tap **Join as operator** → pick a role (Dispatcher / Engineer / Yardmaster)
+   → enter a name → **Join**.
+3. You land on that role's home screen. The Admin dashboard's **Connected
+   devices** panel updates live.
+
+This confirms LAN reachability, SSE realtime, and RBAC — **no HTTPS needed** for
+trains, dispatch, authority, modules, or the operator roster.
+
+---
+
+## 4. Testing voice (push-to-talk) — requires HTTPS
+
+The mic is blocked on a plain-HTTP LAN origin (browsers only treat `localhost`
+and HTTPS as secure). The Comms screen shows a warning and refuses to enable
+voice until the page is served securely. Pick one of the options below.
+
+### Option A — `npm run dev:https` (quickest)
+
+```bash
+npm run dev:https      # next dev with a self-signed cert
+```
+
+Then open **`https://<host-lan-ip>:3000`** on each device.
+
+- Each device shows a **certificate warning** (the cert is self-signed). Tap
+  **Advanced → proceed/visit** to continue. iOS Safari is the strictest here;
+  Chrome (desktop/Android) is the most forgiving.
+- Good for a fast smoke test. If a device flat-out refuses to proceed (no
+  "proceed anyway"), use Option B instead.
+
+### Option B — mkcert (trusted LAN cert, no warnings)
+
+[mkcert](https://github.com/FiloSottile/mkcert) makes a locally-trusted cert so
+devices connect with **no warnings** — the most reliable multi-device path.
+
+```bash
+# Install mkcert (e.g. `choco install mkcert` / `scoop install mkcert` / `brew install mkcert`)
+mkcert -install                                   # create + trust a local CA
+mkcert 192.168.1.23 free-dispatcher.local localhost   # use YOUR host LAN IP
+
+# Run Next with those cert files:
+npm run dev:https -- --experimental-https-key ./192.168.1.23-key.pem \
+                     --experimental-https-cert ./192.168.1.23.pem
+```
+
+- Install the mkcert **root CA on each test device** so it trusts the cert:
+  - **iOS:** AirDrop/email the `rootCA.pem` (path from `mkcert -CAROOT`), open
+    it → install the profile → **Settings → General → About → Certificate Trust
+    Settings → enable full trust**.
+  - **Android:** Settings → Security → Encryption & credentials → Install a
+    certificate → CA certificate.
+- Then open `https://192.168.1.23:3000` — no warning, mic works.
+- `*.pem` is gitignored, so certs won't be committed.
+
+### Option C — real cert via a domain (production path, issue #23)
+
+For a venue deployment with **zero per-device setup**, the plan is Caddy in
+front of Next.js auto-obtaining a **Let's Encrypt cert via DNS-01** (Cloudflare
+free DNS), with a public DNS record pointing at the host's LAN IP. This needs a
+domain + a DNS provider API token and is tracked in **issue #23** — not required
+for a test, but it's the no-warnings, no-install answer for real events.
+
+---
+
+## 5. Voice test checklist
+
+With two+ devices joined to the **same channel** (e.g. both Dispatchers on
+*Dispatch*) over HTTPS:
+
+- [ ] **Enable voice** on each device (grant the mic permission prompt).
+- [ ] **Hold to talk** on device A → device B hears audio; A shows "TALKING",
+      B's roster highlights A as 🔊, and the **Admin** dashboard shows A speaking.
+- [ ] Release → indicators clear everywhere.
+- [ ] **Channel switch** respects role access (e.g. an Engineer has no *Yard*
+      channel).
+- [ ] **Stuck-indicator regression** (fixed in #28): while device A is holding
+      PTT, **kill its tab/connection without releasing** → device B and Admin
+      should clear A's 🔊 within a few seconds (the signaling drop broadcasts a
+      `talking:false`).
+
+---
+
+## 6. Troubleshooting
+
+| Symptom | Fix |
+| --- | --- |
+| Device can't reach the host URL | Same Wi-Fi? Client-isolation off? Allow Node through the host firewall (private network). Try the IP from `ipconfig`/`ifconfig`, not `localhost`. |
+| "Microphone needs a secure context" on Comms | You're on HTTP. Use `https://…` via Option A/B above. |
+| Cert warning won't let you proceed (esp. iOS) | Use Option B (mkcert) and trust the root CA on the device. |
+| QR / auto-discovery doesn't appear | mDNS may be blocked — type the host URL manually. Confirm `SERVER_MODE=true` on the host. |
+| `/admin` says no token / forbidden | Admin is host-only — `SERVER_MODE=true` must be set on the machine serving it. |
+| No trains/session to test with | Run `npm run db:seed`, or create a session in Admin → Session. |
+| Audio one-way only | Both peers must **Enable voice** and grant the mic; check each browser's site mic permission. |

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
+    "dev:https": "next dev --experimental-https",
     "build": "next build",
     "start": "next start",
     "lint": "eslint",


### PR DESCRIPTION
Documentation so a multi-device test can actually be set up from GitHub, plus a fix to the stale env example.

## What's here
- **README.md** rewritten from the create-next-app boilerplate into a real overview: what the app is, quick start, a configuration table (the env vars actually read by the code), and the script list.
- **docs/MULTI_DEVICE_TESTING.md** (new) — the main deliverable:
  - Start the host (`SERVER_MODE`, migrate, seed, run) + firewall note.
  - Join phones over the LAN (QR / typed URL / mDNS). Everything **except the mic** works over plain HTTP today.
  - **Voice needs HTTPS** — three options with honest trade-offs: `npm run dev:https` (Next self-signed, tap-through warning), **mkcert** (trusted LAN cert, no warnings — the reliable path), and the production **#23** Caddy + Let's Encrypt route (needs a domain).
  - A voice test checklist including the **#28 stuck-indicator regression** check, plus troubleshooting.
- **.env.example** fixed — it still documented the removed Zello / token-server vars and omitted the live ones (`FD_TOKEN_SECRET`, `FD_DB_DIR`).
- **package.json** — added `dev:https` (`next dev --experimental-https`) for the quickest cross-device mic test.

## Notes
- Docs/markdown + one npm script; no app code changed. Relying on CI (lint/types/build).
- The HTTPS-for-voice options are documented but **not verified on real hardware** here (no device lab / Node toolchain in this environment). The mkcert path is the most likely to "just work" across iOS/Android.
- Follow-up spotted while writing: `jsonwebtoken`, `@types/jsonwebtoken`, and `libopus-wasm` look like dead deps left from the Zello removal — worth pruning separately (changes the lockfile).
