### PR TITLE
Make the host packageable: standalone output + boot migrations (#32)

### DIFF
--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,11 +1,15 @@
 /**
  * Next.js instrumentation hook — runs once when the server process starts.
- * On the host (SERVER_MODE=true) we begin mDNS advertisement so mobile
- * clients can auto-discover this server (spec §3.1).
+ * Brings the local DB schema up to date, then (on the host, SERVER_MODE=true)
+ * begins mDNS advertisement so mobile clients can auto-discover it (spec §3.1).
  */
 export async function register() {
-  // Only the Node.js server runtime, and only on the host machine.
+  // Only the Node.js server runtime.
   if (process.env.NEXT_RUNTIME !== "nodejs") return;
+
+  // Apply pending migrations on boot so a packaged host (#32) needs no CLI step.
+  const { runMigrations } = await import("@/lib/db/runMigrations");
+  await runMigrations();
 
   const { config } = await import("@/lib/config");
   if (!config.serverMode) return;

--- a/lib/db/runMigrations.ts
+++ b/lib/db/runMigrations.ts
@@ -1,0 +1,30 @@
+/**
+ * Apply pending Drizzle migrations at server boot.
+ *
+ * Called from `instrumentation.ts` so a packaged host (Electron, #32) brings its
+ * local PGlite schema up to date on launch without the user running any CLI —
+ * the `db:migrate` npm script relies on `tsx` + TS source that don't exist in a
+ * packaged build. `migrate()` is idempotent (applied migrations are skipped via
+ * the journal), so this is safe to run on every start, including in dev.
+ *
+ * Unlike the one-shot `db:migrate` script this does NOT close the connection —
+ * the server keeps using the same lazily-opened PGlite instance.
+ */
+import { join } from "node:path";
+import { migrate } from "drizzle-orm/pglite/migrator";
+import { db } from "./client";
+
+let done: Promise<void> | null = null;
+
+export function runMigrations(): Promise<void> {
+  // Run at most once per process.
+  if (done) return done;
+  // Resolve relative to the server's working directory. In dev that's the repo
+  // root; in the standalone build the folder is copied alongside the server via
+  // `outputFileTracingIncludes` (see next.config.ts), so the same path holds.
+  const migrationsFolder = join(process.cwd(), "lib", "db", "migrations");
+  done = migrate(db, { migrationsFolder }).then(() => {
+    console.log("[freedispatcher] db migrations up to date");
+  });
+  return done;
+}

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,21 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // Emit a self-contained server bundle (.next/standalone) so the host can be
+  // packaged (Electron) without a full node_modules / npm install. See #32.
+  output: "standalone",
+
+  // PGlite ships a WASM Postgres; bundling it breaks its wasm loader
+  // ("instantiateWasm is not a function" in the standalone build). Keep it
+  // external so it's required from node_modules and traced into standalone.
+  serverExternalPackages: ["@electric-sql/pglite"],
+
+  // The Drizzle migration files are read at runtime by the boot-time migrator
+  // (instrumentation.ts → lib/db/runMigrations). They aren't a traced import,
+  // so include them explicitly in the standalone output.
+  outputFileTracingIncludes: {
+    "/**": ["./lib/db/migrations/**/*"],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
First step toward the cross-platform desktop installer (#32): make the host **packageable**. This is the foundation the Electron shell (next PR) builds on.

## Why
A packaged host can't run today's startup (`npm install` → `tsx lib/db/migrate.ts` → `next start`) — there's no npm, no `tsx`, no TS source in a package. So:
- The server must be a self-contained bundle → `output: 'standalone'`.
- Migrations must apply themselves on launch, without a CLI.

## Changes
- **`next.config.ts`**: `output: 'standalone'`; trace `lib/db/migrations` into the bundle; mark `@electric-sql/pglite` as `serverExternalPackages` — bundling it breaks its WASM loader (`instantiateWasm is not a function`), so it's kept external and traced from `node_modules`.
- **`lib/db/runMigrations.ts`**: idempotent, packaged-safe migrator (no `tsx`), runs once per process against the bundled migrations folder.
- **`instrumentation.ts`**: run migrations on boot, before mDNS. Bonus: `npm run dev` no longer needs a manual `db:migrate`.

## Verified locally (Node 24)
- `next build` emits `.next/standalone/` with PGlite's `pglite.wasm` + `pglite.data` and the migration SQL bundled.
- Running the standalone server (`node server.js` from the bundle, fresh `FD_DB_DIR`): logs `db migrations up to date`, `GET /api/session` → **200**, mDNS advertises.
- `npm run lint` + `npx tsc --noEmit` clean.

## Not in this PR
The Electron host shell (control panel + QR window), electron-builder installers (NSIS/dmg/AppImage), code signing/notarization, and the CI build matrix — that's the next PR.

Refs #32
