### PR TITLE
ci/build: clear package + CI build warnings (#32)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,9 @@ jobs:
     name: Lint · Types · Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -22,13 +22,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, macos-latest, ubuntu-latest]
+        os: [windows-2025, macos-latest, ubuntu-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           lfs: true # real icon binaries (*.ico/*.png) + image assets, not LFS pointers
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: "22"
           cache: "npm"
@@ -43,7 +43,7 @@ jobs:
         run: npm run dist -- --publish never
 
       - name: Upload installers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v5
         with:
           name: installer-${{ matrix.os }}
           if-no-files-found: warn

--- a/package.json
+++ b/package.json
@@ -61,7 +61,13 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": true
     },
-    "linux": { "target": ["AppImage", "deb"], "category": "Utility", "icon": "build/icon.png" }
+    "linux": {
+      "target": ["AppImage", "deb"],
+      "category": "Utility",
+      "icon": "build/icon.png",
+      "desktopName": "free-dispatcher.desktop",
+      "synopsis": "Train dispatch for modular Free-moN sessions"
+    }
   },
   "overrides": {
     "postcss": "^8.5.10"


### PR DESCRIPTION
Clears the build/CI warnings:
- GitHub Actions bumped to Node-24 majors (checkout@v5, setup-node@v5, upload-artifact@v5) — no more Node-20 deprecation notices.
- Windows runner pinned to windows-2025 — clears the redirect notice.
- electron-builder linux.desktopName + synopsis — clears the desktopName warning.

This PR's CI validates the checkout@v5/setup-node@v5 bump; the package-workflow changes (upload-artifact@v5, windows-2025, desktopName) verify on the next Package run (I'll dispatch one after merge).

Refs #32