### PR TITLE
Host: select which network interface to advertise (#32)

### DIFF
--- a/app/api/server-info/route.ts
+++ b/app/api/server-info/route.ts
@@ -1,6 +1,7 @@
 /**
- * GET /api/server-info — host IP, port, server URL, and a scannable QR code
- * for the Admin header (spec §3.1). `scheme` query param toggles http/https.
+ * GET /api/server-info — host IP, port, server URL, a scannable QR code, and
+ * the list of LAN interfaces (spec §3.1). `scheme` toggles http/https; `host`
+ * selects which interface IP the url/QR point at (must be a real interface).
  */
 import { NextResponse } from "next/server";
 import { serverInfo } from "@/lib/server/advertise";
@@ -9,7 +10,8 @@ export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
 
 export async function GET(req: Request) {
-  const scheme =
-    new URL(req.url).searchParams.get("scheme") === "https" ? "https" : "http";
-  return NextResponse.json(await serverInfo(scheme));
+  const params = new URL(req.url).searchParams;
+  const scheme = params.get("scheme") === "https" ? "https" : "http";
+  const host = params.get("host") ?? undefined;
+  return NextResponse.json(await serverInfo(scheme, host));
 }

--- a/electron/control-panel.html
+++ b/electron/control-panel.html
@@ -45,6 +45,7 @@
     <div class="qr"><img id="qr" alt="Join QR code" /></div>
     <div class="hint">Operators scan this or open the address below on their phone (same Wi-Fi):</div>
     <div id="url" class="url" title="Click to open">—</div>
+    <select id="iface" title="Choose which network address to show operators" style="display: none; max-width: 380px; background: #0b1220; color: #cbd5e1; border: 1px solid #1e293b; border-radius: 8px; padding: 6px 10px; font-size: 12px;"></select>
     <div class="row">
       <button class="primary" id="admin">Open Admin console</button>
       <button class="ghost" id="copy">Copy address</button>
@@ -62,6 +63,26 @@
       const $ = (id) => document.getElementById(id);
       let joinUrl = "";
       let crashed = false;
+      let selectedHost = null;
+      let ifaceSig = "";
+
+      function renderInterfaces(info) {
+        const list = info.interfaces || [];
+        const sel = $("iface");
+        sel.style.display = list.length > 1 ? "block" : "none";
+        const sig = list.map((i) => i.address).join(",");
+        if (sig !== ifaceSig) {
+          ifaceSig = sig;
+          sel.innerHTML = "";
+          for (const i of list) {
+            const o = document.createElement("option");
+            o.value = i.address;
+            o.textContent = i.address + "  (" + i.name + ")";
+            sel.appendChild(o);
+          }
+        }
+        sel.value = info.ip;
+      }
 
       function showError(msg, detail) {
         crashed = true;
@@ -74,10 +95,11 @@
 
       async function refresh() {
         try {
-          const info = await window.fd.getInfo();
+          const info = await window.fd.getInfo(selectedHost);
           joinUrl = info.url;
           $("url").textContent = info.url;
           $("qr").src = info.qrDataUrl;
+          renderInterfaces(info);
           $("status").textContent = "Running · " + info.ip + ":" + info.port;
           $("status").className = "status up";
           $("err").style.display = "none";
@@ -103,6 +125,7 @@
       $("url").addEventListener("click", () => joinUrl && window.fd.openUrl(joinUrl));
       $("copy").addEventListener("click", () => joinUrl && navigator.clipboard.writeText(joinUrl));
       $("logs").addEventListener("click", () => window.fd.openLogs());
+      $("iface").addEventListener("change", () => { selectedHost = $("iface").value; refresh(); });
 
       refresh();
       setInterval(refresh, 4000);

--- a/electron/main.js
+++ b/electron/main.js
@@ -144,10 +144,11 @@ function waitForServer(timeoutMs = 30000) {
 }
 
 /** Proxy the server's /api/server-info to the renderer (avoids file:// CORS). */
-function fetchServerInfo() {
+function fetchServerInfo(host) {
+  const q = host ? `?host=${encodeURIComponent(host)}` : "";
   return new Promise((resolve, reject) => {
     http
-      .get(`${LOOPBACK}/api/server-info`, (res) => {
+      .get(`${LOOPBACK}/api/server-info${q}`, (res) => {
         let body = "";
         res.on("data", (c) => (body += c));
         res.on("end", () => {
@@ -214,7 +215,7 @@ function createTray() {
   tray.on("click", showWindow);
 }
 
-ipcMain.handle("get-info", () => fetchServerInfo());
+ipcMain.handle("get-info", (_e, host) => fetchServerInfo(host));
 ipcMain.handle("log-path", () => logPath());
 ipcMain.on("open-admin", () => shell.openExternal(`${LOOPBACK}/admin`));
 ipcMain.on("open-url", (_e, url) => shell.openExternal(url));

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -5,8 +5,9 @@
 const { contextBridge, ipcRenderer } = require("electron");
 
 contextBridge.exposeInMainWorld("fd", {
-  /** Latest server info: { ip, port, url, qrDataUrl, serverMode }. */
-  getInfo: () => ipcRenderer.invoke("get-info"),
+  /** Latest server info: { ip, port, url, qrDataUrl, serverMode, interfaces }.
+   *  Pass an interface IP to point the url/QR at a specific address. */
+  getInfo: (host) => ipcRenderer.invoke("get-info", host),
   /** Open the Admin console in the user's default browser. */
   openAdmin: () => ipcRenderer.send("open-admin"),
   /** Open an arbitrary URL (the join URL) in the default browser. */

--- a/lib/server/advertise.ts
+++ b/lib/server/advertise.ts
@@ -16,37 +16,72 @@ import QRCode from "qrcode";
 import { Bonjour, type Service } from "bonjour-service";
 import { config } from "@/lib/config";
 
-/** First non-internal IPv4 address, or 127.0.0.1 if none found. */
-export function detectLanIp(): string {
-  const ifaces = networkInterfaces();
-  for (const addrs of Object.values(ifaces)) {
-    for (const addr of addrs ?? []) {
-      if (addr.family === "IPv4" && !addr.internal) return addr.address;
-    }
-  }
-  return "127.0.0.1";
+export interface LanInterface {
+  name: string;
+  address: string;
 }
 
-export function serverUrl(scheme: "http" | "https" = "http"): string {
-  return `${scheme}://${detectLanIp()}:${config.port}`;
+/**
+ * Preference rank for the default address (lower = better). Real LAN ranges
+ * win; VPN/CGNAT (100.64/10, e.g. Tailscale) and link-local lose — they can
+ * auto-detect first on some machines but aren't reachable by LAN phones.
+ */
+function addressRank(ip: string): number {
+  if (ip.startsWith("192.168.")) return 0;
+  if (ip.startsWith("10.")) return 1;
+  const m = ip.match(/^172\.(\d+)\./);
+  if (m && Number(m[1]) >= 16 && Number(m[1]) <= 31) return 2;
+  if (ip.startsWith("169.254.")) return 8; // link-local
+  if (ip.startsWith("100.")) return 9; // CGNAT / Tailscale — last resort
+  return 5; // other / public / unknown VPN
+}
+
+/** All non-internal IPv4 interfaces, best LAN candidate first. */
+export function listLanIps(): LanInterface[] {
+  const out: LanInterface[] = [];
+  for (const [name, addrs] of Object.entries(networkInterfaces())) {
+    for (const addr of addrs ?? []) {
+      if (addr.family === "IPv4" && !addr.internal) {
+        out.push({ name, address: addr.address });
+      }
+    }
+  }
+  return out.sort((a, b) => addressRank(a.address) - addressRank(b.address));
+}
+
+/** Best-guess LAN IP (preferred private range), or 127.0.0.1 if none. */
+export function detectLanIp(): string {
+  return listLanIps()[0]?.address ?? "127.0.0.1";
+}
+
+/** URL for a specific host, or the auto-detected default. */
+export function serverUrl(scheme: "http" | "https" = "http", host?: string): string {
+  return `${scheme}://${host || detectLanIp()}:${config.port}`;
 }
 
 /** QR code as a PNG data URL encoding the server URL. */
 export async function serverQrDataUrl(
   scheme: "http" | "https" = "http",
+  host?: string,
 ): Promise<string> {
-  return QRCode.toDataURL(serverUrl(scheme), { width: 320, margin: 1 });
+  return QRCode.toDataURL(serverUrl(scheme, host), { width: 320, margin: 1 });
 }
 
-/** Snapshot of the info the Admin header needs (spec §3.1). */
-export async function serverInfo(scheme: "http" | "https" = "http") {
-  const ip = detectLanIp();
+/**
+ * Snapshot of the info the host console needs (spec §3.1). The server listens
+ * on all interfaces; `interfaces` lists the candidate addresses, and `host`
+ * (if a valid interface IP) selects which one `url`/`qrDataUrl` point at.
+ */
+export async function serverInfo(scheme: "http" | "https" = "http", host?: string) {
+  const interfaces = listLanIps();
+  const ip = host && interfaces.some((i) => i.address === host) ? host : detectLanIp();
   return {
     ip,
     port: config.port,
-    url: serverUrl(scheme),
-    qrDataUrl: await serverQrDataUrl(scheme),
+    url: serverUrl(scheme, ip),
+    qrDataUrl: await serverQrDataUrl(scheme, ip),
     serverMode: config.serverMode,
+    interfaces,
   };
 }
 


### PR DESCRIPTION
Fixes auto-detect picking an unreachable address (your earlier log showed a Tailscale 100.x IP). The default now prefers real private LAN ranges (192.168/10/172.16) over CGNAT/link-local, and the control panel adds an interface dropdown to switch the advertised address (QR + URL update live). The server still binds all interfaces.

Verified server-side: /api/server-info now defaults to the 192.168 Wi-Fi IP over Tailscale, lists both interfaces, retargets url/QR on ?host=, and ignores bogus hosts. The dropdown itself is GUI (verify on a packaged build).

Refs #32