### PR TITLE
fix: revert invalid electron-builder linux config (#32)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,13 +61,7 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "notarize": true
     },
-    "linux": {
-      "target": ["AppImage", "deb"],
-      "category": "Utility",
-      "icon": "build/icon.png",
-      "desktopName": "free-dispatcher.desktop",
-      "synopsis": "Train dispatch for modular Free-moN sessions"
-    }
+    "linux": { "target": ["AppImage", "deb"], "category": "Utility", "icon": "build/icon.png" }
   },
   "overrides": {
     "postcss": "^8.5.10"


### PR DESCRIPTION
Hotfix: linux.desktopName/synopsis are invalid electron-builder 26 schema keys and broke the packaged build on all OSes (Invalid configuration object) — regression from #39. Restores the known-good linux config; verified with a local electron-builder --dir build. The cosmetic desktopName warning returns (not worth a broken build).

Refs #32