### PR TITLE
ci: sign + notarize the macOS build when secrets are present (#35)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -36,10 +36,40 @@ jobs:
       - name: Install dependencies
         run: npm install --no-audit --no-fund
 
-      - name: Build installer (unsigned)
+      # macOS only: if the signing secrets are configured, decode the App Store
+      # Connect API key to a file and export the signing env so electron-builder
+      # signs (Developer ID via CSC_LINK) + notarizes (notarytool via the API
+      # key). With no secrets it stays unsigned — so forks and pre-setup builds
+      # still work. See docs/SIGNING.md for the secret setup.
+      - name: Prepare macOS signing
+        if: runner.os == 'macOS'
         env:
-          # Skip macOS code signing / notarization — unsigned test builds.
-          CSC_IDENTITY_AUTO_DISCOVERY: "false"
+          APPLE_API_KEY_B64: ${{ secrets.APPLE_API_KEY_B64 }}
+          APPLE_API_KEY_ID: ${{ secrets.APPLE_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_API_ISSUER }}
+          CSC_LINK: ${{ secrets.CSC_LINK }}
+          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+        run: |
+          if [ -n "$CSC_LINK" ] && [ -n "$APPLE_API_KEY_B64" ]; then
+            echo "$APPLE_API_KEY_B64" | base64 --decode > "$RUNNER_TEMP/apple_api_key.p8"
+            {
+              echo "APPLE_API_KEY=$RUNNER_TEMP/apple_api_key.p8"
+              echo "APPLE_API_KEY_ID=$APPLE_API_KEY_ID"
+              echo "APPLE_API_ISSUER=$APPLE_API_ISSUER"
+              echo "CSC_LINK=$CSC_LINK"
+              echo "CSC_KEY_PASSWORD=$CSC_KEY_PASSWORD"
+              echo "FD_SIGN_MAC=1"
+            } >> "$GITHUB_ENV"
+            echo "macOS signing + notarization enabled."
+          else
+            echo "No macOS signing secrets — building unsigned."
+          fi
+
+      - name: Build installer
+        env:
+          # Sign on macOS only when the secrets were prepared above; otherwise
+          # skip signing (Windows/Linux are unsigned regardless for now).
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ env.FD_SIGN_MAC == '1' && 'true' || 'false' }}
         run: npm run dist -- --publish never
 
       - name: Upload installers

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -59,6 +59,44 @@ spctl -a -vvv -t install "dist/mac/Free Dispatcher.app"   # → "accepted, sourc
 
 ---
 
+## Sign in CI (GitHub Actions — no Mac required)
+
+The Package workflow (`.github/workflows/package.yml`) signs + notarizes the
+macOS build automatically **when these repo secrets are set** (Settings →
+Secrets and variables → Actions). With the secrets absent it builds unsigned, so
+forks and pre-setup builds still work.
+
+| Secret | Value |
+| --- | --- |
+| `CSC_LINK` | base64 of your **Developer ID Application** `.p12` |
+| `CSC_KEY_PASSWORD` | the `.p12` export password |
+| `APPLE_API_KEY_B64` | base64 of your App Store Connect `.p8` |
+| `APPLE_API_KEY_ID` | the API **Key ID** |
+| `APPLE_API_ISSUER` | the **Issuer ID** |
+
+Base64-encode the two files on any machine:
+
+```bash
+# macOS / Linux
+base64 -i AuthKey_XXXXXXXXXX.p8        # → APPLE_API_KEY_B64
+base64 -i DeveloperID_Application.p12  # → CSC_LINK
+```
+```powershell
+# Windows PowerShell
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("AuthKey_XXXXXXXXXX.p8"))
+[Convert]::ToBase64String([IO.File]::ReadAllBytes("DeveloperID_Application.p12"))
+```
+
+Then run the Package workflow (push a `v*` tag or **Actions → Package installers
+→ Run workflow**) — the macOS runner produces a **signed + notarized** `.dmg`,
+no Mac of your own needed. Getting the `.p12` without a Mac: see step 1
+(`openssl` CSR → Apple portal → `.cer` → `.p12`).
+
+> ⚠️ Revoke the `.p8` that was shared in chat earlier and create a fresh App
+> Store Connect API key for `APPLE_API_KEY_B64`.
+
+---
+
 ## Windows — unsigned (for now)
 
 `npm run dist` on Windows produces an unsigned NSIS installer. On first run users


### PR DESCRIPTION
Wires macOS signing + notarization into the Package workflow's macOS runner — no Mac of your own needed. It activates when these repo secrets are set, and builds unsigned without them (forks/pre-setup):

- CSC_LINK (base64 Developer ID Application .p12) + CSC_KEY_PASSWORD
- APPLE_API_KEY_B64 (base64 App Store Connect .p8) + APPLE_API_KEY_ID + APPLE_API_ISSUER

docs/SIGNING.md has the setup (base64 commands, getting the .p12 without a Mac, revoke-the-shared-key reminder).

I can't verify the signed path here (needs your Apple secrets), but the unsigned fallback is unchanged — I'll dispatch a build after merge to confirm it's still green. Closes #35 once you've added the secrets and a signed dmg is produced.

Refs #35