### PR TITLE
ci: Windows signing via Azure Trusted Signing when configured (#36)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -65,12 +65,40 @@ jobs:
             echo "No macOS signing secrets — building unsigned."
           fi
 
+      # Windows only: enable Azure Trusted Signing when its secrets are set.
+      # electron-builder signs via win.azureSignOptions (injected as -c.*
+      # config overrides) using AZURE_* service-principal auth. No secrets →
+      # unsigned. See docs/SIGNING.md for the secret + Azure setup.
+      - name: Prepare Windows signing
+        if: runner.os == 'Windows'
+        shell: bash
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZ_ENDPOINT: ${{ secrets.AZURE_TS_ENDPOINT }}
+          AZ_ACCOUNT: ${{ secrets.AZURE_TS_ACCOUNT }}
+          AZ_PROFILE: ${{ secrets.AZURE_TS_PROFILE }}
+        run: |
+          if [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZ_ENDPOINT" ]; then
+            {
+              echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
+              echo "AZURE_CLIENT_ID=$AZURE_CLIENT_ID"
+              echo "AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET"
+              echo "FD_WIN_SIGN_ARGS=-c.win.azureSignOptions.endpoint=$AZ_ENDPOINT -c.win.azureSignOptions.codeSigningAccountName=$AZ_ACCOUNT -c.win.azureSignOptions.certificateProfileName=$AZ_PROFILE"
+            } >> "$GITHUB_ENV"
+            echo "Windows Azure Trusted Signing enabled."
+          else
+            echo "No Windows signing secrets — building unsigned."
+          fi
+
       - name: Build installer
         env:
-          # Sign on macOS only when the secrets were prepared above; otherwise
-          # skip signing (Windows/Linux are unsigned regardless for now).
+          # macOS signs only when its secrets were prepared above; Windows signs
+          # via the injected Azure args (FD_WIN_SIGN_ARGS). No secrets on either
+          # → unsigned (Linux is always unsigned for now).
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ env.FD_SIGN_MAC == '1' && 'true' || 'false' }}
-        run: npm run dist -- --publish never
+        run: npm run dist -- --publish never ${{ env.FD_WIN_SIGN_ARGS }}
 
       - name: Upload installers
         uses: actions/upload-artifact@v5

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -97,19 +97,39 @@ no Mac of your own needed. Getting the `.p12` without a Mac: see step 1
 
 ---
 
-## Windows — unsigned (for now)
+## Windows — Azure Trusted Signing
 
-`npm run dist` on Windows produces an unsigned NSIS installer. On first run users
-see **SmartScreen → "Windows protected your PC"**; they click **More info → Run
-anyway**. Functional, just not friction-free.
+The Package workflow's Windows job signs via **Azure Trusted Signing** when its
+secrets are set (electron-builder `win.azureSignOptions`, injected as config
+overrides). Without them it builds **unsigned** — SmartScreen "unknown
+publisher" click-through. ~$9.99/month, no USB token, clears SmartScreen.
 
-**When you're ready to sign**, the cheapest modern path is **Azure Trusted
-Signing** (~$10/mo, cloud, no USB token, clears SmartScreen; US/Canada
-individuals/orgs). electron-builder supports it natively via `win.azureSignOptions`
-— set up a Trusted Signing account + app registration, then add that block and
-the auth env vars. (Alternatives: SSL.com eSigner / DigiCert KeyLocker cloud
-certs, or a hardware-token OV/EV cert.) Plain `.pfx` files are no longer issued —
-since 2023 the private key must live on an HSM or hardware token.
+### One-time Azure setup
+1. Create a **Trusted Signing account** (Azure portal → Trusted / Artifact
+   Signing) and complete **identity validation** — Microsoft verifies the
+   publisher; can take a few days.
+2. Create a **certificate profile** in that account (note its name).
+3. Create an **app registration** (Microsoft Entra) with a **client secret**,
+   and assign it the **Trusted Signing Certificate Profile Signer** role on the
+   account.
+4. Note the account's **endpoint** (region URL, e.g. `https://eus.codesigning.azure.net/`).
+
+### Repo secrets (Settings → Secrets and variables → Actions)
+| Secret | Value |
+| --- | --- |
+| `AZURE_TENANT_ID` | Entra tenant id |
+| `AZURE_CLIENT_ID` | app registration (client) id |
+| `AZURE_CLIENT_SECRET` | the client secret |
+| `AZURE_TS_ENDPOINT` | Trusted Signing endpoint URL |
+| `AZURE_TS_ACCOUNT` | Trusted Signing account name |
+| `AZURE_TS_PROFILE` | certificate profile name |
+
+Then run the Package workflow (`v*` tag or **Actions → Package installers → Run
+workflow**) — the Windows job produces a signed `.exe`.
+
+> Cheaper alternatives if you reconsider: **SignPath Foundation** (free for
+> open-source projects) or a **Certum** open-source cert (~$50). Plain `.pfx`
+> files are no longer issued — the private key must live on an HSM/token.
 
 ---
 


### PR DESCRIPTION
Wires Azure Trusted Signing into the Package workflow's Windows job (your chosen ~$10/mo option). It activates when the Azure secrets are set and builds unsigned without them (forks/pre-setup).

electron-builder win.azureSignOptions is injected as -c.* CLI overrides (so no per-account values live in package.json and unsigned builds stay valid); auth is an Entra service principal via AZURE_* env.

Secrets to add: AZURE_TENANT_ID, AZURE_CLIENT_ID, AZURE_CLIENT_SECRET, AZURE_TS_ENDPOINT, AZURE_TS_ACCOUNT, AZURE_TS_PROFILE. Full Azure setup in docs/SIGNING.md.

Can't verify the signed path here (needs your Azure account); the unsigned fallback is unchanged — I'll dispatch a build after merge to confirm it's still green. Closes #36 once secrets are added and a signed .exe is produced.

Refs #36