### PR TITLE
fix: Windows Azure signing — publisherName + JS config (#36)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -83,10 +83,10 @@ jobs:
             echo "No macOS signing secrets — building unsigned."
           fi
 
-      # Windows only: enable Azure Trusted Signing when its secrets are set.
-      # electron-builder signs via win.azureSignOptions (injected as -c.*
-      # config overrides) using AZURE_* service-principal auth. No secrets →
-      # unsigned. See docs/SIGNING.md for the secret + Azure setup.
+      # Windows only: export the Azure Trusted Signing env when the secrets are
+      # set. electron-builder.config.cjs reads these and adds win.azureSignOptions
+      # (auth = the AZURE_TENANT_ID/CLIENT_ID/CLIENT_SECRET service principal).
+      # No secrets → unsigned. See docs/SIGNING.md for the Azure setup.
       - name: Prepare Windows signing
         if: runner.os == 'Windows'
         shell: bash
@@ -94,35 +94,33 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          AZ_ENDPOINT: ${{ secrets.AZURE_TS_ENDPOINT }}
-          AZ_ACCOUNT: ${{ secrets.AZURE_TS_ACCOUNT }}
-          AZ_PROFILE: ${{ secrets.AZURE_TS_PROFILE }}
+          AZURE_TS_ENDPOINT: ${{ secrets.AZURE_TS_ENDPOINT }}
+          AZURE_TS_ACCOUNT: ${{ secrets.AZURE_TS_ACCOUNT }}
+          AZURE_TS_PROFILE: ${{ secrets.AZURE_TS_PROFILE }}
+          AZURE_TS_PUBLISHER: ${{ secrets.AZURE_TS_PUBLISHER }}
         run: |
-          if [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZ_ENDPOINT" ]; then
+          if [ -n "$AZURE_CLIENT_ID" ] && [ -n "$AZURE_TS_ENDPOINT" ] && [ -n "$AZURE_TS_PUBLISHER" ]; then
             {
               echo "AZURE_TENANT_ID=$AZURE_TENANT_ID"
               echo "AZURE_CLIENT_ID=$AZURE_CLIENT_ID"
               echo "AZURE_CLIENT_SECRET=$AZURE_CLIENT_SECRET"
-              echo "FD_WIN_SIGN_ARGS=-c.win.azureSignOptions.endpoint=$AZ_ENDPOINT -c.win.azureSignOptions.codeSigningAccountName=$AZ_ACCOUNT -c.win.azureSignOptions.certificateProfileName=$AZ_PROFILE"
+              echo "AZURE_TS_ENDPOINT=$AZURE_TS_ENDPOINT"
+              echo "AZURE_TS_ACCOUNT=$AZURE_TS_ACCOUNT"
+              echo "AZURE_TS_PROFILE=$AZURE_TS_PROFILE"
+              echo "AZURE_TS_PUBLISHER=$AZURE_TS_PUBLISHER"
             } >> "$GITHUB_ENV"
             echo "Windows Azure Trusted Signing enabled."
           else
-            echo "No Windows signing secrets — building unsigned."
+            echo "Windows signing secrets incomplete — building unsigned."
           fi
 
       - name: Build installer
-        shell: bash
         env:
-          # macOS signs only when its secrets were prepared above; Windows signs
-          # via the injected Azure args ($FD_WIN_SIGN_ARGS). No secrets on either
-          # → unsigned (Linux is always unsigned for now). electron-builder is
-          # invoked directly (not through `npm run dist --`) so the `-c.*`
-          # config overrides aren't mangled by npm's argument forwarding.
+          # macOS signs when its secrets are present (CSC_IDENTITY_AUTO_DISCOVERY);
+          # Windows signs via Azure when the AZURE_TS_* env is present (set above,
+          # read by electron-builder.config.cjs). Unsigned otherwise.
           CSC_IDENTITY_AUTO_DISCOVERY: ${{ env.FD_SIGN_MAC == '1' && 'true' || 'false' }}
-        run: |
-          npm run build
-          npm run prepare:standalone
-          npx electron-builder --publish never $FD_WIN_SIGN_ARGS
+        run: npm run dist
 
       - name: Upload installers
         uses: actions/upload-artifact@v5

--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -123,6 +123,7 @@ publisher" click-through. ~$9.99/month, no USB token, clears SmartScreen.
 | `AZURE_TS_ENDPOINT` | Trusted Signing endpoint URL |
 | `AZURE_TS_ACCOUNT` | Trusted Signing account name |
 | `AZURE_TS_PROFILE` | certificate profile name |
+| `AZURE_TS_PUBLISHER` | publisher/subject name on the cert profile (your validated identity name) — required by electron-builder's schema |
 
 Then run the Package workflow (`v*` tag or **Actions → Package installers → Run
 workflow**) — the Windows job produces a signed `.exe`.

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -1,0 +1,51 @@
+/**
+ * electron-builder configuration (#32). A JS config (not package.json `build`)
+ * so Windows Azure Trusted Signing can be added conditionally as a real object
+ * from env vars — injecting it via CLI `-c.*` overrides produced a malformed
+ * value that failed schema validation (#36).
+ *
+ * Signing is env-driven and optional:
+ *  - macOS: signed + notarized when CSC_LINK + APPLE_API_* are set (the CI
+ *    "Prepare macOS signing" step); unsigned otherwise.
+ *  - Windows: Azure Trusted Signing when AZURE_TS_* + AZURE_CLIENT_ID are set;
+ *    unsigned otherwise.
+ */
+const config = {
+  appId: "org.freedispatcher.host",
+  productName: "Free Dispatcher",
+  artifactName: "${name}-${version}-${arch}.${ext}",
+  directories: { output: "dist", buildResources: "build" },
+  files: ["electron/**/*", "package.json"],
+  extraResources: [
+    { from: ".next/standalone", to: "standalone" },
+    { from: ".next/standalone/node_modules", to: "standalone/node_modules" },
+  ],
+  win: { target: ["nsis"], icon: "build/icon.ico" },
+  nsis: { oneClick: false, allowToChangeInstallationDirectory: true, perMachine: false },
+  mac: {
+    target: ["dmg"],
+    icon: "build/icon.icns",
+    category: "public.app-category.utilities",
+    hardenedRuntime: true,
+    entitlements: "build/entitlements.mac.plist",
+    entitlementsInherit: "build/entitlements.mac.plist",
+    notarize: true,
+  },
+  linux: { target: ["AppImage", "deb"], category: "Utility", icon: "build/icon.png" },
+};
+
+// Windows Azure Trusted Signing — only when the account env vars are present
+// (the CI "Prepare Windows signing" step sets them from secrets). Auth is the
+// AZURE_TENANT_ID / AZURE_CLIENT_ID / AZURE_CLIENT_SECRET service principal.
+if (process.env.AZURE_TS_ENDPOINT && process.env.AZURE_CLIENT_ID && process.env.AZURE_TS_PUBLISHER) {
+  config.win.azureSignOptions = {
+    endpoint: process.env.AZURE_TS_ENDPOINT,
+    codeSigningAccountName: process.env.AZURE_TS_ACCOUNT,
+    certificateProfileName: process.env.AZURE_TS_PROFILE,
+    // Required by electron-builder's schema; must match the publisher/subject
+    // name on your Trusted Signing certificate profile.
+    publisherName: process.env.AZURE_TS_PUBLISHER,
+  };
+}
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint",
     "prepare:standalone": "node scripts/prepare-standalone.mjs",
     "electron:dev": "npm run build && npm run prepare:standalone && electron .",
-    "dist": "npm run build && npm run prepare:standalone && electron-builder",
+    "dist": "npm run build && npm run prepare:standalone && electron-builder --config electron-builder.config.cjs",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx lib/db/migrate.ts",
     "db:seed": "tsx lib/db/seed.ts"
@@ -40,29 +40,6 @@
     "tailwindcss": "^4",
     "tsx": "^4.22.4",
     "typescript": "^5"
-  },
-  "build": {
-    "appId": "org.freedispatcher.host",
-    "productName": "Free Dispatcher",
-    "artifactName": "${name}-${version}-${arch}.${ext}",
-    "directories": { "output": "dist", "buildResources": "build" },
-    "files": ["electron/**/*", "package.json"],
-    "extraResources": [
-      { "from": ".next/standalone", "to": "standalone" },
-      { "from": ".next/standalone/node_modules", "to": "standalone/node_modules" }
-    ],
-    "win": { "target": ["nsis"], "icon": "build/icon.ico" },
-    "nsis": { "oneClick": false, "allowToChangeInstallationDirectory": true, "perMachine": false },
-    "mac": {
-      "target": ["dmg"],
-      "icon": "build/icon.icns",
-      "category": "public.app-category.utilities",
-      "hardenedRuntime": true,
-      "entitlements": "build/entitlements.mac.plist",
-      "entitlementsInherit": "build/entitlements.mac.plist",
-      "notarize": true
-    },
-    "linux": { "target": ["AppImage", "deb"], "category": "Utility", "icon": "build/icon.png" }
   },
   "overrides": {
     "postcss": "^8.5.10"


### PR DESCRIPTION
Root cause of the Windows signing failure: electron-builder's azureSignOptions schema REQUIRES publisherName (not just endpoint/account/profile). Also moved the build config to electron-builder.config.cjs so azureSignOptions is built as a proper object from env (the -c.* CLI overrides were fragile). Adds the AZURE_TS_PUBLISHER secret. Verified locally: passes schema + reaches Invoke-TrustedSigning (fails only at dummy-cred auth); unsigned builds unaffected. Refs #36