### PR TITLE
fix: --publish never in dist script (#42)

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint",
     "prepare:standalone": "node scripts/prepare-standalone.mjs",
     "electron:dev": "npm run build && npm run prepare:standalone && electron .",
-    "dist": "npm run build && npm run prepare:standalone && electron-builder --config electron-builder.config.cjs",
+    "dist": "npm run build && npm run prepare:standalone && electron-builder --config electron-builder.config.cjs --publish never",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "tsx lib/db/migrate.ts",
     "db:seed": "tsx lib/db/seed.ts"


### PR DESCRIPTION
Reverting the build step to 'npm run dist' dropped --publish never, so CI electron-builder tried to publish to GitHub (GH_TOKEN error) and all 3 jobs failed. Bake --publish never into dist; the release job publishes via gh. Refs #42 #36