### PR TITLE
chore: adopt 0.x SemVer release policy with beta channel

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -150,11 +150,18 @@ jobs:
           path: dist
           merge-multiple: true
 
+      # A tag with a hyphen is a SemVer pre-release (v0.8.0-beta.1, v0.8.0-rc.1):
+      # publish it as a GitHub pre-release so it never becomes "latest" and
+      # stable users aren't offered it. Plain tags (v0.8.0) publish as latest.
       - name: Publish GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          PRERELEASE_FLAG=""
+          case "$GITHUB_REF_NAME" in
+            *-*) PRERELEASE_FLAG="--prerelease" ;;
+          esac
           gh release create "$GITHUB_REF_NAME" dist/* \
             --repo "$GITHUB_REPOSITORY" \
             --title "$GITHUB_REF_NAME" \
-            --generate-notes
+            --generate-notes $PRERELEASE_FLAG

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,16 @@
 # Changelog
 
-All notable changes will be documented in this file. Follow Keep a Changelog principles and Semantic Versioning when tagging releases.
+All notable changes will be documented in this file. Follow [Keep a Changelog](https://keepachangelog.com/) principles and [Semantic Versioning](https://semver.org/) when tagging releases.
+
+While on the 0.x line the app is pre-1.0: behavior and storage formats may change between minor versions. Betas are tagged as `vX.Y.Z-beta.N` (SemVer pre-releases) and ship as GitHub pre-releases; stable cuts are tagged `vX.Y.Z`. See [RELEASING.md](RELEASING.md).
+
+## [Unreleased]
+
+Targeting **0.8.0**. Add entries here under Added / Changed / Fixed / Removed as PRs land; on release this heading becomes the version + date.
+
+### Added
+- Electron desktop shell packaging across Windows, macOS, and Linux, with code signing wired up (Azure Trusted Signing on Windows, Developer ID + notarization on macOS).
+- Tag-driven release pipeline: pushing a `v*` tag builds installers and publishes a GitHub Release; pre-release tags publish as GitHub pre-releases.
 
 ## 0.7.0 - 2025-12-26
 - Added Electron shell and IPC-based backend URL resolution for the React frontend.
@@ -8,6 +18,3 @@ All notable changes will be documented in this file. Follow Keep a Changelog pri
 - Added Electron packaging config and scripts (`electron:build`, `backend:bundle`).
 - Retired Docker-based workflow and removed LAN socat scripts; updated documentation accordingly.
 - Ignored PyInstaller artifacts and slimmed packaged assets to include only bundled backend.
-
-## Unreleased
-- (placeholder)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,69 @@
+# Releasing Free-Dispatcher
+
+Free-Dispatcher follows [Semantic Versioning](https://semver.org/). While we are on
+the **0.x** line the app is pre-1.0: behavior and storage formats may change between
+minor versions, and a bump to `0.(N+1).0` can carry breaking changes.
+
+**The git tag is the single source of truth for a release.** The
+[`Package installers`](.github/workflows/package.yml) workflow rewrites the version
+from the tag, builds signed installers for Windows / macOS / Linux, and publishes a
+GitHub Release. You do not hand-edit version numbers to ship — you tag.
+
+## Version scheme
+
+| Kind | Tag | Example | GitHub Release |
+| --- | --- | --- | --- |
+| Stable | `vX.Y.Z` | `v0.8.0` | latest |
+| Beta | `vX.Y.Z-beta.N` | `v0.8.0-beta.1` | pre-release |
+| Release candidate | `vX.Y.Z-rc.N` | `v0.8.0-rc.1` | pre-release |
+
+These order the way you'd expect:
+`0.8.0-beta.1 < 0.8.0-beta.2 < 0.8.0-rc.1 < 0.8.0`. Any tag **with a hyphen** is
+treated as a pre-release and published as a GitHub pre-release, so it never becomes
+"latest" and stable users aren't offered it.
+
+On `main`, `package.json` carries the **next** target with a `-dev` suffix (e.g.
+`0.8.0-dev`) purely as a marker. The shipped number always comes from the tag.
+
+## When to bump what (0.x rules)
+
+- **Breaking** change (data migration required, incompatible behavior) → bump the
+  **minor**: `0.7.x` → `0.8.0`.
+- **Feature**, backwards-compatible → also minor on 0.x (there's no separate "major"
+  signal pre-1.0).
+- **Bug fix** only → bump the **patch**: `0.8.0` → `0.8.1`.
+
+When the app is stable enough to promise compatibility, cut `1.0.0` and switch to
+normal SemVer (breaking → major).
+
+## Cutting a release
+
+1. **Land the work.** Every PR updates the `## [Unreleased]` section of
+   [CHANGELOG.md](CHANGELOG.md) under Added / Changed / Fixed / Removed.
+2. **Roll the changelog.** Rename `## [Unreleased]` to `## X.Y.Z - YYYY-MM-DD`, and add a
+   fresh empty `## [Unreleased]` above it. Commit.
+3. **Set the dev marker** in `package.json` to the *next* target, e.g. `0.9.0-dev`,
+   in the same commit.
+4. **Tag and push:**
+   ```bash
+   git tag v0.8.0            # stable
+   # or
+   git tag v0.8.0-beta.1     # beta -> publishes as a GitHub pre-release
+   git push origin v0.8.0
+   ```
+5. CI builds installers and publishes the GitHub Release automatically. For a beta,
+   confirm it shows as **Pre-release** on the Releases page.
+
+A beta cycle typically looks like: `v0.8.0-beta.1` → fixes → `v0.8.0-beta.2` → … →
+`v0.8.0` once it's solid.
+
+## Branching
+
+We use GitHub Flow: `main` is always releasable. Contributors branch off `main`, open
+a PR (CI must pass), and merge. Releases are just tags on `main` — there is no
+long-lived `develop` or `release` branch.
+
+## Signing
+
+Installer signing activates automatically when the per-platform secrets are present;
+builds are unsigned otherwise (so forks still build). See [docs/SIGNING.md](docs/SIGNING.md).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "free-dispatcher",
-  "version": "2.0.0-dev",
+  "version": "0.8.0-dev",
   "private": true,
   "description": "Local-first train dispatch for modular Free-moN sessions",
   "author": "Will Gage <willcgage@gmail.com>",


### PR DESCRIPTION
## What

Establishes a best-practice versioning policy now that Free-Dispatcher is moving from
beta-only into full releases alongside ongoing beta builds. Continues the **0.x** line.

## Why

The release plumbing already derives the version from the git tag and publishes a GitHub
Release, but there was no policy distinguishing stable from beta, and the metadata was
inconsistent (`package.json` at `2.0.0-dev` while the changelog stopped at `0.7.0`).

## Changes

- **`.github/workflows/package.yml`** — tags with a hyphen (`v0.8.0-beta.1`, `v0.8.0-rc.1`)
  now publish as GitHub **pre-releases**, so betas never become "latest" or reach stable
  users. Plain tags (`v0.8.0`) publish as latest. This is the only mechanical change needed
  to make beta builds first-class.
- **`package.json`** — `0.8.0-dev` (was `2.0.0-dev`), a next-target marker; the shipped
  number always comes from the tag.
- **`CHANGELOG.md`** — reconciled to the 0.x line: proper `## [Unreleased]` section
  targeting 0.8.0, a pre-1.0 semantics note, and the broken 2.0.0 jump removed.
- **`RELEASING.md`** (new) — contributor-facing release guide: tag-is-source-of-truth
  model, version table (stable / beta / rc), 0.x bump rules, cut procedure, GitHub Flow
  branching, signing pointer.

## Version scheme

| Kind | Tag | GitHub Release |
| --- | --- | --- |
| Stable | `v0.8.0` | latest |
| Beta | `v0.8.0-beta.1` | pre-release |
| Release candidate | `v0.8.0-rc.1` | pre-release |

## Deferred (tracked on the project board)

- #52 — Auto-update via `electron-updater` (stable + beta channels)
- #53 — Automate releases with Conventional Commits + `release-please`

## Next release

`v0.8.0-beta.1` to put a beta in testers' hands, then `v0.8.0` once solid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
