### PR TITLE
fix: ship Module Repository anon key so admin login works (#56)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,8 +32,10 @@ SERVER_MODE=true
 # if you are pointing at a local / staging instance.
 # MODULE_REPO_URL=https://dpifxkipqfaxujidgjyg.supabase.co
 #
-# Public Supabase anon key for the Module Repository. Required as the `apikey`
-# header on auth calls (POST /auth/v1/token). This is a CLIENT-SIDE PUBLIC key
-# — it is safe to commit, but keep it out of the repo by setting it here.
-# Obtain from the Module Repository project dashboard → Settings → API.
+# Public Supabase anon key for the Module Repository, sent as the `apikey`
+# header on auth calls (POST /auth/v1/token). This is a CLIENT-SIDE PUBLIC key,
+# so the production project's key ships as the built-in default (see
+# lib/config.ts) — you do NOT need to set this for normal use. Override only
+# when pointing at a local / staging Supabase instance; obtain the key from that
+# project's dashboard → Settings → API.
 # MODULE_REPO_ANON_KEY=

--- a/lib/config.ts
+++ b/lib/config.ts
@@ -39,9 +39,15 @@ export const config = {
   moduleRepo: {
     // Supabase project URL for the Module Repository.
     url: process.env.MODULE_REPO_URL ?? "https://dpifxkipqfaxujidgjyg.supabase.co",
-    // Public anon key — required as `apikey` header on Supabase auth calls.
-    // This is a client-side public key; safe to bundle.
-    anonKey: process.env.MODULE_REPO_ANON_KEY ?? "",
+    // Public anon key — required as the `apikey` header on Supabase auth calls.
+    // This is a client-side public key (exposed to browsers by design), so it
+    // ships as the default for the production project, mirroring `url` above —
+    // a packaged build has no .env, and without a default every admin login
+    // fails with Supabase's "No API key found in request". Override via env
+    // only when pointing at a local / staging instance.
+    anonKey:
+      process.env.MODULE_REPO_ANON_KEY ??
+      "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImRwaWZ4a2lwcWZheHVqaWRnanlnIiwicm9sZSI6ImFub24iLCJpYXQiOjE3ODA3NzU2NjYsImV4cCI6MjA5NjM1MTY2Nn0.W91jEVB9GtIN3DViIgtW2ki2t1MyDGR18fIFG3UJ030",
   },
 } as const;
 

--- a/lib/server/ModuleRepoAuth.ts
+++ b/lib/server/ModuleRepoAuth.ts
@@ -13,6 +13,18 @@ export class ReauthRequired extends Error {
   }
 }
 
+// The anon key ships as a default (lib/config.ts), but a misconfigured env
+// override could blank it. Guard before calling Supabase so we surface a clear,
+// app-level message instead of leaking Supabase's raw "No API key found in
+// request".
+function assertConfigured(): void {
+  if (!config.moduleRepo.anonKey) {
+    throw new Error(
+      "Module Repository is not configured (MODULE_REPO_ANON_KEY is empty).",
+    );
+  }
+}
+
 interface AuthRecord {
   email: string;
   access_token: string;
@@ -63,6 +75,7 @@ function expiresAt(expiresIn: number): string {
 }
 
 export async function signIn(email: string, password: string): Promise<void> {
+  assertConfigured();
   const res = await fetch(
     `${config.moduleRepo.url}/auth/v1/token?grant_type=password`,
     {
@@ -111,6 +124,7 @@ export async function getValidToken(): Promise<string> {
   }
 
   // Access token expired — try to refresh.
+  assertConfigured();
   const res = await fetch(
     `${config.moduleRepo.url}/auth/v1/token?grant_type=refresh_token`,
     {

--- a/lib/server/__tests__/ModuleRepoAuth.test.ts
+++ b/lib/server/__tests__/ModuleRepoAuth.test.ts
@@ -29,6 +29,7 @@ vi.mock("@/lib/config", () => ({
 }));
 
 // Import after mocks are established
+import { config } from "@/lib/config";
 import {
   signIn,
   signOut,
@@ -124,6 +125,19 @@ describe("signIn", () => {
     );
 
     await expect(signIn("u@e.com", "p")).rejects.toThrow("Sign-in failed (500)");
+  });
+
+  it("fails with a clear message (no fetch) when the anon key is empty", async () => {
+    const original = config.moduleRepo.anonKey;
+    (config.moduleRepo as { anonKey: string }).anonKey = "";
+    try {
+      await expect(signIn("u@e.com", "p")).rejects.toThrow(
+        "Module Repository is not configured",
+      );
+      expect(fetch).not.toHaveBeenCalled();
+    } finally {
+      (config.moduleRepo as { anonKey: string }).anonKey = original;
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #56.

## Problem

Admin login failed with Supabase's `No API key found in request`. The sign-in call sends
`config.moduleRepo.anonKey` as the `apikey` header, but that defaulted to `""` when
`MODULE_REPO_ANON_KEY` was unset — and a packaged build has no `.env`, while
`electron/main.js` doesn't forward the variable. So the header was always empty in
production and Supabase rejected the request before credentials were ever checked.

## Fix

- **`lib/config.ts`** — ship the production project's public anon key as the built-in
  default, exactly mirroring how `url` already defaults. It's a client-side public key
  (exposed to browsers by design), so bundling it is safe. Override via env only for
  local/staging instances.
- **`lib/server/ModuleRepoAuth.ts`** — guard `signIn` + token refresh so an empty key
  fails with a clear `Module Repository is not configured` message instead of leaking
  Supabase's raw error.
- **`.env.example`** — document that the key now ships as a default and is only needed to
  override.
- **test** — cover the empty-key guard (clear throw, no `fetch`).

## Verification

- `npm test` — 24 passing (incl. new guard test); `npm run lint` + `npx tsc --noEmit` clean.
- Live check against the auth endpoint:
  - **with** the baked key → `400 invalid_credentials` (key accepted; only the fake
    password is rejected)
  - **without** a key → `401 No API key found in request` (the original bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
