### PR TITLE
chore: add MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025-2026 Will Gage
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "description": "Local-first train dispatch for modular Free-moN sessions",
   "author": "Will Gage <willcgage@gmail.com>",
+  "license": "MIT",
   "main": "electron/main.js",
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Adds an MIT `LICENSE` file and a `"license": "MIT"` field to `package.json`.

The repo was previously public with **no license**, which legally means all-rights-reserved (not open source). An OSI-approved license is:

- **required** for [SignPath Foundation](https://signpath.org/) free code-signing eligibility — our chosen Windows signing route after Azure Trusted Signing identity validation failed twice, and
- good practice for a publicly distributed application.

Copyright holder: Will Gage. Year: 2025–2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
