### PR TITLE
feat: standalone session archiving + sessions list (#57)

### DIFF
--- a/app/admin/session/page.tsx
+++ b/app/admin/session/page.tsx
@@ -1,16 +1,42 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useFdSession } from "@/lib/client/useFdSession";
-import { apiSend } from "@/lib/client/api";
+import { apiGet, apiSend } from "@/lib/client/api";
 import { Panel } from "@/components/admin/ui";
+import type { SessionRow } from "@/lib/client/types";
 
 export default function AdminSession() {
   const { state, refresh } = useFdSession();
   const [busy, setBusy] = useState(false);
   const [form, setForm] = useState({ name: "", date: "", venue: "" });
+  const [sessions, setSessions] = useState<SessionRow[]>([]);
 
   const session = state?.session ?? null;
+  const hasActive = sessions.some((s) => s.status === "active");
+
+  const loadSessions = useCallback(async () => {
+    try {
+      const { sessions } = await apiGet<{ sessions: SessionRow[] }>(
+        "/api/sessions",
+      );
+      setSessions(sessions);
+    } catch {
+      /* list is best-effort; the active-session panel still works */
+    }
+  }, []);
+
+  useEffect(() => {
+    // loadSessions setStates after an await (not synchronously here); refetch
+    // whenever the live session state changes so the list tracks archive/start.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadSessions();
+  }, [loadSessions, state]);
+
+  // Refresh both the live state and the list after any mutation.
+  const after = useCallback(async () => {
+    await Promise.all([refresh(), loadSessions()]);
+  }, [refresh, loadSessions]);
 
   async function createSession(e: React.FormEvent) {
     e.preventDefault();
@@ -30,7 +56,7 @@ export default function AdminSession() {
         venue: form.venue || undefined,
       });
       setForm({ name: "", date: "", venue: "" });
-      await refresh();
+      await after();
     } catch (err) {
       alert(err instanceof Error ? err.message : "create failed");
     } finally {
@@ -38,14 +64,78 @@ export default function AdminSession() {
     }
   }
 
+  async function archiveActive() {
+    if (
+      !session ||
+      !confirm(
+        `Archive "${session.name}"? It will end the active session — you can reactivate it later from Past sessions.`,
+      )
+    )
+      return;
+    setBusy(true);
+    try {
+      await apiSend("POST", "/api/session/archive");
+      await after();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "archive failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function reactivate(s: SessionRow) {
+    if (!confirm(`Reactivate "${s.name}" as the active session?`)) return;
+    setBusy(true);
+    try {
+      await apiSend("PATCH", `/api/sessions/${s.id}`);
+      await after();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "reactivate failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function remove(s: SessionRow) {
+    if (
+      !confirm(
+        `Permanently delete "${s.name}" and all its trains, operators, and logs? This cannot be undone.`,
+      )
+    )
+      return;
+    setBusy(true);
+    try {
+      await apiSend("DELETE", `/api/sessions/${s.id}`);
+      await after();
+    } catch (err) {
+      alert(err instanceof Error ? err.message : "delete failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   const input =
     "w-full rounded-md border border-slate-700 bg-slate-800 px-3 py-2 text-sm text-slate-100 placeholder-slate-500";
+  const canSubmit = !busy && form.name.trim().length > 0;
 
   return (
     <div className="max-w-xl space-y-5">
       <h1 className="text-2xl font-bold">Session management</h1>
 
-      <Panel title="Active session">
+      <Panel
+        title="Active session"
+        actions={
+          session ? (
+            <button
+              disabled={busy}
+              onClick={archiveActive}
+              className="rounded-md border border-amber-700/60 px-3 py-1 text-xs font-semibold text-amber-300 hover:bg-amber-900/30 disabled:opacity-50"
+            >
+              Archive session
+            </button>
+          ) : undefined
+        }
+      >
         {session ? (
           <dl className="space-y-1 text-sm">
             <div className="flex justify-between">
@@ -99,12 +189,76 @@ export default function AdminSession() {
             </p>
           )}
           <button
-            disabled={busy}
+            disabled={!canSubmit}
             className="rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-500 disabled:opacity-50"
           >
             {session ? "Archive & start new" : "Create session"}
           </button>
+          {!form.name.trim() && (
+            <p className="text-xs text-slate-500">
+              Enter a session name to continue.
+            </p>
+          )}
         </form>
+      </Panel>
+
+      <Panel title={`Past sessions (${sessions.length})`}>
+        {sessions.length === 0 ? (
+          <p className="text-sm text-slate-400">No sessions yet.</p>
+        ) : (
+          <ul className="divide-y divide-slate-800">
+            {sessions.map((s) => (
+              <li
+                key={s.id}
+                className="flex items-center justify-between gap-3 py-2.5"
+              >
+                <div className="min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="truncate font-medium text-slate-100">
+                      {s.name}
+                    </span>
+                    {s.status === "active" ? (
+                      <span className="rounded bg-emerald-600/20 px-1.5 py-0.5 text-xs font-medium text-emerald-300">
+                        active
+                      </span>
+                    ) : (
+                      <span className="rounded bg-slate-700/50 px-1.5 py-0.5 text-xs text-slate-400">
+                        archived
+                      </span>
+                    )}
+                  </div>
+                  <div className="text-xs text-slate-500">
+                    {s.venue ?? "—"} · {s.date ?? "—"} ·{" "}
+                    {new Date(s.createdAt).toLocaleDateString()}
+                  </div>
+                </div>
+                {s.status === "archived" && (
+                  <div className="flex shrink-0 gap-2">
+                    <button
+                      disabled={busy || hasActive}
+                      onClick={() => reactivate(s)}
+                      title={
+                        hasActive
+                          ? "Archive the active session first"
+                          : "Make this the active session"
+                      }
+                      className="rounded px-2 py-1 text-xs font-medium text-sky-300 hover:bg-sky-900/30 disabled:opacity-40"
+                    >
+                      Reactivate
+                    </button>
+                    <button
+                      disabled={busy}
+                      onClick={() => remove(s)}
+                      className="rounded px-2 py-1 text-xs font-medium text-red-300 hover:bg-red-900/30 disabled:opacity-50"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
       </Panel>
     </div>
   );

--- a/app/api/session/archive/route.ts
+++ b/app/api/session/archive/route.ts
@@ -1,0 +1,22 @@
+/**
+ * POST /api/session/archive — archive the active session WITHOUT starting a
+ * new one (Admin, spec §3.3). Ends the current event cleanly; the dashboard
+ * then shows "no active session" until one is created or reactivated.
+ */
+import { NextResponse } from "next/server";
+import { sessionManager } from "@/lib/server/SessionManager";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+
+  const archived = await sessionManager.archiveActiveSession(guard.claims.operatorId);
+  if (!archived) {
+    return NextResponse.json({ error: "no active session to archive" }, { status: 409 });
+  }
+  return NextResponse.json({ session: archived });
+}

--- a/app/api/sessions/[id]/route.ts
+++ b/app/api/sessions/[id]/route.ts
@@ -1,0 +1,51 @@
+/**
+ * PATCH  /api/sessions/:id — reactivate an archived session (Admin). Refused
+ *   if another session is already active (the one-active singleton).
+ * DELETE /api/sessions/:id — permanently delete an archived session and its
+ *   cascade (Admin). The active session must be archived first.
+ */
+import { NextResponse } from "next/server";
+import { sessionManager } from "@/lib/server/SessionManager";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  try {
+    const session = await sessionManager.reactivateSession(id);
+    return NextResponse.json({ session });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "reactivate failed";
+    const status = message.includes("not found") ? 404 : 409;
+    return NextResponse.json({ error: message }, { status });
+  }
+}
+
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  const result = await sessionManager.deleteSession(id);
+  if (result === "not_found") {
+    return NextResponse.json({ error: "session not found" }, { status: 404 });
+  }
+  if (result === "active") {
+    return NextResponse.json(
+      { error: "cannot delete the active session — archive it first" },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/app/api/sessions/route.ts
+++ b/app/api/sessions/route.ts
@@ -1,0 +1,19 @@
+/**
+ * GET /api/sessions — list all sessions (active + archived), newest first.
+ * Admin management view (spec §3.3). The singular /api/session returns only
+ * the active session's full state for every client; this is the admin roster.
+ */
+import { NextResponse } from "next/server";
+import { sessionManager } from "@/lib/server/SessionManager";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+
+  const sessions = await sessionManager.listSessions();
+  return NextResponse.json({ sessions });
+}

--- a/lib/client/useFdSession.ts
+++ b/lib/client/useFdSession.ts
@@ -13,6 +13,7 @@ import type { FullState, OpsLogEntry } from "./types";
 
 const REFETCH_EVENTS = new Set([
   "session_start",
+  "session_archived",
   "train_status_changed",
   "operator_joined",
   "operator_left",
@@ -63,6 +64,7 @@ export function useFdSession(): UseFdSession {
 
     const types = [
       "session_start",
+      "session_archived",
       "train_status_changed",
       "operator_joined",
       "operator_left",

--- a/lib/server/SessionManager.ts
+++ b/lib/server/SessionManager.ts
@@ -10,7 +10,7 @@
  * fan-out layer on top of it. A single instance is reused across HMR via
  * globalThis, mirroring the db client.
  */
-import { and, eq, isNull } from "drizzle-orm";
+import { and, desc, eq, isNull } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import {
   sessions,
@@ -319,6 +319,69 @@ class SessionManager {
     });
 
     await this.broadcast({ type: "emergency_stop" }, session.id);
+  }
+
+  // ---- Session lifecycle (archive / list / reactivate) -------------------
+
+  /** All sessions, newest first (Admin management view). */
+  async listSessions() {
+    return db.select().from(sessions).orderBy(desc(sessions.createdAt));
+  }
+
+  /**
+   * Archive the active session without starting a new one (spec §3.3). Returns
+   * the archived session, or null if there was nothing active to archive.
+   */
+  async archiveActiveSession(byOperator: string | null): Promise<typeof sessions.$inferSelect | null> {
+    const session = await this.getActiveSession();
+    if (!session) return null;
+
+    const [archived] = await db
+      .update(sessions)
+      .set({ status: "archived" })
+      .where(eq(sessions.id, session.id))
+      .returning();
+
+    await this.broadcast(
+      { type: "session_archived", sessionId: session.id },
+      session.id,
+    );
+    void byOperator; // reserved for future audit attribution
+    return archived;
+  }
+
+  /**
+   * Reactivate an archived session, restoring it as the singleton active one.
+   * Refuses if another session is already active (the one-active invariant).
+   */
+  async reactivateSession(id: string): Promise<typeof sessions.$inferSelect> {
+    const active = await this.getActiveSession();
+    if (active && active.id !== id) {
+      throw new Error("another session is already active — archive it first");
+    }
+
+    const [row] = await db
+      .update(sessions)
+      .set({ status: "active" })
+      .where(eq(sessions.id, id))
+      .returning();
+    if (!row) throw new Error("session not found");
+
+    await this.broadcast({ type: "session_start", sessionId: row.id }, row.id);
+    return row;
+  }
+
+  /**
+   * Permanently delete an archived session and its cascade. Refuses to delete
+   * the active session — archive it first.
+   */
+  async deleteSession(id: string): Promise<"deleted" | "not_found" | "active"> {
+    const [row] = await db.select().from(sessions).where(eq(sessions.id, id)).limit(1);
+    if (!row) return "not_found";
+    if (row.status === "active") return "active";
+
+    await db.delete(sessions).where(eq(sessions.id, id));
+    return "deleted";
   }
 }
 

--- a/lib/server/events.ts
+++ b/lib/server/events.ts
@@ -6,6 +6,7 @@ import type { OperatorRole, TrainStatus } from "@/lib/db/schema";
 
 export type FdEvent =
   | { type: "session_start"; sessionId: string }
+  | { type: "session_archived"; sessionId: string }
   | {
       type: "train_status_changed";
       trainId: string;


### PR DESCRIPTION
Fixes #57.

## Problem

Two issues with session management:

1. **Silent no-op** — "Archive & start new" appeared to do nothing. `createSession`
   returned early when the name field was empty, with no feedback.
2. **No easy archiving** — a session could only be archived as a *side effect* of starting
   a new one. There was no way to end an event without immediately starting another, and no
   view of past sessions.

## Changes

**Bug fix**
- Disable the submit button while the name is blank + inline "Enter a session name to
  continue" hint. The click can no longer be a silent no-op.

**Standalone archive**
- `POST /api/session/archive` archives the active session on its own.
- "Archive session" action on the Active session panel.

**Sessions management list**
- `GET /api/sessions` — all sessions (active + archived), newest first (admin).
- `PATCH /api/sessions/:id` — reactivate an archived session; refused when another is
  already active (one-active singleton).
- `DELETE /api/sessions/:id` — permanently delete an archived session (refuses the active
  one).
- "Past sessions" panel listing every session with Reactivate (disabled w/ tooltip while
  another is active) and Delete.
- New `session_archived` SSE event so other open screens drop to "no active session" live.

## Verification

- `npm run lint`, `npx tsc --noEmit`, `npm test` (24) — all clean.
- Exercised the full flow in-browser against the dev server: create → standalone archive
  (active → "no active session", appears as archived) → reactivate → second-reactivate
  blocked by the singleton guard (button disabled, tooltip "Archive the active session
  first") → delete. Submit button stays disabled on an empty name. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
