### PR TITLE
feat: in-app auto-update with version display (#52)

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -133,6 +133,8 @@ jobs:
             dist/*.dmg
             dist/*.AppImage
             dist/*.deb
+            dist/*.yml
+            dist/*.blockmap
 
   # On a release tag, gather every platform's installers and publish a GitHub
   # Release with them attached (auto-generated notes).

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { ensureAdminToken } from "@/lib/client/api";
+import { ensureAdminToken, apiGet } from "@/lib/client/api";
 
 const NAV = [
   { href: "/admin", label: "Dashboard" },
@@ -17,11 +17,15 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const [ready, setReady] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [version, setVersion] = useState<string | null>(null);
 
   useEffect(() => {
     ensureAdminToken()
       .then(() => setReady(true))
       .catch((e) => setError(e instanceof Error ? e.message : "auth failed"));
+    apiGet<{ version?: string }>("/api/server-info")
+      .then((info) => setVersion(info.version ?? null))
+      .catch(() => {});
   }, []);
 
   return (
@@ -30,6 +34,9 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
         <div className="mb-6">
           <div className="text-lg font-bold tracking-tight">Free Dispatcher</div>
           <div className="text-xs text-slate-400">Admin · host console</div>
+          {version && (
+            <div className="mt-0.5 text-xs text-slate-600">v{version}</div>
+          )}
         </div>
         <nav className="space-y-1">
           {NAV.map((item) => {

--- a/electron-builder.config.cjs
+++ b/electron-builder.config.cjs
@@ -14,6 +14,11 @@ const config = {
   appId: "org.freedispatcher.host",
   productName: "Free Dispatcher",
   artifactName: "${name}-${version}-${arch}.${ext}",
+  // Auto-update feed (electron-updater). Public repo, so clients download
+  // updates with no token. CI builds with `--publish never`, which still emits
+  // the updater metadata (latest.yml / *.blockmap) into dist/; the release job
+  // attaches those to the GitHub Release for the updater to read.
+  publish: [{ provider: "github", owner: "willcgage", repo: "free-dispatcher" }],
   directories: { output: "dist", buildResources: "build" },
   files: ["electron/**/*", "package.json"],
   extraResources: [

--- a/electron/control-panel.html
+++ b/electron/control-panel.html
@@ -32,6 +32,17 @@
       }
       .primary { background: #0284c7; }
       .ghost { background: #1e293b; color: #cbd5e1; }
+      .update {
+        width: 100%; max-width: 380px; background: #0b1220;
+        border: 1px solid #1e293b; border-radius: 10px; padding: 10px 12px;
+        font-size: 13px; color: #cbd5e1; display: none;
+        flex-direction: column; gap: 8px; align-items: center;
+      }
+      .update .row { justify-content: center; }
+      .update button { padding: 6px 12px; font-size: 13px; }
+      .progress { display: none; width: 100%; height: 6px; background: #1e293b; border-radius: 999px; overflow: hidden; }
+      .progress > div { height: 100%; width: 0%; background: #0284c7; transition: width 0.2s; }
+      .beta { font-size: 11px; color: #64748b; display: flex; align-items: center; gap: 6px; cursor: pointer; }
       #err { display: none; max-width: 380px; text-align: center; background: #3f1d1d; color: #fecaca; font-size: 12px; padding: 10px 12px; border-radius: 10px; }
       #err pre { white-space: pre-wrap; word-break: break-word; margin: 6px 0 0; color: #fca5a5; font-size: 11px; max-height: 120px; overflow: auto; }
     </style>
@@ -39,7 +50,7 @@
   <body>
     <div style="text-align: center">
       <h1>Free Dispatcher</h1>
-      <div class="sub">Host console</div>
+      <div class="sub">Host console · <span id="version">—</span></div>
     </div>
     <div id="status" class="status down">Starting…</div>
     <div class="qr"><img id="qr" alt="Join QR code" /></div>
@@ -51,6 +62,12 @@
       <button class="ghost" id="copy">Copy address</button>
     </div>
     <div class="hint">Closing this window keeps the host running in the tray — quit from the tray icon to stop the server.</div>
+    <div id="update" class="update">
+      <span id="upd-text">Checking for updates…</span>
+      <div class="progress" id="upd-progress"><div id="upd-bar"></div></div>
+      <div class="row" id="upd-actions"></div>
+      <label class="beta"><input type="checkbox" id="beta" /> Include beta updates</label>
+    </div>
     <div id="err">
       <span id="errmsg"></span>
       <pre id="errdetail"></pre>
@@ -126,6 +143,60 @@
       $("copy").addEventListener("click", () => joinUrl && navigator.clipboard.writeText(joinUrl));
       $("logs").addEventListener("click", () => window.fd.openLogs());
       $("iface").addEventListener("change", () => { selectedHost = $("iface").value; refresh(); });
+
+      // ---- Auto-update -----------------------------------------------------
+      function addUpdBtn(label, fn, cls) {
+        const b = document.createElement("button");
+        b.className = cls || "primary";
+        b.textContent = label;
+        b.addEventListener("click", fn);
+        $("upd-actions").appendChild(b);
+      }
+
+      function renderUpdate(s) {
+        $("upd-actions").innerHTML = "";
+        $("upd-progress").style.display = "none";
+        switch (s.state) {
+          case "checking":
+            $("upd-text").textContent = "Checking for updates…";
+            break;
+          case "current":
+            $("upd-text").textContent = "Up to date";
+            break;
+          case "available":
+            $("upd-text").textContent = "Update available: v" + s.version;
+            addUpdBtn("Download", () => window.fd.updaterDownload());
+            break;
+          case "downloading":
+            $("upd-text").textContent = "Downloading… " + (s.percent || 0) + "%";
+            $("upd-progress").style.display = "block";
+            $("upd-bar").style.width = (s.percent || 0) + "%";
+            break;
+          case "downloaded":
+            $("upd-text").textContent = "Update ready: v" + s.version;
+            addUpdBtn("Restart & install", () => window.fd.updaterInstall());
+            break;
+          case "error":
+            $("upd-text").textContent = "Update check failed";
+            addUpdBtn("Retry", () => window.fd.updaterCheck(), "ghost");
+            break;
+        }
+      }
+
+      async function initUpdater() {
+        const st = await window.fd.updaterState();
+        $("version").textContent = "v" + st.version;
+        if (!st.enabled) return; // dev build: show version, hide update UI
+        $("beta").checked = st.beta;
+        $("update").style.display = "flex";
+        renderUpdate({ state: "checking" });
+      }
+
+      window.fd.onUpdater(renderUpdate);
+      $("beta").addEventListener("change", () =>
+        window.fd.updaterSetBeta($("beta").checked),
+      );
+      initUpdater();
 
       refresh();
       setInterval(refresh, 4000);

--- a/electron/main.js
+++ b/electron/main.js
@@ -14,12 +14,16 @@
  * userData/logs/host.log so failures in a packaged build are diagnosable.
  */
 const { app, BrowserWindow, Menu, Tray, ipcMain, nativeImage, shell, utilityProcess } = require("electron");
+const { autoUpdater } = require("electron-updater");
 const path = require("node:path");
 const fs = require("node:fs");
 const http = require("node:http");
 const crypto = require("node:crypto");
 
 const PORT = Number(process.env.FD_PORT) || 3000;
+// Re-check for updates while the host stays open (long-running event sessions
+// rarely restart). The launch check covers the common case.
+const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
 const HOST_BIND = "0.0.0.0"; // listen on all interfaces so LAN phones can join
 const LOOPBACK = `http://127.0.0.1:${PORT}`;
 const MAX_RESTARTS = 1;
@@ -96,6 +100,7 @@ function startServer() {
       HOSTNAME: HOST_BIND,
       FD_DB_DIR: dataDir,
       FD_TOKEN_SECRET: tokenSecret(),
+      FD_APP_VERSION: app.getVersion(),
       NODE_ENV: "production",
     },
   });
@@ -215,11 +220,108 @@ function createTray() {
   tray.on("click", showWindow);
 }
 
+// ---- Auto-update (electron-updater) -------------------------------------
+
+/** Persisted "include beta releases" preference. Defaults on while pre-1.0 so
+ *  testers receive pre-release builds; toggled from the host window. */
+function betaPrefPath() {
+  return path.join(app.getPath("userData"), "update-include-beta");
+}
+function getBetaPref() {
+  try {
+    return fs.readFileSync(betaPrefPath(), "utf8").trim() !== "0";
+  } catch {
+    return true;
+  }
+}
+function setBetaPref(on) {
+  try {
+    fs.writeFileSync(betaPrefPath(), on ? "1" : "0");
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** Push an updater status object to the control-panel renderer (if open). */
+function sendUpdate(payload) {
+  win?.webContents?.send("updater", payload);
+}
+
+let updaterStarted = false;
+
+function setupAutoUpdater() {
+  // electron-updater needs a packaged app (real version + update feed). In dev
+  // it errors with "No published versions"; skip and report disabled instead.
+  if (!app.isPackaged) {
+    log("updater: disabled in dev (app not packaged)");
+    return;
+  }
+  if (updaterStarted) return;
+  updaterStarted = true;
+
+  autoUpdater.autoDownload = false; // opt-in: the user chooses to download
+  autoUpdater.autoInstallOnAppQuit = true; // apply a downloaded update on quit
+  autoUpdater.allowPrerelease = getBetaPref();
+  autoUpdater.logger = {
+    info: (m) => log(`[updater] ${m}`),
+    warn: (m) => log(`[updater:warn] ${m}`),
+    error: (m) => log(`[updater:err] ${m}`),
+    debug: () => {},
+  };
+
+  autoUpdater.on("checking-for-update", () => sendUpdate({ state: "checking" }));
+  autoUpdater.on("update-available", (info) =>
+    sendUpdate({ state: "available", version: info.version }),
+  );
+  autoUpdater.on("update-not-available", () => sendUpdate({ state: "current" }));
+  autoUpdater.on("download-progress", (p) =>
+    sendUpdate({ state: "downloading", percent: Math.round(p.percent) }),
+  );
+  autoUpdater.on("update-downloaded", (info) =>
+    sendUpdate({ state: "downloaded", version: info.version }),
+  );
+  autoUpdater.on("error", (err) =>
+    sendUpdate({ state: "error", message: String((err && err.message) || err) }),
+  );
+
+  const check = () =>
+    autoUpdater
+      .checkForUpdates()
+      .catch((e) => log(`updater check failed: ${e && e.message}`));
+  check(); // on launch
+  setInterval(check, UPDATE_CHECK_INTERVAL_MS); // on interval
+}
+
 ipcMain.handle("get-info", (_e, host) => fetchServerInfo(host));
 ipcMain.handle("log-path", () => logPath());
 ipcMain.on("open-admin", () => shell.openExternal(`${LOOPBACK}/admin`));
 ipcMain.on("open-url", (_e, url) => shell.openExternal(url));
 ipcMain.on("open-logs", () => shell.showItemInFolder(logPath()));
+
+// Updater IPC. The renderer drives the opt-in flow; results stream back via the
+// "updater" channel wired in setupAutoUpdater.
+ipcMain.handle("updater-state", () => ({
+  version: app.getVersion(),
+  beta: getBetaPref(),
+  enabled: app.isPackaged,
+}));
+ipcMain.handle("updater-check", () =>
+  autoUpdater.checkForUpdates().catch((e) => ({ error: String(e && e.message) })),
+);
+ipcMain.handle("updater-download", () =>
+  autoUpdater.downloadUpdate().catch((e) => ({ error: String(e && e.message) })),
+);
+ipcMain.on("updater-install", () => {
+  quitting = true;
+  autoUpdater.quitAndInstall();
+});
+ipcMain.handle("updater-set-beta", (_e, on) => {
+  setBetaPref(!!on);
+  autoUpdater.allowPrerelease = !!on;
+  return autoUpdater
+    .checkForUpdates()
+    .catch((e) => ({ error: String(e && e.message) }));
+});
 
 app.whenReady().then(async () => {
   log(`app ready — packaged=${app.isPackaged} userData=${app.getPath("userData")}`);
@@ -233,6 +335,7 @@ app.whenReady().then(async () => {
     notifyStatus({ state: "crashed", detail: lastServerError || String(err && err.message) });
   }
   createWindow();
+  setupAutoUpdater();
 });
 
 function shutdown() {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -18,4 +18,19 @@ contextBridge.exposeInMainWorld("fd", {
   logPath: () => ipcRenderer.invoke("log-path"),
   /** Subscribe to server lifecycle status: { state: 'restarting'|'crashed', ... }. */
   onStatus: (cb) => ipcRenderer.on("server-status", (_e, s) => cb(s)),
+
+  // ---- Auto-update -------------------------------------------------------
+  /** { version, beta, enabled } — current version + updater availability. */
+  updaterState: () => ipcRenderer.invoke("updater-state"),
+  /** Trigger a check now (results arrive via onUpdater). */
+  updaterCheck: () => ipcRenderer.invoke("updater-check"),
+  /** Download the available update (progress arrives via onUpdater). */
+  updaterDownload: () => ipcRenderer.invoke("updater-download"),
+  /** Quit and install a downloaded update. */
+  updaterInstall: () => ipcRenderer.send("updater-install"),
+  /** Toggle whether beta (pre-release) updates are offered; re-checks. */
+  updaterSetBeta: (on) => ipcRenderer.invoke("updater-set-beta", on),
+  /** Subscribe to updater status:
+   *  { state: 'checking'|'current'|'available'|'downloading'|'downloaded'|'error', ... }. */
+  onUpdater: (cb) => ipcRenderer.on("updater", (_e, s) => cb(s)),
 });

--- a/lib/server/advertise.ts
+++ b/lib/server/advertise.ts
@@ -82,6 +82,9 @@ export async function serverInfo(scheme: "http" | "https" = "http", host?: strin
     qrDataUrl: await serverQrDataUrl(scheme, ip),
     serverMode: config.serverMode,
     interfaces,
+    // App version: set by the Electron host (FD_APP_VERSION) in a packaged
+    // build; falls back to the npm package version in dev.
+    version: process.env.FD_APP_VERSION ?? process.env.npm_package_version ?? "dev",
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,18 @@
 {
   "name": "free-dispatcher",
-  "version": "2.0.0-dev",
+  "version": "0.8.0-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "free-dispatcher",
-      "version": "2.0.0-dev",
+      "version": "0.8.0-dev",
+      "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
+        "electron-updater": "^6.8.9",
         "next": "16.2.9",
         "qrcode": "^1.5.4",
         "react": "19.2.4",
@@ -93,7 +95,6 @@
       "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.7",
         "@babel/generator": "^7.29.7",
@@ -324,8 +325,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@electric-sql/pglite/-/pglite-0.5.2.tgz",
       "integrity": "sha512-y6ySdFE7FQB7BkVaSNaPINgY7mXCyvi+3GQB5ySX9WGwgrdh31WXMP5RM40oAyYff47lIr7xdcW8UbCW5NHDmw==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/@electron-internal/extract-zip": {
       "version": "1.0.3",
@@ -574,6 +574,7 @@
       "dev": true,
       "license": "BSD-2-Clause",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "cross-dirname": "^0.1.0",
         "debug": "^4.3.4",
@@ -595,6 +596,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -602,6 +604,28 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -3482,7 +3506,6 @@
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3552,7 +3575,6 @@
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -4366,7 +4388,6 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4691,7 +4712,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -5112,7 +5132,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -5164,7 +5183,6 @@
       "version": "9.7.0",
       "resolved": "https://registry.npmjs.org/builder-util-runtime/-/builder-util-runtime-9.7.0.tgz",
       "integrity": "sha512-g/kR520giAFYkSXTzcmF3kqQq7wi8F6N6SzeDgZrqTBN+VHdmgWOyTdD1yD7AATDId/yXLvuP34CxW46/BwCdw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "debug": "^4.3.4",
@@ -5497,7 +5515,8 @@
       "integrity": "sha512-+R08/oI0nl3vfPcqftZRpytksBXDzOUveBq/NBVx0sUp1axwzPQrKinNx5yd5sxPu8j1wIy8AfnVQ+5eFdha6Q==",
       "dev": true,
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "peer": true
     },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
@@ -5586,7 +5605,6 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -5752,7 +5770,6 @@
       "integrity": "sha512-O3zJUFUYHJKgzPqioHxfxzBzlSC1eXCSr79gMSBKBP5AgjjpmrydMsMLotEg9fAJF36vdUncb+4ndRNxoPdlSQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "app-builder-lib": "26.15.3",
         "builder-util": "26.15.3",
@@ -6642,6 +6659,34 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/electron-updater": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/electron-updater/-/electron-updater-6.8.9.tgz",
+      "integrity": "sha512-ZhVxM9iGONUpZGI1FxdMRgJjUFXi7AYGVa5PwKlO1tV1/4zDxQmfKpXOHVztKrd6L9rLcFjERvi1Mf2vxyTkig==",
+      "license": "MIT",
+      "dependencies": {
+        "builder-util-runtime": "9.7.0",
+        "fs-extra": "^10.1.0",
+        "js-yaml": "^4.1.0",
+        "lazy-val": "^1.0.5",
+        "lodash.escaperegexp": "^4.1.2",
+        "lodash.isequal": "^4.5.0",
+        "semver": "~7.7.3",
+        "tiny-typed-emitter": "^2.1.0"
+      }
+    },
+    "node_modules/electron-updater/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/electron-winstaller": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/electron-winstaller/-/electron-winstaller-5.4.0.tgz",
@@ -6649,6 +6694,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@electron/asar": "^3.2.1",
         "debug": "^4.1.1",
@@ -6669,6 +6715,7 @@
       "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "graceful-fs": "^4.1.2",
         "jsonfile": "^4.0.0",
@@ -6684,6 +6731,7 @@
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -6694,6 +6742,7 @@
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 4.0.0"
       }
@@ -7029,7 +7078,6 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -7215,7 +7263,6 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7699,7 +7746,6 @@
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
       "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -8039,7 +8085,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/has-bigints": {
@@ -8907,7 +8952,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -8985,7 +9029,6 @@
       "version": "6.2.1",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
       "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -9044,7 +9087,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/lazy-val/-/lazy-val-1.0.5.tgz",
       "integrity": "sha512-0/BnGCCfyUMkBpeDgWihanIAF9JmZhHBgUhEqzvf+adhNGLoP6TaiI5oF8oyb3I45P+PcnrqihSf01M0l0G5+Q==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/levn": {
@@ -9345,6 +9387,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lodash.escaperegexp": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/lodash.escaperegexp/-/lodash.escaperegexp-4.1.2.tgz",
+      "integrity": "sha512-TM9YBvyC84ZxE3rgfefxUWiQKLilstD6k7PTGt6wfbtXF8ixIJLOL3VYyV/z+ZiPLsVxAsKAFVwWlWeb2Y8Yyw==",
+      "license": "MIT"
+    },
+    "node_modules/lodash.isequal": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.isequal/-/lodash.isequal-4.5.0.tgz",
+      "integrity": "sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==",
+      "deprecated": "This package is deprecated. Use require('node:util').isDeepStrictEqual instead.",
+      "license": "MIT"
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -9589,6 +9644,7 @@
       "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "minimist": "^1.2.6"
       },
@@ -9600,7 +9656,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/multicast-dns": {
@@ -10359,6 +10414,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "dependencies": {
         "commander": "^9.4.0"
       },
@@ -10376,6 +10432,7 @@
       "dev": true,
       "license": "MIT",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": "^12.20.0 || >=14"
       }
@@ -10552,7 +10609,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10562,7 +10618,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10792,6 +10847,7 @@
       "deprecated": "Rimraf versions prior to v4 are no longer supported",
       "dev": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "glob": "^7.1.3"
       },
@@ -10963,7 +11019,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -11697,6 +11752,7 @@
       "integrity": "sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mkdirp": "^0.5.1",
         "rimraf": "~2.6.2"
@@ -11851,6 +11907,12 @@
         "semver": "bin/semver"
       }
     },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA==",
+      "license": "MIT"
+    },
     "node_modules/tinybench": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
@@ -11906,7 +11968,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12184,7 +12245,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12258,7 +12318,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
@@ -12392,7 +12451,6 @@
       "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -13008,7 +13066,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -13022,7 +13079,6 @@
       "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/chai": "^5.2.2",
         "@vitest/expect": "3.2.6",
@@ -13452,7 +13508,6 @@
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@electric-sql/pglite": "^0.5.2",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
+    "electron-updater": "^6.8.9",
     "next": "16.2.9",
     "qrcode": "^1.5.4",
     "react": "19.2.4",


### PR DESCRIPTION
Implements #52.

In-app auto-update for the host app, with the current version shown in the UI and a
user-controlled (opt-in) download/install flow.

## What you get

- **Version display** — under the host-window title, and in the Admin console sidebar.
- **Check on launch + on an interval** — the host checks for a newer release when it opens
  and re-checks every 6h while it stays open (event sessions rarely restart).
- **Opt-in download + install** — when an update is found, the host shows it; the user
  chooses Download (with a progress bar), then Restart & install. Nothing happens silently
  mid-session.
- **Beta channel toggle** — "Include beta updates" (on by default while we're pre-1.0), so
  testers get pre-releases and that can be turned off later.

## How it works

- `electron/main.js` — `autoUpdater` with `autoDownload=false`, launch + interval checks,
  event → renderer streaming, IPC for check/download/install, persisted beta preference.
  Disabled in dev (no packaged feed).
- `electron/control-panel.html` + `preload.js` — the version line and update strip.
- `electron-builder.config.cjs` — GitHub publish provider for the feed.
- `.github/workflows/package.yml` — attaches updater metadata (`latest*.yml`, `*.blockmap`)
  to releases; previously only installers were uploaded.
- `lib/server/advertise.ts` / `AdminShell.tsx` — version surfaced via `/api/server-info`.

## Verification

- `npm run lint`, `npx tsc --noEmit`, `npm run build`, `npm test` (24) — all clean.
- `node --check` on the Electron main + preload.
- Drove the control-panel update strip through **every** state in-browser with a mocked
  preload: version shown, available→Download, downloading→progress bar (42%),
  downloaded→Restart & install, error→Retry, beta toggle — and confirmed the IPC calls fire
  (`download`, `install`, `beta:false`).

## Not yet verified here (needs published releases)

The live update loop — an installed build seeing a newer one and applying it — can only be
tested across two real releases. Plan: cut `v0.8.0-beta.1`, install it, bump to
`v0.8.0-beta.2`, confirm the auto-update on **Windows** (unsigned this round, so first
install shows a SmartScreen warning; macOS auto-update needs signing/notarization, so mac
is build-only for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
