### PR TITLE
feat: physical Emergency Stop via pluggable command-station adapters (#55)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -5,7 +5,8 @@
       "name": "free-dispatcher",
       "runtimeExecutable": "npm",
       "runtimeArgs": ["run", "dev"],
-      "port": 3000
+      "port": 3000,
+      "autoPort": true
     }
   ]
 }

--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,9 +1,19 @@
 "use client";
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useFdSession } from "@/lib/client/useFdSession";
-import { apiSend } from "@/lib/client/api";
+import { apiGet, apiSend } from "@/lib/client/api";
 import { Panel, StatusBadge, Dot } from "@/components/admin/ui";
+
+interface CommandStationStatus {
+  type: string;
+  label: string;
+  connected: boolean;
+  capabilities: { emergencyStop: boolean; emergencyOff: boolean };
+  target: string | null;
+}
+
+type EmergencyMode = "stop" | "off" | "on";
 
 function elapsed(since: string): string {
   const ms = Date.now() - new Date(since).getTime();
@@ -15,17 +25,49 @@ function elapsed(since: string): string {
 export default function AdminDashboard() {
   const { state, opsLog, connected, refresh } = useFdSession();
   const [busy, setBusy] = useState(false);
+  const [cmd, setCmd] = useState<CommandStationStatus | null>(null);
 
   const session = state?.session ?? null;
   const trains = state?.trains ?? [];
   const operators = state?.operators ?? [];
 
-  async function emergencyStop() {
-    if (!confirm("Emergency Stop All — revoke authority for every train?")) return;
+  const loadCmd = useCallback(async () => {
+    try {
+      setCmd(await apiGet<CommandStationStatus>("/api/command-station"));
+    } catch {
+      /* status is best-effort */
+    }
+  }, []);
+
+  useEffect(() => {
+    // loadCmd setStates after an await, not synchronously here.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void loadCmd();
+  }, [loadCmd]);
+
+  async function emergencyStop(mode: EmergencyMode) {
+    const prompts: Record<EmergencyMode, string> = {
+      stop: "Emergency Stop — revoke authority and halt trains?",
+      off: "Emergency Off — revoke authority and CUT TRACK POWER?",
+      on: "Restore track power?",
+    };
+    if (!confirm(prompts[mode])) return;
     setBusy(true);
     try {
-      await apiSend("POST", "/api/admin/emergency-stop");
-      await refresh();
+      const res = await apiSend<{ physical?: { applied: boolean; detail?: string; reason?: string } }>(
+        "POST",
+        "/api/admin/emergency-stop",
+        { mode },
+      );
+      const p = res.physical;
+      if (p) {
+        alert(
+          p.applied
+            ? `Done — ${p.detail}.`
+            : `Authority ${mode === "on" ? "unchanged" : "revoked"}. No physical action: ${p.reason}.`,
+        );
+      }
+      await Promise.all([refresh(), loadCmd()]);
     } catch (e) {
       alert(e instanceof Error ? e.message : "E-stop failed");
     } finally {
@@ -149,13 +191,65 @@ export default function AdminDashboard() {
         {/* Quick actions + devices */}
         <div className="space-y-5">
           <Panel title="Quick actions">
-            <button
-              disabled={busy}
-              onClick={emergencyStop}
-              className="w-full rounded-md bg-red-600 px-4 py-2.5 text-sm font-bold text-white hover:bg-red-500 disabled:opacity-50"
-            >
-              ⏹ Emergency Stop All
-            </button>
+            <div className="space-y-2">
+              <button
+                disabled={busy}
+                onClick={() => emergencyStop("stop")}
+                title={
+                  cmd?.capabilities.emergencyStop
+                    ? "Halt all trains, keep track power"
+                    : "Revokes authority; this connection can't halt locos while keeping power"
+                }
+                className="w-full rounded-md bg-red-600 px-4 py-2.5 text-sm font-bold text-white hover:bg-red-500 disabled:opacity-50"
+              >
+                ⏹ Emergency Stop
+              </button>
+              <button
+                disabled={busy}
+                onClick={() => emergencyStop("off")}
+                title={
+                  cmd?.capabilities.emergencyOff
+                    ? "Revoke authority and cut track power"
+                    : "Revokes authority; no command station connected to cut power"
+                }
+                className="w-full rounded-md border border-red-700/60 px-4 py-2 text-sm font-semibold text-red-300 hover:bg-red-900/30 disabled:opacity-50"
+              >
+                ⚡ Emergency Off (cut power)
+              </button>
+              {cmd?.connected && cmd.capabilities.emergencyOff && (
+                <button
+                  disabled={busy}
+                  onClick={() => emergencyStop("on")}
+                  className="w-full rounded-md border border-slate-700 px-4 py-1.5 text-xs font-medium text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+                >
+                  Restore power
+                </button>
+              )}
+              <p className="pt-1 text-xs text-slate-500">
+                {cmd ? (
+                  <>
+                    Command station:{" "}
+                    <span className="text-slate-300">{cmd.label}</span>
+                    {cmd.type !== "null" && (
+                      <>
+                        {" "}
+                        ·{" "}
+                        <span
+                          className={
+                            cmd.connected ? "text-emerald-400" : "text-amber-400"
+                          }
+                        >
+                          {cmd.connected ? "connected" : "not connected"}
+                        </span>
+                        {cmd.target ? ` (${cmd.target})` : ""}
+                      </>
+                    )}
+                  </>
+                ) : (
+                  "Checking command station…"
+                )}
+              </p>
+            </div>
           </Panel>
 
           <Panel title={`Connected devices (${operators.length})`}>

--- a/app/api/admin/emergency-stop/route.ts
+++ b/app/api/admin/emergency-stop/route.ts
@@ -1,9 +1,17 @@
 /**
- * POST /api/admin/emergency-stop — Admin/Dispatcher triggers Emergency Stop All:
- * revokes all authority and broadcasts emergency_stop to every client (spec §3.2, §5.2).
+ * POST /api/admin/emergency-stop — Admin/Dispatcher emergency action (spec §3.2,
+ * §5.2). Always revokes all dispatch authority and broadcasts emergency_stop;
+ * when a command station is connected it ALSO acts on the physical layout via
+ * the active adapter (#55).
+ *
+ * Body: { mode?: "stop" | "off" | "on" }
+ *   - "stop" (default): halt locos keeping power (if the station supports it)
+ *   - "off":            cut track power
+ *   - "on":             restore track power (no authority change)
  */
 import { NextResponse } from "next/server";
 import { sessionManager } from "@/lib/server/SessionManager";
+import { commandStation } from "@/lib/commandstation/CommandStationService";
 import { requireRole } from "@/lib/server/guard";
 
 export const dynamic = "force-dynamic";
@@ -13,11 +21,29 @@ export async function POST(req: Request) {
   const guard = requireRole(req, ["admin", "dispatcher"]);
   if (!guard.ok) return guard.response;
 
+  const mode = await req
+    .json()
+    .then((b: { mode?: string }) => b?.mode ?? "stop")
+    .catch(() => "stop");
+
+  // "on" only restores power — no authority change.
+  if (mode === "on") {
+    return NextResponse.json({ ok: true, physical: commandStation.powerOn() });
+  }
+
+  // "stop" / "off": revoke authority (the always-on baseline), then act
+  // physically through the active adapter.
   try {
     await sessionManager.emergencyStop(guard.claims.operatorId);
-    return NextResponse.json({ ok: true });
   } catch (err) {
     const message = err instanceof Error ? err.message : "e-stop failed";
     return NextResponse.json({ error: message }, { status: 409 });
   }
+
+  const physical =
+    mode === "off"
+      ? commandStation.emergencyOff()
+      : commandStation.emergencyStop();
+
+  return NextResponse.json({ ok: true, authority: "revoked", physical });
 }

--- a/app/api/command-station/route.ts
+++ b/app/api/command-station/route.ts
@@ -1,0 +1,13 @@
+/**
+ * GET /api/command-station — current command-station adapter + capabilities,
+ * so the dashboard can show what Emergency Stop / Off will physically do (#55).
+ */
+import { NextResponse } from "next/server";
+import { commandStation } from "@/lib/commandstation/CommandStationService";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET() {
+  return NextResponse.json(commandStation.status());
+}

--- a/lib/commandstation/CommandStationService.ts
+++ b/lib/commandstation/CommandStationService.ts
@@ -1,0 +1,52 @@
+/**
+ * CommandStationService — resolves the active command-station adapter and
+ * exposes the physical emergency actions to the API layer.
+ *
+ * Phase 1 selects the adapter from the running WiThrottle connection: when the
+ * WiThrottle monitor is enabled we use the JMRI adapter (reflecting live
+ * connection state), otherwise the authority-only NullAdapter. Future phases
+ * add an explicit `commandStation` setting (type + transport) and more adapters
+ * (LCC/OpenLCB, DCC-EX native, Z21, …) without touching callers.
+ */
+import { wiThrottleService } from "@/lib/withrottle/WiThrottleService";
+import { NullAdapter } from "./NullAdapter";
+import { JmriAdapter } from "./JmriAdapter";
+import type {
+  ActionResult,
+  CommandStationAdapter,
+  CommandStationStatus,
+} from "./types";
+
+class CommandStationService {
+  private nullAdapter = new NullAdapter();
+  private jmriAdapter = new JmriAdapter();
+
+  /** The adapter in effect right now. */
+  get active(): CommandStationAdapter {
+    return wiThrottleService.enabled ? this.jmriAdapter : this.nullAdapter;
+  }
+
+  status(): CommandStationStatus {
+    return this.active.status();
+  }
+  emergencyStop(): ActionResult {
+    return this.active.emergencyStop();
+  }
+  emergencyOff(): ActionResult {
+    return this.active.emergencyOff();
+  }
+  powerOn(): ActionResult {
+    return this.active.powerOn();
+  }
+}
+
+const globalForCs = globalThis as unknown as {
+  __fdCommandStation?: CommandStationService;
+};
+
+export const commandStation =
+  globalForCs.__fdCommandStation ?? new CommandStationService();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForCs.__fdCommandStation = commandStation;
+}

--- a/lib/commandstation/JmriAdapter.ts
+++ b/lib/commandstation/JmriAdapter.ts
@@ -1,0 +1,60 @@
+/**
+ * JmriAdapter — drives a JMRI (or DCC-EX) server over the WiThrottle protocol,
+ * reusing the existing WiThrottle client connection (lib/withrottle).
+ *
+ * WiThrottle gives a reliable global track-power off/on (`PPA0`/`PPA1`), so
+ * emergencyOff() is fully supported. It has NO single "stop all locos but keep
+ * power" command — that's a per-throttle action and our client owns no
+ * throttles — so emergencyStop() is advertised as unsupported here; the
+ * keep-power global arrives with the LCC adapter (Phase 2). The capability flag
+ * lets the UI reflect this honestly per active connection.
+ */
+import { wiThrottleService } from "@/lib/withrottle/WiThrottleService";
+import type {
+  ActionResult,
+  CommandStationAdapter,
+  CommandStationStatus,
+} from "./types";
+
+export class JmriAdapter implements CommandStationAdapter {
+  readonly type = "jmri-withrottle";
+  readonly label = "JMRI / WiThrottle";
+  readonly capabilities = { emergencyStop: false, emergencyOff: true };
+
+  status(): CommandStationStatus {
+    const t = wiThrottleService.target;
+    return {
+      type: this.type,
+      label: this.label,
+      connected: wiThrottleService.connected,
+      capabilities: this.capabilities,
+      target: t ? `${t.host}:${t.port}` : null,
+    };
+  }
+
+  emergencyStop(): ActionResult {
+    return {
+      applied: false,
+      reason:
+        "WiThrottle has no keep-power stop — use Emergency Off, or connect an LCC bus",
+    };
+  }
+
+  emergencyOff(): ActionResult {
+    if (!wiThrottleService.connected) {
+      return { applied: false, reason: "WiThrottle server not connected" };
+    }
+    return wiThrottleService.powerOff()
+      ? { applied: true, detail: "track power cut (PPA0)" }
+      : { applied: false, reason: "command send failed" };
+  }
+
+  powerOn(): ActionResult {
+    if (!wiThrottleService.connected) {
+      return { applied: false, reason: "WiThrottle server not connected" };
+    }
+    return wiThrottleService.powerOn()
+      ? { applied: true, detail: "track power restored (PPA1)" }
+      : { applied: false, reason: "command send failed" };
+  }
+}

--- a/lib/commandstation/NullAdapter.ts
+++ b/lib/commandstation/NullAdapter.ts
@@ -1,0 +1,41 @@
+/**
+ * NullAdapter — the always-available fallback when no command station is
+ * connected. Emergency Stop still revokes authority (handled by the route);
+ * this adapter simply reports that nothing physical happened.
+ */
+import type {
+  ActionResult,
+  CommandStationAdapter,
+  CommandStationStatus,
+} from "./types";
+
+const UNAVAILABLE: ActionResult = {
+  applied: false,
+  reason: "no command station connected — authority revoked only",
+};
+
+export class NullAdapter implements CommandStationAdapter {
+  readonly type = "null";
+  readonly label = "Authority-only (no command station)";
+  readonly capabilities = { emergencyStop: false, emergencyOff: false };
+
+  status(): CommandStationStatus {
+    return {
+      type: this.type,
+      label: this.label,
+      connected: false,
+      capabilities: this.capabilities,
+      target: null,
+    };
+  }
+
+  emergencyStop(): ActionResult {
+    return UNAVAILABLE;
+  }
+  emergencyOff(): ActionResult {
+    return UNAVAILABLE;
+  }
+  powerOn(): ActionResult {
+    return { applied: false, reason: "no command station connected" };
+  }
+}

--- a/lib/commandstation/__tests__/adapters.test.ts
+++ b/lib/commandstation/__tests__/adapters.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mutable mock of the WiThrottle service the JMRI adapter delegates to.
+// vi.hoisted so it exists before the hoisted vi.mock factory runs.
+const wt = vi.hoisted(() => ({
+  connected: false,
+  enabled: false,
+  target: null as { host: string; port: number } | null,
+  powerOff: vi.fn((): boolean => true),
+  powerOn: vi.fn((): boolean => true),
+}));
+vi.mock("@/lib/withrottle/WiThrottleService", () => ({
+  wiThrottleService: wt,
+}));
+
+import { NullAdapter } from "../NullAdapter";
+import { JmriAdapter } from "../JmriAdapter";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  wt.connected = false;
+  wt.enabled = false;
+  wt.target = null;
+  wt.powerOff.mockReturnValue(true);
+  wt.powerOn.mockReturnValue(true);
+});
+
+describe("NullAdapter", () => {
+  const a = new NullAdapter();
+
+  it("advertises no physical capabilities", () => {
+    expect(a.capabilities).toEqual({ emergencyStop: false, emergencyOff: false });
+    expect(a.status().connected).toBe(false);
+  });
+
+  it("reports nothing physical happened", () => {
+    expect(a.emergencyStop().applied).toBe(false);
+    expect(a.emergencyOff().applied).toBe(false);
+    expect(a.powerOn().applied).toBe(false);
+  });
+});
+
+describe("JmriAdapter", () => {
+  const a = new JmriAdapter();
+
+  it("supports power-off but not keep-power stop", () => {
+    expect(a.capabilities).toEqual({ emergencyStop: false, emergencyOff: true });
+  });
+
+  it("status reflects live connection + target", () => {
+    wt.connected = true;
+    wt.target = { host: "10.0.0.5", port: 12090 };
+    const s = a.status();
+    expect(s.connected).toBe(true);
+    expect(s.target).toBe("10.0.0.5:12090");
+  });
+
+  it("emergencyOff sends PPA0 when connected", () => {
+    wt.connected = true;
+    const r = a.emergencyOff();
+    expect(wt.powerOff).toHaveBeenCalledOnce();
+    expect(r).toEqual({ applied: true, detail: expect.stringContaining("PPA0") });
+  });
+
+  it("emergencyOff is a no-op (not applied) when disconnected", () => {
+    wt.connected = false;
+    const r = a.emergencyOff();
+    expect(wt.powerOff).not.toHaveBeenCalled();
+    expect(r.applied).toBe(false);
+  });
+
+  it("emergencyOff reports failure when the send fails", () => {
+    wt.connected = true;
+    wt.powerOff.mockReturnValue(false);
+    expect(a.emergencyOff().applied).toBe(false);
+  });
+
+  it("emergencyStop is unsupported on WiThrottle", () => {
+    wt.connected = true;
+    const r = a.emergencyStop();
+    expect(r.applied).toBe(false);
+    expect(wt.powerOff).not.toHaveBeenCalled();
+  });
+
+  it("powerOn sends PPA1 when connected", () => {
+    wt.connected = true;
+    const r = a.powerOn();
+    expect(wt.powerOn).toHaveBeenCalledOnce();
+    expect(r).toEqual({ applied: true, detail: expect.stringContaining("PPA1") });
+  });
+});

--- a/lib/commandstation/types.ts
+++ b/lib/commandstation/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Command-station adapter contract (#55).
+ *
+ * Free Dispatcher's Emergency Stop always revokes dispatch authority; when a
+ * command station is connected it ALSO acts on the physical layout through one
+ * of these adapters. New control systems (JMRI, LCC/OpenLCB, DCC-EX native,
+ * Z21, …) are added as drop-in implementations — nothing else changes.
+ *
+ * Two semantics, because layouts/operators want both:
+ *  - emergencyStop(): halt every locomotive, KEEP track power on (lights/sound
+ *    stay; easy recovery). Not all systems can do this globally.
+ *  - emergencyOff():  cut track power entirely (the absolute kill switch).
+ */
+
+export interface CommandStationCapabilities {
+  /** Can stop all locomotives while keeping track power on. */
+  emergencyStop: boolean;
+  /** Can cut (and restore) track power. */
+  emergencyOff: boolean;
+}
+
+export interface CommandStationStatus {
+  /** Stable id, e.g. "null" | "jmri-withrottle". */
+  type: string;
+  /** Human label for the UI, e.g. "JMRI / WiThrottle". */
+  label: string;
+  /** True when the adapter has a live connection able to act physically. */
+  connected: boolean;
+  capabilities: CommandStationCapabilities;
+  /** Connection detail (host:port), when applicable. */
+  target: string | null;
+}
+
+/** Outcome of a physical action — `applied` distinguishes "did it" from "couldn't". */
+export type ActionResult =
+  | { applied: true; detail: string }
+  | { applied: false; reason: string };
+
+export interface CommandStationAdapter {
+  readonly type: string;
+  readonly label: string;
+  readonly capabilities: CommandStationCapabilities;
+  status(): CommandStationStatus;
+  /** Stop all locomotives, keep track power on. */
+  emergencyStop(): ActionResult;
+  /** Cut track power. */
+  emergencyOff(): ActionResult;
+  /** Restore track power after an emergency off. */
+  powerOn(): ActionResult;
+}

--- a/lib/withrottle/WiThrottleMonitor.ts
+++ b/lib/withrottle/WiThrottleMonitor.ts
@@ -69,6 +69,16 @@ export class WiThrottleMonitor extends EventEmitter {
     this.setState("disconnected");
   }
 
+  /**
+   * Send a raw WiThrottle command line over the live connection (a newline is
+   * appended). Returns false if not currently connected. Used by the JMRI
+   * command-station adapter to drive track power (`PPA0`/`PPA1`).
+   */
+  send(command: string): boolean {
+    if (!this.socket || this._state !== "connected") return false;
+    return this.socket.write(`${command}\n`);
+  }
+
   private connect(): void {
     if (this.closed) return;
     this.setState("connecting");

--- a/lib/withrottle/WiThrottleService.ts
+++ b/lib/withrottle/WiThrottleService.ts
@@ -68,6 +68,24 @@ class WiThrottleService {
     this.current = null;
   }
 
+  get connected(): boolean {
+    return this._state === "connected";
+  }
+
+  get target(): { host: string; port: number } | null {
+    return this.current;
+  }
+
+  /** Cut track power on the connected WiThrottle server (`PPA0`). */
+  powerOff(): boolean {
+    return this.monitor?.send("PPA0") ?? false;
+  }
+
+  /** Restore track power (`PPA1`). */
+  powerOn(): boolean {
+    return this.monitor?.send("PPA1") ?? false;
+  }
+
   /** Broadcast a train_status_changed if the address maps to a roster train. */
   private async notifyTrain(address: number): Promise<void> {
     const session = await sessionManager.getActiveSession();


### PR DESCRIPTION
Phase 1 of #55 — make **Emergency Stop physically stop trains**, not just revoke dispatch authority, behind a pluggable adapter layer so new control systems drop in cleanly.

## What this does

Emergency Stop now **always revokes authority** (the safety baseline that works with no hardware) **and** acts on the physical layout through the active **command-station adapter**.

Two semantics, user-selectable on the dashboard:
- **Emergency Stop** — halt all locos, keep track power on.
- **Emergency Off** — cut track power entirely.

## Architecture (the pluggable layer)

`lib/commandstation/` — a `CommandStationAdapter` interface (`emergencyStop` / `emergencyOff` / `powerOn` / `status` + capability flags) with:
- **NullAdapter** — authority-only fallback (always available).
- **JmriAdapter** — drives JMRI/DCC-EX over the **existing WiThrottle connection** (`PPA0`/`PPA1`).
- **CommandStationService** — selects the active adapter.

Adding LCC/OpenLCB, DCC-EX native, Z21, … later = one new adapter, nothing else changes.

## Honest capability handling

WiThrottle has a reliable global power-off, but **no** single "stop all locos while keeping power" (that's per-throttle, and our client owns no throttles). So `JmriAdapter` advertises `emergencyStop` as **unsupported**, and the UI says so per connection. The keep-power global is exactly what the **LCC adapter (Phase 2)** delivers — which is why JMRI + LCC together cover both semantics.

## API / UI

- `POST /api/admin/emergency-stop` → `{ mode: "stop" | "off" | "on" }`; revokes authority (stop/off) then calls the adapter. Returns what physically happened.
- `GET /api/command-station` → active adapter + capabilities.
- Dashboard: Emergency Stop + Emergency Off (+ Restore power when connected), a status line showing the active command station, and a result toast stating the physical outcome.

## Verification

- 33 tests pass (9 new adapter tests: capability flags, `PPA0`/`PPA1` generation, connected/disconnected paths); lint + typecheck + build clean.
- In-browser (NullAdapter path): Emergency Stop revoked authority (ops log shows `emergency_stop`) and reported "No physical action — no command station connected"; tooltips + status line accurate. The JMRI/WiThrottle send path is unit-tested (no live WiThrottle server available here).

Next: **Phase 2** = `LccAdapter` (OpenLCB node over GridConnect TCP producing the global Emergency Stop / Emergency Off events), after a quick spike to pin the exact event IDs against NMRA S-9.7.0.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
