### PR TITLE
feat: ship release notes with the app and show them in-app

### DIFF
--- a/app/admin/release-notes/page.tsx
+++ b/app/admin/release-notes/page.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { apiGet } from "@/lib/client/api";
+import type { ChangelogEntry } from "@/lib/changelog/parse";
+
+interface ChangelogResponse {
+  version: string;
+  entries: ChangelogEntry[];
+}
+
+/** True when the running app version belongs to this changelog entry
+ *  (exact, or a pre-release of it: 0.8.0-beta.1 / 0.8.0-dev → 0.8.0). */
+function isCurrent(entryVersion: string, appVersion: string): boolean {
+  return appVersion === entryVersion || appVersion.startsWith(`${entryVersion}-`);
+}
+
+export default function ReleaseNotes() {
+  const [data, setData] = useState<ChangelogResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    apiGet<ChangelogResponse>("/api/changelog")
+      .then(setData)
+      .catch((e) => setError(e instanceof Error ? e.message : "failed to load"));
+  }, []);
+
+  return (
+    <div className="max-w-2xl space-y-5">
+      <div className="flex items-baseline justify-between">
+        <h1 className="text-2xl font-bold">Release notes</h1>
+        {data && (
+          <span className="text-sm text-slate-400">
+            You’re running <span className="text-slate-200">v{data.version}</span>
+          </span>
+        )}
+      </div>
+
+      {error ? (
+        <p className="text-sm text-red-300">Couldn’t load release notes: {error}</p>
+      ) : !data ? (
+        <p className="text-sm text-slate-400">Loading…</p>
+      ) : data.entries.length === 0 ? (
+        <p className="text-sm text-slate-400">No release notes yet.</p>
+      ) : (
+        <ol className="space-y-4">
+          {data.entries.map((e) => {
+            const current = isCurrent(e.version, data.version);
+            return (
+              <li
+                key={e.version + (e.date ?? "")}
+                className={`rounded-lg border p-4 ${
+                  current
+                    ? "border-sky-700/60 bg-sky-950/20"
+                    : "border-slate-800 bg-slate-900/40"
+                }`}
+              >
+                <div className="mb-2 flex items-center gap-2">
+                  <h2 className="text-lg font-semibold text-slate-100">
+                    {e.url ? (
+                      <a
+                        href={e.url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="hover:underline"
+                      >
+                        {e.version}
+                      </a>
+                    ) : (
+                      e.version
+                    )}
+                  </h2>
+                  {current && (
+                    <span className="rounded bg-sky-600/20 px-1.5 py-0.5 text-xs font-medium text-sky-300">
+                      current
+                    </span>
+                  )}
+                  {e.date && (
+                    <span className="ml-auto text-xs text-slate-500">{e.date}</span>
+                  )}
+                </div>
+
+                {e.sections.map((s, i) => (
+                  <div key={i} className="mt-2">
+                    {s.heading && (
+                      <div className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                        {s.heading}
+                      </div>
+                    )}
+                    <ul className="mt-1 list-disc space-y-1 pl-5 text-sm text-slate-300">
+                      {s.items.map((it, j) => (
+                        <li key={j}>{it}</li>
+                      ))}
+                    </ul>
+                  </div>
+                ))}
+              </li>
+            );
+          })}
+        </ol>
+      )}
+    </div>
+  );
+}

--- a/app/api/changelog/route.ts
+++ b/app/api/changelog/route.ts
@@ -9,7 +9,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { NextResponse } from "next/server";
-import { parseChangelog, isReleased } from "@/lib/changelog/parse";
+import { parseChangelog, isReleased, compareVersions } from "@/lib/changelog/parse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -20,8 +20,16 @@ const VERSION =
 export async function GET() {
   try {
     const md = await readFile(join(process.cwd(), "CHANGELOG.md"), "utf8");
-    // Released versions only — the in-progress "Unreleased" section is internal.
-    const entries = parseChangelog(md).filter((e) => isReleased(e.version));
+    // Released versions only (drop the in-progress "Unreleased" section),
+    // bounded by the running version: the currently-installed release down to
+    // the first — never anything newer than what's installed. When the version
+    // isn't a real release (e.g. a "-dev" build), show the full released history.
+    const ceiling = /^\d+\.\d+\.\d+$/.test(VERSION) ? VERSION : null;
+    const entries = parseChangelog(md).filter(
+      (e) =>
+        isReleased(e.version) &&
+        (!ceiling || compareVersions(e.version, ceiling) <= 0),
+    );
     return NextResponse.json({ version: VERSION, entries });
   } catch {
     return NextResponse.json({ version: VERSION, entries: [] });

--- a/app/api/changelog/route.ts
+++ b/app/api/changelog/route.ts
@@ -1,0 +1,27 @@
+/**
+ * GET /api/changelog — parsed release notes for the in-app Release Notes page.
+ *
+ * Reads the bundled CHANGELOG.md from the server's working directory (the repo
+ * root in dev; the standalone dir in a packaged build, where prepare-standalone
+ * copies it). Fully offline — no network. Returns the current app version too
+ * so the UI can highlight "what you're running".
+ */
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { NextResponse } from "next/server";
+import { parseChangelog } from "@/lib/changelog/parse";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const VERSION =
+  process.env.FD_APP_VERSION ?? process.env.npm_package_version ?? "dev";
+
+export async function GET() {
+  try {
+    const md = await readFile(join(process.cwd(), "CHANGELOG.md"), "utf8");
+    return NextResponse.json({ version: VERSION, entries: parseChangelog(md) });
+  } catch {
+    return NextResponse.json({ version: VERSION, entries: [] });
+  }
+}

--- a/app/api/changelog/route.ts
+++ b/app/api/changelog/route.ts
@@ -9,7 +9,7 @@
 import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { NextResponse } from "next/server";
-import { parseChangelog } from "@/lib/changelog/parse";
+import { parseChangelog, isReleased } from "@/lib/changelog/parse";
 
 export const dynamic = "force-dynamic";
 export const runtime = "nodejs";
@@ -20,7 +20,9 @@ const VERSION =
 export async function GET() {
   try {
     const md = await readFile(join(process.cwd(), "CHANGELOG.md"), "utf8");
-    return NextResponse.json({ version: VERSION, entries: parseChangelog(md) });
+    // Released versions only — the in-progress "Unreleased" section is internal.
+    const entries = parseChangelog(md).filter((e) => isReleased(e.version));
+    return NextResponse.json({ version: VERSION, entries });
   } catch {
     return NextResponse.json({ version: VERSION, entries: [] });
   }

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -11,6 +11,7 @@ const NAV = [
   { href: "/admin/trains", label: "Trains" },
   { href: "/admin/modules", label: "Modules" },
   { href: "/admin/settings", label: "Settings" },
+  { href: "/admin/release-notes", label: "Release notes" },
 ];
 
 export function AdminShell({ children }: { children: React.ReactNode }) {
@@ -35,7 +36,12 @@ export function AdminShell({ children }: { children: React.ReactNode }) {
           <div className="text-lg font-bold tracking-tight">Free Dispatcher</div>
           <div className="text-xs text-slate-400">Admin · host console</div>
           {version && (
-            <div className="mt-0.5 text-xs text-slate-600">v{version}</div>
+            <Link
+              href="/admin/release-notes"
+              className="mt-0.5 block text-xs text-slate-600 hover:text-slate-400"
+            >
+              v{version}
+            </Link>
           )}
         </div>
         <nav className="space-y-1">

--- a/lib/changelog/__tests__/parse.test.ts
+++ b/lib/changelog/__tests__/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseChangelog, isReleased } from "../parse";
+import { parseChangelog, isReleased, compareVersions } from "../parse";
 
 const SAMPLE = `# Changelog
 
@@ -58,5 +58,12 @@ describe("parseChangelog", () => {
     expect(isReleased("0.7.0")).toBe(true);
     expect(isReleased("Unreleased")).toBe(false);
     expect(isReleased("[Unreleased]")).toBe(false);
+  });
+
+  it("compareVersions orders releases and ignores pre-release tags", () => {
+    expect(compareVersions("0.7.0", "0.8.0")).toBeLessThan(0);
+    expect(compareVersions("0.10.0", "0.9.0")).toBeGreaterThan(0);
+    expect(compareVersions("1.2.3", "1.2.3")).toBe(0);
+    expect(compareVersions("0.8.0-beta.2", "0.8.0")).toBe(0);
   });
 });

--- a/lib/changelog/__tests__/parse.test.ts
+++ b/lib/changelog/__tests__/parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { parseChangelog } from "../parse";
+import { parseChangelog, isReleased } from "../parse";
 
 const SAMPLE = `# Changelog
 
@@ -51,5 +51,12 @@ describe("parseChangelog", () => {
     expect(v7.date).toBe("2025-12-26");
     expect(v7.sections[0].heading).toBeNull();
     expect(v7.sections[0].items).toHaveLength(2);
+  });
+
+  it("isReleased keeps semver versions and rejects Unreleased", () => {
+    expect(isReleased("0.8.0")).toBe(true);
+    expect(isReleased("0.7.0")).toBe(true);
+    expect(isReleased("Unreleased")).toBe(false);
+    expect(isReleased("[Unreleased]")).toBe(false);
   });
 });

--- a/lib/changelog/__tests__/parse.test.ts
+++ b/lib/changelog/__tests__/parse.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { parseChangelog } from "../parse";
+
+const SAMPLE = `# Changelog
+
+Preamble paragraph that should be ignored. See [CONTRIBUTING.md](CONTRIBUTING.md).
+
+## [Unreleased]
+
+A prose note that is not a bullet.
+
+## [0.8.0](https://github.com/o/r/compare/v0.7.0...v0.8.0) (2026-06-29)
+
+### Features
+
+* in-app auto-update ([#52](https://x/52)) ([#61](https://x/61)) ([649fd1c](https://x/c))
+* session archiving ([#57](https://x/57))
+
+### Bug Fixes
+
+* ship the anon key so login works ([#56](https://x/56))
+
+## 0.7.0 - 2025-12-26
+- Added Electron shell and IPC backend resolution.
+- Bundled FastAPI backend.
+`;
+
+describe("parseChangelog", () => {
+  const entries = parseChangelog(SAMPLE);
+
+  it("drops the preamble and the empty Unreleased entry", () => {
+    expect(entries.map((e) => e.version)).toEqual(["0.8.0", "0.7.0"]);
+  });
+
+  it("parses release-please version, date, and compare url", () => {
+    const v8 = entries[0];
+    expect(v8.date).toBe("2026-06-29");
+    expect(v8.url).toContain("compare/v0.7.0...v0.8.0");
+    expect(v8.sections.map((s) => s.heading)).toEqual(["Features", "Bug Fixes"]);
+  });
+
+  it("strips markdown links and commit-sha noise from items", () => {
+    const features = entries[0].sections[0].items;
+    expect(features[0]).toBe("in-app auto-update (#52) (#61)");
+    expect(features[1]).toBe("session archiving (#57)");
+  });
+
+  it("parses the hand-written '0.7.0 - date' heading with ungrouped bullets", () => {
+    const v7 = entries[1];
+    expect(v7.version).toBe("0.7.0");
+    expect(v7.date).toBe("2025-12-26");
+    expect(v7.sections[0].heading).toBeNull();
+    expect(v7.sections[0].items).toHaveLength(2);
+  });
+});

--- a/lib/changelog/parse.ts
+++ b/lib/changelog/parse.ts
@@ -22,6 +22,11 @@ export interface ChangelogEntry {
   sections: ChangelogSection[];
 }
 
+/** A released entry has a semver-number heading (excludes "Unreleased"). */
+export function isReleased(version: string): boolean {
+  return /^\d+\.\d+\.\d+/.test(version.trim());
+}
+
 /** Strip markdown links to their label and drop bare commit-sha refs. */
 function cleanItem(text: string): string {
   return text

--- a/lib/changelog/parse.ts
+++ b/lib/changelog/parse.ts
@@ -1,0 +1,101 @@
+/**
+ * Changelog parser — turns the project CHANGELOG.md (Keep a Changelog +
+ * release-please output) into structured entries the UI can render without a
+ * markdown dependency. Pure (no fs) so it can be unit-tested.
+ *
+ * Handles both heading styles:
+ *   ## [0.8.0](https://…compare…) (2026-06-29)   ← release-please
+ *   ## 0.7.0 - 2025-12-26                          ← hand-written
+ *   ## [Unreleased]
+ * and bullets grouped under `### Features` / `### Bug Fixes` / etc.
+ */
+export interface ChangelogSection {
+  /** e.g. "Features", "Bug Fixes", or null for ungrouped bullets. */
+  heading: string | null;
+  items: string[];
+}
+
+export interface ChangelogEntry {
+  version: string;
+  date: string | null;
+  url: string | null;
+  sections: ChangelogSection[];
+}
+
+/** Strip markdown links to their label and drop bare commit-sha refs. */
+function cleanItem(text: string): string {
+  return text
+    .replace(/\[([^\]]+)\]\([^)]+\)/g, "$1") // [label](url) -> label
+    .replace(/\s*\(\s*[0-9a-f]{7,40}\s*\)/g, "") // drop (deadbee) commit hashes
+    .replace(/\s{2,}/g, " ")
+    .trim();
+}
+
+function parseHeading(raw: string): { version: string; date: string | null; url: string | null } {
+  let rest = raw.trim();
+  let url: string | null = null;
+
+  // [version](url) form
+  const link = rest.match(/^\[([^\]]+)\]\(([^)]+)\)\s*(.*)$/);
+  if (link) {
+    const version = link[1].trim();
+    url = link[2].trim();
+    rest = link[3].trim();
+    const date = rest.match(/(\d{4}-\d{2}-\d{2})/);
+    return { version, date: date ? date[1] : null, url };
+  }
+
+  // bare "[Unreleased]" or "0.7.0 - 2025-12-26"
+  const date = rest.match(/(\d{4}-\d{2}-\d{2})/);
+  const version = rest
+    .replace(/\(?\d{4}-\d{2}-\d{2}\)?/, "")
+    .replace(/[-–]\s*$/, "")
+    .replace(/^\[|\]$/g, "")
+    .trim();
+  return { version: version || rest.replace(/^\[|\]$/g, ""), date: date ? date[1] : null, url };
+}
+
+export function parseChangelog(markdown: string): ChangelogEntry[] {
+  const lines = markdown.split(/\r?\n/);
+  const entries: ChangelogEntry[] = [];
+  let entry: ChangelogEntry | null = null;
+  let currentHeading: string | null = null;
+
+  /** Append an item to the entry's current section, opening one if needed. */
+  const pushItem = (text: string) => {
+    if (!entry) return;
+    let section = entry.sections[entry.sections.length - 1];
+    if (!section || section.heading !== currentHeading) {
+      section = { heading: currentHeading, items: [] };
+      entry.sections.push(section);
+    }
+    section.items.push(text);
+  };
+
+  for (const line of lines) {
+    const h2 = line.match(/^##\s+(.+?)\s*$/);
+    if (h2) {
+      const { version, date, url } = parseHeading(h2[1]);
+      entry = { version, date, url, sections: [] };
+      currentHeading = null;
+      entries.push(entry);
+      continue;
+    }
+    if (!entry) continue; // skip the file preamble
+
+    const h3 = line.match(/^###\s+(.+?)\s*$/);
+    if (h3) {
+      currentHeading = h3[1].trim();
+      continue;
+    }
+
+    const bullet = line.match(/^\s*[-*]\s+(.+)$/);
+    if (bullet) {
+      const text = cleanItem(bullet[1]);
+      if (text) pushItem(text);
+    }
+  }
+
+  // Drop entries with no actual content (e.g. an empty Unreleased heading).
+  return entries.filter((e) => e.sections.some((s) => s.items.length > 0));
+}

--- a/lib/changelog/parse.ts
+++ b/lib/changelog/parse.ts
@@ -27,6 +27,19 @@ export function isReleased(version: string): boolean {
   return /^\d+\.\d+\.\d+/.test(version.trim());
 }
 
+/** Compare dotted numeric versions (major.minor.patch); pre-release tags
+ *  ignored. Returns negative / 0 / positive like a sort comparator. */
+export function compareVersions(a: string, b: string): number {
+  const nums = (v: string) =>
+    v.split("-")[0].split(".").map((n) => parseInt(n, 10) || 0);
+  const pa = nums(a);
+  const pb = nums(b);
+  for (let i = 0; i < 3; i++) {
+    if ((pa[i] ?? 0) !== (pb[i] ?? 0)) return (pa[i] ?? 0) - (pb[i] ?? 0);
+  }
+  return 0;
+}
+
 /** Strip markdown links to their label and drop bare commit-sha refs. */
 function cleanItem(text: string): string {
   return text

--- a/scripts/prepare-standalone.mjs
+++ b/scripts/prepare-standalone.mjs
@@ -27,6 +27,9 @@ if (!existsSync(join(standalone, "server.js"))) {
 const copies = [
   [join(root, ".next", "static"), join(standalone, ".next", "static")],
   [join(root, "public"), join(standalone, "public")],
+  // Ship the changelog so the in-app Release Notes page works offline; the
+  // server reads it from its cwd (the standalone dir) at runtime.
+  [join(root, "CHANGELOG.md"), join(standalone, "CHANGELOG.md")],
 ];
 
 for (const [from, to] of copies) {


### PR DESCRIPTION
Keep release notes **and ship them in-app**. release-please already generates the changelog from Conventional Commits; this surfaces it to operators.

## What

- **Bundled & offline** — `CHANGELOG.md` is copied into the standalone build, and `GET /api/changelog` reads + parses it at runtime with no network (the host runs at meets without internet).
- **Release Notes page** (`/admin/release-notes`) — renders each version as a card (Features / Bug Fixes / Added / …), highlights the version you're running, and links each version to its GitHub compare view. Reachable from a new **Release notes** nav item and the now-clickable sidebar version.
- **Dependency-free parser** (`lib/changelog/parse.ts`) — handles both the release-please format (`## [0.8.0](compare) (date)`) and the hand-written one (`## 0.7.0 - date`), strips markdown links and commit-sha noise.

## Verification

- 37 tests pass (4 new parser tests covering both heading styles + link/sha cleanup); lint, typecheck, build clean.
- In-browser: the page renders the **real** CHANGELOG (Unreleased + 0.7.0 cards) with "You're running v0.8.0-dev". Screenshot below.

Once release-please's `0.8.0` PR (#63) merges, that page will show a proper **0.8.0** entry marked **current** in packaged release builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
