### PR TITLE
fix: correct Module Repository sync endpoint path (#70)

### DIFF
--- a/lib/server/ModuleRepoSync.ts
+++ b/lib/server/ModuleRepoSync.ts
@@ -70,7 +70,10 @@ export async function syncModules(): Promise<SyncResult | SyncError> {
   }
 
   const meta = await readSyncMeta();
-  const url = new URL(`${config.moduleRepo.url}/functions/v1/api/v1/modules/full`);
+  // Supabase routes /functions/v1/<slug> by the first path segment, so the
+  // endpoint is the function's own slug. (The earlier `/api/v1/modules/full`
+  // path resolved to a non-existent `api` function and 404'd — issue #70.)
+  const url = new URL(`${config.moduleRepo.url}/functions/v1/modules-full`);
   if (meta?.last_synced_at) {
     url.searchParams.set("updated_since", meta.last_synced_at);
   }
@@ -103,7 +106,17 @@ export async function syncModules(): Promise<SyncResult | SyncError> {
   }
 
   if (!res.ok) {
-    return { error: "api_error", message: `Module Repository returned ${res.status}.` };
+    // Surface the real status + any upstream message, so the next endpoint
+    // problem is self-diagnosing instead of a bare "api_error" (#70).
+    const body = (await res.json().catch(() => null)) as
+      | { error?: string; message?: string }
+      | null;
+    const base =
+      res.status === 404
+        ? "Module Repository sync endpoint not found (404) — check the function path/config."
+        : `Module Repository returned ${res.status}.`;
+    const detail = body?.message ?? body?.error;
+    return { error: "api_error", message: detail ? `${base} ${detail}` : base };
   }
 
   const modules = (await res.json()) as ModuleFull[];

--- a/lib/server/__tests__/ModuleRepoSync.test.ts
+++ b/lib/server/__tests__/ModuleRepoSync.test.ts
@@ -126,7 +126,7 @@ describe("syncModules — happy path", () => {
     await syncModules();
 
     expect(fetch).toHaveBeenCalledWith(
-      expect.stringContaining("/functions/v1/api/v1/modules/full"),
+      expect.stringContaining("/functions/v1/modules-full"),
       expect.objectContaining({
         headers: expect.objectContaining({
           Authorization: "Bearer bearer-token",
@@ -230,6 +230,27 @@ describe("syncModules — error handling", () => {
     const result = await syncModules();
 
     expect(result).toMatchObject({ error: "api_error" });
+  });
+
+  it("names a 404 endpoint problem instead of a bare api_error", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 404 }));
+
+    const result = await syncModules();
+
+    expect(result).toMatchObject({ error: "api_error" });
+    expect((result as { message: string }).message).toContain("404");
+  });
+
+  it("includes the upstream message in the error", async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "query_failed", message: "boom" }), {
+        status: 500,
+      }),
+    );
+
+    const result = await syncModules();
+
+    expect((result as { message: string }).message).toContain("boom");
   });
 });
 


### PR DESCRIPTION
Fixes #70.

## Cause

Module sync requested `…/functions/v1/api/v1/modules/full`. Supabase routes edge functions by the **first** path segment, so that resolved to a non-existent `api` function → **404**, which the sync flattened into a generic `api_error`. The real endpoint is the function's own slug: `…/functions/v1/modules-full`.

## Fix

- Point the sync at `/functions/v1/modules-full` ([`ModuleRepoSync.ts`](lib/server/ModuleRepoSync.ts)).
- Surface the real HTTP status + any upstream message instead of a bare `api_error`, with a distinct call-out for a 404 endpoint problem — so the next path/endpoint issue diagnoses itself.

## Verification

- 13 sync tests pass (2 new: 404 message, upstream-message passthrough); lint + typecheck clean.
- **Live** against the production Module Repository: the corrected URL returns `200` with the real catalog (**16 modules**, 18 KB), and the `updated_since` re-sync variant also returns `200`. (The old `/api/v1/modules/full` path returns `404`.)

Ships in the next release (0.8.2) via the automated pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
