### PR TITLE
fix: Emergency Stop cuts track power (the reliable stop for any throttle) (#55)

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -13,7 +13,7 @@ interface CommandStationStatus {
   target: string | null;
 }
 
-type EmergencyMode = "stop" | "off" | "on";
+type EmergencyMode = "off" | "on";
 
 function elapsed(since: string): string {
   const ms = Date.now() - new Date(since).getTime();
@@ -47,8 +47,7 @@ export default function AdminDashboard() {
 
   async function emergencyStop(mode: EmergencyMode) {
     const prompts: Record<EmergencyMode, string> = {
-      stop: "Emergency Stop — revoke authority and halt trains?",
-      off: "Emergency Off — revoke authority and CUT TRACK POWER?",
+      off: "Emergency Stop — revoke authority and CUT TRACK POWER? This halts every train.",
       on: "Restore track power?",
     };
     if (!confirm(prompts[mode])) return;
@@ -194,28 +193,21 @@ export default function AdminDashboard() {
             <div className="space-y-2">
               <button
                 disabled={busy}
-                onClick={() => emergencyStop("stop")}
+                onClick={() => emergencyStop("off")}
                 title={
-                  cmd?.capabilities.emergencyStop
-                    ? "Halt all trains, keep track power"
-                    : "Revokes authority; this connection can't halt locos while keeping power"
+                  cmd?.capabilities.emergencyOff
+                    ? "Revoke authority and cut track power — stops every train"
+                    : "Revokes authority; no command station connected to cut power"
                 }
                 className="w-full rounded-md bg-red-600 px-4 py-2.5 text-sm font-bold text-white hover:bg-red-500 disabled:opacity-50"
               >
                 ⏹ Emergency Stop
               </button>
-              <button
-                disabled={busy}
-                onClick={() => emergencyStop("off")}
-                title={
-                  cmd?.capabilities.emergencyOff
-                    ? "Revoke authority and cut track power"
-                    : "Revokes authority; no command station connected to cut power"
-                }
-                className="w-full rounded-md border border-red-700/60 px-4 py-2 text-sm font-semibold text-red-300 hover:bg-red-900/30 disabled:opacity-50"
-              >
-                ⚡ Emergency Off (cut power)
-              </button>
+              <p className="text-xs text-slate-500">
+                Cuts track power — the stop that halts every train, whatever
+                throttle it&apos;s on. Authority is always revoked; power is cut
+                when a command station is connected.
+              </p>
               {cmd?.connected && cmd.capabilities.emergencyOff && (
                 <button
                   disabled={busy}


### PR DESCRIPTION
## What

The dashboard's primary **Emergency Stop** now revokes authority **and cuts
track power** (WiThrottle `PPA0`). Removes the separate keep-power "Emergency
Stop" button, leaving one honest control + **Restore power**.

## Why

Validated live against **JMRI + a Digitrax command station**:

- ✅ **Power-cut halts every train** end-to-end (JMRI → LocoNet → track power drops).
- ❌ A **keep-power** estop (acquire loco → send `X`) can't reliably stop a loco
  held by a **physical DCC throttle**: DCC slot-sharing lets the controlling
  throttle immediately re-command speed and override it. It also needs a
  steal/share handshake that only reaches JMRI-managed (WiThrottle-app) throttles.
- On a **mixed fleet** (handhelds + phone apps), only power-cut is universal —
  matching a real fascia big-red-button.

So keep-power was a false promise on this hardware; cutting power is the reliable
stop. Authority revocation remains the always-on baseline when no command station
is connected.

## Closes

Closes #55 — decision recorded (cut-power), physical stop reaches the station,
UI states exactly what it does.

## Test

- `tsc --noEmit`, `eslint`, and the command-station adapter tests pass.
- Physical behavior validated by hand against live JMRI/Digitrax hardware (power
  cut + restore observed on the layout).
