### PR TITLE
feat: track model API — layout authoring + occupancy/allocation + SSE (part of #80)

### DIFF
--- a/app/api/layouts/[id]/route.ts
+++ b/app/api/layouts/[id]/route.ts
@@ -1,0 +1,25 @@
+/**
+ * GET /api/layouts/:id — full District→Section→Block tree for a layout
+ *   (any authenticated role).
+ */
+import { NextResponse } from "next/server";
+import { trackModel } from "@/lib/server/TrackModel";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = requireRole(req, ["admin", "dispatcher", "engineer", "yardmaster"]);
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  const layout = await trackModel.getLayout(id);
+  if (!layout) {
+    return NextResponse.json({ error: "layout not found" }, { status: 404 });
+  }
+  return NextResponse.json({ layout });
+}

--- a/app/api/layouts/route.ts
+++ b/app/api/layouts/route.ts
@@ -1,0 +1,40 @@
+/**
+ * GET  /api/layouts — list layouts (any authenticated role).
+ * POST /api/layouts — create a layout, optionally with its whole
+ *   District→Section→Block tree (Admin). Body: LayoutInput (#80).
+ */
+import { NextResponse } from "next/server";
+import { trackModel, type LayoutInput } from "@/lib/server/TrackModel";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const guard = requireRole(req, ["admin", "dispatcher", "engineer", "yardmaster"]);
+  if (!guard.ok) return guard.response;
+  return NextResponse.json({ layouts: await trackModel.listLayouts() });
+}
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+
+  let body: LayoutInput;
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  if (!body?.name?.trim()) {
+    return NextResponse.json({ error: "name is required" }, { status: 400 });
+  }
+
+  try {
+    const layout = await trackModel.createLayout(body);
+    return NextResponse.json({ layout }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "create failed";
+    return NextResponse.json({ error: message }, { status: 400 });
+  }
+}

--- a/app/api/track/allocate/route.ts
+++ b/app/api/track/allocate/route.ts
@@ -1,0 +1,63 @@
+/**
+ * POST /api/track/allocate — allocate one or more Sections to a train, in a
+ *   direction, for the active session (Admin/Dispatcher). All sections must be
+ *   in one District; a section already actively allocated is rejected (#80/#90).
+ *   Body: { sectionIds: string[], trainId, direction: "AtoB" | "BtoA" }
+ */
+import { NextResponse } from "next/server";
+import { trackModel } from "@/lib/server/TrackModel";
+import { requireRole } from "@/lib/server/guard";
+import type { SectionDirection } from "@/lib/db/schema";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const DIRECTIONS: SectionDirection[] = ["AtoB", "BtoA"];
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin", "dispatcher"]);
+  if (!guard.ok) return guard.response;
+
+  let body: {
+    sectionIds?: string[];
+    trainId?: string;
+    direction?: SectionDirection;
+  };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  if (!Array.isArray(body.sectionIds) || body.sectionIds.length === 0) {
+    return NextResponse.json(
+      { error: "sectionIds must be a non-empty array" },
+      { status: 400 },
+    );
+  }
+  if (!body.trainId) {
+    return NextResponse.json({ error: "trainId is required" }, { status: 400 });
+  }
+  if (!body.direction || !DIRECTIONS.includes(body.direction)) {
+    return NextResponse.json(
+      { error: "direction must be 'AtoB' or 'BtoA'" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const allocations = await trackModel.allocateSections(
+      body.sectionIds,
+      body.trainId,
+      body.direction,
+      guard.claims.operatorId,
+    );
+    return NextResponse.json({ allocations }, { status: 201 });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "allocation failed";
+    // Missing/invalid input → 400; conflict or no-session → 409.
+    const status = /do not exist|must be in one district/.test(message)
+      ? 400
+      : 409;
+    return NextResponse.json({ error: message }, { status });
+  }
+}

--- a/app/api/track/occupancy/route.ts
+++ b/app/api/track/occupancy/route.ts
@@ -1,0 +1,42 @@
+/**
+ * POST /api/track/occupancy — mark/clear a Block's occupancy for the active
+ *   session (Admin/Dispatcher/Yardmaster). Body: { blockId, occupied, trainId? }
+ *   (#80, manual in v1).
+ */
+import { NextResponse } from "next/server";
+import { trackModel } from "@/lib/server/TrackModel";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin", "dispatcher", "yardmaster"]);
+  if (!guard.ok) return guard.response;
+
+  let body: { blockId?: string; occupied?: boolean; trainId?: string | null };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  if (!body.blockId || typeof body.occupied !== "boolean") {
+    return NextResponse.json(
+      { error: "blockId and boolean occupied are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const row = await trackModel.setBlockOccupancy(
+      body.blockId,
+      body.occupied,
+      body.trainId ?? null,
+      guard.claims.operatorId,
+    );
+    return NextResponse.json({ occupancy: row });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "occupancy update failed";
+    return NextResponse.json({ error: message }, { status: 409 });
+  }
+}

--- a/app/api/track/release/route.ts
+++ b/app/api/track/release/route.ts
@@ -1,0 +1,36 @@
+/**
+ * POST /api/track/release — release every active allocation of a Section for the
+ *   active session (Admin/Dispatcher). Body: { sectionId } (#80).
+ */
+import { NextResponse } from "next/server";
+import { trackModel } from "@/lib/server/TrackModel";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin", "dispatcher"]);
+  if (!guard.ok) return guard.response;
+
+  let body: { sectionId?: string };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  if (!body.sectionId) {
+    return NextResponse.json({ error: "sectionId is required" }, { status: 400 });
+  }
+
+  try {
+    const released = await trackModel.releaseSection(
+      body.sectionId,
+      guard.claims.operatorId,
+    );
+    return NextResponse.json({ released });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "release failed";
+    return NextResponse.json({ error: message }, { status: 409 });
+  }
+}

--- a/app/api/track/state/route.ts
+++ b/app/api/track/state/route.ts
@@ -1,0 +1,16 @@
+/**
+ * GET /api/track/state — live Block occupancy + active Section allocations for
+ *   the active session (any authenticated role) (#80).
+ */
+import { NextResponse } from "next/server";
+import { trackModel } from "@/lib/server/TrackModel";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function GET(req: Request) {
+  const guard = requireRole(req, ["admin", "dispatcher", "engineer", "yardmaster"]);
+  if (!guard.ok) return guard.response;
+  return NextResponse.json(await trackModel.getSessionTrackState());
+}

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -1,0 +1,346 @@
+/**
+ * TrackModel (#80) — the track model service.
+ *
+ * Two concerns:
+ *  - **Authoring** the static, layout-scoped hierarchy District → Section →
+ *    Block (created once per layout, reused across sessions).
+ *  - **Runtime** state for the active session: manual Block occupancy and
+ *    Section allocation to trains (with a direction), released via a flag.
+ *
+ * Runtime mutations broadcast an FdEvent + persist to ops_log through the
+ * SessionManager, mirroring how authority changes work. Conflicting allocation
+ * is caught at the DB level by a partial unique index (one active allocation per
+ * section per session); an allocation route must also stay within one District.
+ */
+import { and, eq, inArray } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import {
+  layouts,
+  districts,
+  sections,
+  blocks,
+  blockOccupancy,
+  sectionAllocations,
+  type SectionDirection,
+} from "@/lib/db/schema";
+import { sessionManager } from "./SessionManager";
+
+// ---- Authoring input/output shapes ---------------------------------------
+
+export interface BlockInput {
+  name: string;
+  position?: number;
+  moduleRecordNumber?: string | null;
+}
+export interface SectionInput {
+  name: string;
+  track?: string | null;
+  position?: number;
+  blocks?: BlockInput[];
+}
+export interface DistrictInput {
+  name: string;
+  position?: number;
+  sections?: SectionInput[];
+}
+export interface LayoutInput {
+  name: string;
+  description?: string | null;
+  districts?: DistrictInput[];
+}
+
+type BlockRow = typeof blocks.$inferSelect;
+type SectionRow = typeof sections.$inferSelect;
+type DistrictRow = typeof districts.$inferSelect;
+type LayoutRow = typeof layouts.$inferSelect;
+
+export interface LayoutTree extends LayoutRow {
+  districts: (DistrictRow & {
+    sections: (SectionRow & { blocks: BlockRow[] })[];
+  })[];
+}
+
+// ---- Pure helpers (unit-tested) ------------------------------------------
+
+/**
+ * A route allocation must live within a single District (#80). Throws when the
+ * given sections span more than one, or when a requested section is missing.
+ */
+export function assertSingleDistrict(
+  found: { id: string; districtId: string }[],
+  requestedIds: string[],
+): string {
+  if (found.length !== requestedIds.length) {
+    throw new Error("one or more sections do not exist");
+  }
+  const districtIds = new Set(found.map((s) => s.districtId));
+  if (districtIds.size > 1) {
+    throw new Error("all sections in an allocation must be in one district");
+  }
+  return [...districtIds][0];
+}
+
+/** Nest flat district/section/block rows under a layout into a tree. */
+export function buildLayoutTree(
+  layout: LayoutRow,
+  districtRows: DistrictRow[],
+  sectionRows: SectionRow[],
+  blockRows: BlockRow[],
+): LayoutTree {
+  const byPos = <T extends { position: number }>(a: T, b: T) =>
+    a.position - b.position;
+  const blocksBySection = new Map<string, BlockRow[]>();
+  for (const b of blockRows) {
+    const arr = blocksBySection.get(b.sectionId) ?? [];
+    arr.push(b);
+    blocksBySection.set(b.sectionId, arr);
+  }
+  const sectionsByDistrict = new Map<string, SectionRow[]>();
+  for (const s of sectionRows) {
+    const arr = sectionsByDistrict.get(s.districtId) ?? [];
+    arr.push(s);
+    sectionsByDistrict.set(s.districtId, arr);
+  }
+  return {
+    ...layout,
+    districts: [...districtRows].sort(byPos).map((d) => ({
+      ...d,
+      sections: (sectionsByDistrict.get(d.id) ?? []).sort(byPos).map((s) => ({
+        ...s,
+        blocks: (blocksBySection.get(s.id) ?? []).sort(byPos),
+      })),
+    })),
+  };
+}
+
+// ---- Service -------------------------------------------------------------
+
+class TrackModel {
+  // -- Authoring (static, layout-scoped) --------------------------------
+
+  /** Create a layout and, optionally, its whole District→Section→Block tree. */
+  async createLayout(input: LayoutInput): Promise<LayoutTree> {
+    const layoutId = await db.transaction(async (tx) => {
+      const [layout] = await tx
+        .insert(layouts)
+        .values({ name: input.name, description: input.description ?? null })
+        .returning();
+
+      for (const [di, d] of (input.districts ?? []).entries()) {
+        const [district] = await tx
+          .insert(districts)
+          .values({ layoutId: layout.id, name: d.name, position: d.position ?? di })
+          .returning();
+
+        for (const [si, s] of (d.sections ?? []).entries()) {
+          const [section] = await tx
+            .insert(sections)
+            .values({
+              districtId: district.id,
+              name: s.name,
+              track: s.track ?? null,
+              position: s.position ?? si,
+            })
+            .returning();
+
+          if (s.blocks?.length) {
+            await tx.insert(blocks).values(
+              s.blocks.map((b, bi) => ({
+                sectionId: section.id,
+                name: b.name,
+                position: b.position ?? bi,
+                moduleRecordNumber: b.moduleRecordNumber ?? null,
+              })),
+            );
+          }
+        }
+      }
+      return layout.id;
+    });
+
+    return this.getLayout(layoutId) as Promise<LayoutTree>;
+  }
+
+  /** All layouts, newest first. */
+  async listLayouts(): Promise<LayoutRow[]> {
+    return db.select().from(layouts);
+  }
+
+  /** Full District→Section→Block tree for a layout, or null if missing. */
+  async getLayout(layoutId: string): Promise<LayoutTree | null> {
+    const [layout] = await db
+      .select()
+      .from(layouts)
+      .where(eq(layouts.id, layoutId))
+      .limit(1);
+    if (!layout) return null;
+
+    const districtRows = await db
+      .select()
+      .from(districts)
+      .where(eq(districts.layoutId, layoutId));
+    const districtIds = districtRows.map((d) => d.id);
+    const sectionRows = districtIds.length
+      ? await db.select().from(sections).where(inArray(sections.districtId, districtIds))
+      : [];
+    const sectionIds = sectionRows.map((s) => s.id);
+    const blockRows = sectionIds.length
+      ? await db.select().from(blocks).where(inArray(blocks.sectionId, sectionIds))
+      : [];
+
+    return buildLayoutTree(layout, districtRows, sectionRows, blockRows);
+  }
+
+  // -- Runtime (active-session-scoped) ----------------------------------
+
+  /** Mark/clear a Block's occupancy for the active session (upsert). */
+  async setBlockOccupancy(
+    blockId: string,
+    occupied: boolean,
+    trainId: string | null,
+    updatedBy: string | null,
+  ) {
+    const session = await sessionManager.getActiveSession();
+    if (!session) throw new Error("no active session");
+
+    const [row] = await db
+      .insert(blockOccupancy)
+      .values({ sessionId: session.id, blockId, occupied, trainId, updatedBy })
+      .onConflictDoUpdate({
+        target: [blockOccupancy.sessionId, blockOccupancy.blockId],
+        set: { occupied, trainId, updatedBy, updatedAt: new Date() },
+      })
+      .returning();
+
+    await sessionManager.broadcast(
+      { type: "block_occupancy_changed", blockId, occupied, trainId },
+      session.id,
+    );
+    return row;
+  }
+
+  /**
+   * Allocate one or more Sections to a train, in a direction, for the active
+   * session. All sections must be in one District. A section already actively
+   * allocated is rejected (partial unique index → surfaced as a 409). Atomic:
+   * if any section conflicts, none are allocated.
+   */
+  async allocateSections(
+    sectionIds: string[],
+    trainId: string,
+    direction: SectionDirection,
+    byOperator: string | null,
+  ) {
+    if (sectionIds.length === 0) throw new Error("no sections to allocate");
+    const session = await sessionManager.getActiveSession();
+    if (!session) throw new Error("no active session");
+
+    const found = await db
+      .select({ id: sections.id, districtId: sections.districtId })
+      .from(sections)
+      .where(inArray(sections.id, sectionIds));
+    assertSingleDistrict(found, sectionIds);
+
+    let allocated;
+    try {
+      allocated = await db.transaction(async (tx) =>
+        tx
+          .insert(sectionAllocations)
+          .values(
+            sectionIds.map((sectionId) => ({
+              sessionId: session.id,
+              sectionId,
+              trainId,
+              direction,
+              allocatedBy: byOperator,
+            })),
+          )
+          .returning(),
+      );
+    } catch (err) {
+      if (isUniqueViolation(err)) {
+        throw new Error("a section is already allocated to another train");
+      }
+      throw err;
+    }
+
+    for (const a of allocated) {
+      await sessionManager.broadcast(
+        {
+          type: "section_allocated",
+          allocationId: a.id,
+          sectionId: a.sectionId,
+          trainId: a.trainId,
+          direction: a.direction as SectionDirection,
+        },
+        session.id,
+      );
+    }
+    return allocated;
+  }
+
+  /** Release every active allocation of a Section for the active session. */
+  async releaseSection(sectionId: string, byOperator: string | null) {
+    const session = await sessionManager.getActiveSession();
+    if (!session) throw new Error("no active session");
+
+    const released = await db
+      .update(sectionAllocations)
+      .set({ active: false, releasedAt: new Date(), allocatedBy: byOperator })
+      .where(
+        and(
+          eq(sectionAllocations.sessionId, session.id),
+          eq(sectionAllocations.sectionId, sectionId),
+          eq(sectionAllocations.active, true),
+        ),
+      )
+      .returning();
+
+    for (const a of released) {
+      await sessionManager.broadcast(
+        {
+          type: "section_released",
+          allocationId: a.id,
+          sectionId: a.sectionId,
+          trainId: a.trainId,
+        },
+        session.id,
+      );
+    }
+    return released;
+  }
+
+  /** Live occupancy + active allocations for the active session. */
+  async getSessionTrackState() {
+    const session = await sessionManager.getActiveSession();
+    if (!session) return { occupancy: [], allocations: [] };
+
+    const [occupancy, allocations] = await Promise.all([
+      db.select().from(blockOccupancy).where(eq(blockOccupancy.sessionId, session.id)),
+      db
+        .select()
+        .from(sectionAllocations)
+        .where(
+          and(
+            eq(sectionAllocations.sessionId, session.id),
+            eq(sectionAllocations.active, true),
+          ),
+        ),
+    ]);
+    return { occupancy, allocations };
+  }
+}
+
+/** Postgres/PGlite unique-constraint violation (SQLSTATE 23505). */
+function isUniqueViolation(err: unknown): boolean {
+  if (typeof err !== "object" || err === null) return false;
+  const code = (err as { code?: string }).code;
+  const message = (err as { message?: string }).message ?? "";
+  return code === "23505" || /unique|duplicate key/i.test(message);
+}
+
+const globalForTm = globalThis as unknown as { __fdTrackModel?: TrackModel };
+export const trackModel = globalForTm.__fdTrackModel ?? new TrackModel();
+if (process.env.NODE_ENV !== "production") {
+  globalForTm.__fdTrackModel = trackModel;
+}

--- a/lib/server/__tests__/TrackModel.test.ts
+++ b/lib/server/__tests__/TrackModel.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { assertSingleDistrict, buildLayoutTree } from "../TrackModel";
+
+describe("assertSingleDistrict (#80 route allocation bounding)", () => {
+  it("returns the district when all sections share one", () => {
+    const found = [
+      { id: "s1", districtId: "d1" },
+      { id: "s2", districtId: "d1" },
+    ];
+    expect(assertSingleDistrict(found, ["s1", "s2"])).toBe("d1");
+  });
+
+  it("throws when sections span more than one district", () => {
+    const found = [
+      { id: "s1", districtId: "d1" },
+      { id: "s2", districtId: "d2" },
+    ];
+    expect(() => assertSingleDistrict(found, ["s1", "s2"])).toThrow(
+      /one district/,
+    );
+  });
+
+  it("throws when a requested section is missing", () => {
+    const found = [{ id: "s1", districtId: "d1" }];
+    expect(() => assertSingleDistrict(found, ["s1", "s2"])).toThrow(
+      /do not exist/,
+    );
+  });
+});
+
+describe("buildLayoutTree (#80)", () => {
+  const layout = {
+    id: "L",
+    name: "Test",
+    description: null,
+    createdAt: new Date(),
+  };
+
+  it("nests sections/blocks under districts and sorts by position", () => {
+    const tree = buildLayoutTree(
+      layout,
+      [
+        { id: "d2", layoutId: "L", name: "South", position: 1, createdAt: new Date() },
+        { id: "d1", layoutId: "L", name: "North", position: 0, createdAt: new Date() },
+      ],
+      [
+        { id: "s1", districtId: "d1", name: "Sec B", track: null, position: 1, createdAt: new Date() },
+        { id: "s0", districtId: "d1", name: "Sec A", track: null, position: 0, createdAt: new Date() },
+      ],
+      [
+        { id: "b1", sectionId: "s0", name: "Blk 2", position: 1, moduleRecordNumber: null, createdAt: new Date() },
+        { id: "b0", sectionId: "s0", name: "Blk 1", position: 0, moduleRecordNumber: null, createdAt: new Date() },
+      ],
+    );
+
+    // Districts sorted by position.
+    expect(tree.districts.map((d) => d.name)).toEqual(["North", "South"]);
+    // Sections under d1 sorted by position.
+    expect(tree.districts[0].sections.map((s) => s.name)).toEqual(["Sec A", "Sec B"]);
+    // Blocks under s0 sorted by position.
+    expect(tree.districts[0].sections[0].blocks.map((b) => b.name)).toEqual([
+      "Blk 1",
+      "Blk 2",
+    ]);
+    // Empty district still renders with no sections.
+    expect(tree.districts[1].sections).toEqual([]);
+  });
+});

--- a/lib/server/events.ts
+++ b/lib/server/events.ts
@@ -2,11 +2,34 @@
  * Server-Sent Event contract (spec §5.1). These are the events the server
  * pushes to all connected clients over `/api/events`.
  */
-import type { OperatorRole, TrainStatus } from "@/lib/db/schema";
+import type {
+  OperatorRole,
+  TrainStatus,
+  SectionDirection,
+} from "@/lib/db/schema";
 
 export type FdEvent =
   | { type: "session_start"; sessionId: string }
   | { type: "session_archived"; sessionId: string }
+  | {
+      type: "block_occupancy_changed";
+      blockId: string;
+      occupied: boolean;
+      trainId: string | null;
+    }
+  | {
+      type: "section_allocated";
+      allocationId: string;
+      sectionId: string;
+      trainId: string;
+      direction: SectionDirection;
+    }
+  | {
+      type: "section_released";
+      allocationId: string;
+      sectionId: string;
+      trainId: string;
+    }
   | {
       type: "train_status_changed";
       trainId: string;


### PR DESCRIPTION
## What

The service + API on top of the #80 schema — the dispatcher's core track-model
operations. Builds on the merged foundation (PR #95).

### Service — `lib/server/TrackModel.ts`
- **Authoring:** create a layout with its whole District→Section→Block tree in one
  call; list layouts; fetch a layout's full tree.
- **Runtime (active session):** mark/clear block occupancy (upsert); allocate one or
  more sections to a train in a direction; release a section.

### Enforcement
- Allocations are **bounded to one District** (a route spanning two is rejected).
- A section **already actively allocated is rejected** — the partial unique index
  surfaces as a `409` (#90 conflict backstop), and multi-section allocation is
  **atomic** (a conflict rolls back the whole route).

### SSE
`block_occupancy_changed`, `section_allocated`, `section_released` — broadcast and
logged through the SessionManager, exactly like authority events.

### Routes (role-gated)
| Method | Path | Role |
|---|---|---|
| GET / POST | `/api/layouts` | read: any · create: admin |
| GET | `/api/layouts/:id` | any |
| GET | `/api/track/state` | any |
| POST | `/api/track/occupancy` | admin/dispatcher/yardmaster |
| POST | `/api/track/allocate` | admin/dispatcher |
| POST | `/api/track/release` | admin/dispatcher |

## Test
- Unit tests for the pure logic (district-bounding, layout-tree nesting).
- DB-level conflict guarantee covered by the migrations test (from PR #95).
- Full suite (50) + typecheck + lint + `next build` green.

## Scope
**Part of #80.** Next: the dispatcher UI (author/pick a layout, mark occupancy,
allocate/release on a schematic) — that's what closes #80 and feeds #78/#79.
