### PR TITLE
feat: on-demand update check + configurable check interval (#52)

### DIFF
--- a/electron/control-panel.html
+++ b/electron/control-panel.html
@@ -66,7 +66,19 @@
       <span id="upd-text">Checking for updates…</span>
       <div class="progress" id="upd-progress"><div id="upd-bar"></div></div>
       <div class="row" id="upd-actions"></div>
+      <div class="row"><button class="ghost" id="upd-check">Check now</button></div>
       <label class="beta"><input type="checkbox" id="beta" /> Include beta updates</label>
+      <label class="beta"
+        >Check automatically every
+        <input
+          id="upd-interval"
+          type="number"
+          min="0"
+          max="10080"
+          style="width: 56px; background: #0b1220; color: #cbd5e1; border: 1px solid #1e293b; border-radius: 6px; padding: 2px 6px; font-size: 11px;"
+        />
+        min <span style="color: #475569">(0 = off)</span></label
+      >
     </div>
     <div id="err">
       <span id="errmsg"></span>
@@ -188,6 +200,7 @@
         $("version").textContent = "v" + st.version;
         if (!st.enabled) return; // dev build: show version, hide update UI
         $("beta").checked = st.beta;
+        $("upd-interval").value = st.intervalMinutes;
         $("update").style.display = "flex";
         renderUpdate({ state: "checking" });
       }
@@ -196,6 +209,17 @@
       $("beta").addEventListener("change", () =>
         window.fd.updaterSetBeta($("beta").checked),
       );
+      $("upd-check").addEventListener("click", () => {
+        $("upd-text").textContent = "Checking for updates…";
+        window.fd.updaterCheck();
+      });
+      $("upd-interval").addEventListener("change", async () => {
+        const v = parseInt($("upd-interval").value, 10);
+        const applied = await window.fd.updaterSetInterval(
+          Number.isFinite(v) ? v : 0,
+        );
+        $("upd-interval").value = applied;
+      });
       initUpdater();
 
       refresh();

--- a/electron/main.js
+++ b/electron/main.js
@@ -21,9 +21,11 @@ const http = require("node:http");
 const crypto = require("node:crypto");
 
 const PORT = Number(process.env.FD_PORT) || 3000;
-// Re-check for updates while the host stays open (long-running event sessions
-// rarely restart). The launch check covers the common case.
-const UPDATE_CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6 hours
+// Re-check for updates while the host stays open. The interval (minutes) is
+// user-configurable from the host window; 0 disables automatic checks (leaving
+// the on-demand "Check now" button). The launch check always runs.
+const DEFAULT_UPDATE_INTERVAL_MIN = 360; // 6 hours
+const MAX_UPDATE_INTERVAL_MIN = 10080; // 1 week
 const HOST_BIND = "0.0.0.0"; // listen on all interfaces so LAN phones can join
 const LOOPBACK = `http://127.0.0.1:${PORT}`;
 const MAX_RESTARTS = 1;
@@ -34,6 +36,7 @@ let tray = null;
 let quitting = false;
 let restarts = 0;
 let lastServerError = "";
+let updateTimer = null;
 
 function logPath() {
   return path.join(app.getPath("userData"), "logs", "host.log");
@@ -242,6 +245,31 @@ function setBetaPref(on) {
   }
 }
 
+/** Persisted automatic update-check interval, in minutes. 0 = off (manual only). */
+function intervalPrefPath() {
+  return path.join(app.getPath("userData"), "update-check-interval-minutes");
+}
+function getIntervalMinutes() {
+  try {
+    const raw = parseInt(fs.readFileSync(intervalPrefPath(), "utf8").trim(), 10);
+    if (!Number.isFinite(raw) || raw < 0) return DEFAULT_UPDATE_INTERVAL_MIN;
+    return Math.min(raw, MAX_UPDATE_INTERVAL_MIN);
+  } catch {
+    return DEFAULT_UPDATE_INTERVAL_MIN;
+  }
+}
+function setIntervalMinutes(minutes) {
+  const n = Number.isFinite(minutes)
+    ? Math.max(0, Math.min(Math.round(minutes), MAX_UPDATE_INTERVAL_MIN))
+    : DEFAULT_UPDATE_INTERVAL_MIN;
+  try {
+    fs.writeFileSync(intervalPrefPath(), String(n));
+  } catch {
+    /* best-effort */
+  }
+  return n;
+}
+
 /** Push an updater status object to the control-panel renderer (if open). */
 function sendUpdate(payload) {
   win?.webContents?.send("updater", payload);
@@ -284,12 +312,31 @@ function setupAutoUpdater() {
     sendUpdate({ state: "error", message: String((err && err.message) || err) }),
   );
 
-  const check = () =>
-    autoUpdater
-      .checkForUpdates()
-      .catch((e) => log(`updater check failed: ${e && e.message}`));
-  check(); // on launch
-  setInterval(check, UPDATE_CHECK_INTERVAL_MS); // on interval
+  runUpdateCheck(); // on launch
+  rescheduleUpdateChecks(); // on the user-defined interval
+}
+
+/** Trigger a single update check (no-op until the app is packaged). */
+function runUpdateCheck() {
+  if (!app.isPackaged) return;
+  return autoUpdater
+    .checkForUpdates()
+    .catch((e) => log(`updater check failed: ${e && e.message}`));
+}
+
+/** (Re)arm the automatic update-check timer from the saved interval (0 = off). */
+function rescheduleUpdateChecks() {
+  if (updateTimer) {
+    clearInterval(updateTimer);
+    updateTimer = null;
+  }
+  const mins = getIntervalMinutes();
+  if (mins > 0) {
+    updateTimer = setInterval(runUpdateCheck, mins * 60 * 1000);
+    log(`updater: auto-check every ${mins} min`);
+  } else {
+    log("updater: auto-check disabled (manual only)");
+  }
 }
 
 ipcMain.handle("get-info", (_e, host) => fetchServerInfo(host));
@@ -304,6 +351,7 @@ ipcMain.handle("updater-state", () => ({
   version: app.getVersion(),
   beta: getBetaPref(),
   enabled: app.isPackaged,
+  intervalMinutes: getIntervalMinutes(),
 }));
 ipcMain.handle("updater-check", () =>
   autoUpdater.checkForUpdates().catch((e) => ({ error: String(e && e.message) })),
@@ -321,6 +369,13 @@ ipcMain.handle("updater-set-beta", (_e, on) => {
   return autoUpdater
     .checkForUpdates()
     .catch((e) => ({ error: String(e && e.message) }));
+});
+// Set the automatic-check interval (minutes; 0 = off) and re-arm the timer.
+// Returns the clamped value actually applied.
+ipcMain.handle("updater-set-interval", (_e, minutes) => {
+  const applied = setIntervalMinutes(Number(minutes));
+  rescheduleUpdateChecks();
+  return applied;
 });
 
 app.whenReady().then(async () => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -30,6 +30,9 @@ contextBridge.exposeInMainWorld("fd", {
   updaterInstall: () => ipcRenderer.send("updater-install"),
   /** Toggle whether beta (pre-release) updates are offered; re-checks. */
   updaterSetBeta: (on) => ipcRenderer.invoke("updater-set-beta", on),
+  /** Set the automatic-check interval in minutes (0 = off). Returns the applied value. */
+  updaterSetInterval: (minutes) =>
+    ipcRenderer.invoke("updater-set-interval", minutes),
   /** Subscribe to updater status:
    *  { state: 'checking'|'current'|'available'|'downloading'|'downloaded'|'error', ... }. */
   onUpdater: (cb) => ipcRenderer.on("updater", (_e, s) => cb(s)),


### PR DESCRIPTION
## What

The host update panel gains two things testers have been missing:

- **"Check now"** button — force an update check on demand, no tray restart.
- **Configurable interval** — "Check automatically every _N_ min", `0 = off`
  (manual only). Replaces the hard-coded 6-hour timer.

The interval persists in `userData` and **re-arms the timer live** when changed
(new `updater-set-interval` IPC) — so a new value takes effect immediately.

## Why

During test builds, waiting up to 6 hours for the next auto-check (or restarting
the tray to force one) is painful. On-demand + short intervals fix that.

## Changes
- `electron/main.js` — interval pref (persisted, clamped 0–10080 min);
  `runUpdateCheck()` / `rescheduleUpdateChecks()`; `intervalMinutes` in
  `updater-state`; `updater-set-interval` IPC.
- `electron/preload.js` — `updaterSetInterval` bridge.
- `electron/control-panel.html` — "Check now" button + interval input.

## Verification

`node --check` passes on both JS files; the UI additions are static markup + a
handler that mirrors the existing (working) beta-toggle path.

⚠️ **Note:** the update panel only runs inside the **packaged** Electron app
(it's gated on `app.isPackaged` and needs the `window.fd` preload bridge), so it
can't be exercised by the dev server or a plain browser preview — it'll be
confirmed in the next packaged test build, which is exactly the workflow this
unblocks.
