### PR TITLE
feat: live dispatcher track view — occupancy + section allocation (#78, #79)

### DIFF
--- a/app/(mobile)/dispatch/page.tsx
+++ b/app/(mobile)/dispatch/page.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useFdSession } from "@/lib/client/useFdSession";
 import { apiSend } from "@/lib/client/api";
+import { TrackBoard } from "@/components/track/TrackBoard";
 import type { TrainRow } from "@/lib/client/types";
 
 function Metric({ label, value }: { label: string; value: number }) {
@@ -85,6 +86,11 @@ export default function DispatchScreen() {
             );
           })}
         </div>
+      </section>
+
+      <section>
+        <h2 className="mb-2 text-sm font-semibold text-slate-300">Track</h2>
+        <TrackBoard trains={trains} canControl />
       </section>
 
       <section>

--- a/app/admin/track/page.tsx
+++ b/app/admin/track/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { useFdSession } from "@/lib/client/useFdSession";
+import { TrackBoard } from "@/components/track/TrackBoard";
+
+export default function AdminTrack() {
+  const { state, connected } = useFdSession();
+  const trains = state?.trains ?? [];
+
+  return (
+    <div className="max-w-3xl space-y-5">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Track</h1>
+        <span
+          className={`text-xs ${connected ? "text-emerald-400" : "text-amber-400"}`}
+        >
+          {connected ? "● live" : "○ reconnecting"}
+        </span>
+      </div>
+      <p className="text-sm text-slate-400">
+        Mark Block occupancy and allocate Sections to trains. Changes broadcast
+        live to every connected screen.
+      </p>
+      {!state?.session ? (
+        <p className="text-sm text-slate-400">
+          No active session.{" "}
+          <a href="/admin/session" className="text-sky-400 hover:underline">
+            Create one →
+          </a>
+        </p>
+      ) : (
+        <TrackBoard trains={trains} canControl />
+      )}
+    </div>
+  );
+}

--- a/components/admin/AdminShell.tsx
+++ b/components/admin/AdminShell.tsx
@@ -9,6 +9,7 @@ const NAV = [
   { href: "/admin", label: "Dashboard" },
   { href: "/admin/session", label: "Session" },
   { href: "/admin/layouts", label: "Layouts" },
+  { href: "/admin/track", label: "Track" },
   { href: "/admin/trains", label: "Trains" },
   { href: "/admin/modules", label: "Modules" },
   { href: "/admin/settings", label: "Settings" },

--- a/components/track/TrackBoard.tsx
+++ b/components/track/TrackBoard.tsx
@@ -1,0 +1,212 @@
+/**
+ * TrackBoard (#80) — the live dispatcher track view, shared by the admin console
+ * and the mobile dispatch screen. Renders the session's layout (District →
+ * Section → Block) with manual Block occupancy and Section allocation, kept live
+ * via useTrackBoard's SSE subscription.
+ */
+"use client";
+
+import { useState } from "react";
+import { apiSend } from "@/lib/client/api";
+import { useTrackBoard, type SectionNode } from "@/lib/client/useTrackBoard";
+import type { TrainRow } from "@/lib/client/types";
+
+type Direction = "AtoB" | "BtoA";
+const DIR_LABEL: Record<Direction, string> = { AtoB: "A→B", BtoA: "B→A" };
+
+export function TrackBoard({
+  trains,
+  canControl,
+}: {
+  trains: TrainRow[];
+  canControl: boolean;
+}) {
+  const { layout, occupancy, allocations, loading, refresh } = useTrackBoard();
+  const [busy, setBusy] = useState(false);
+  // Per-section pending allocation selection (train + direction).
+  const [sel, setSel] = useState<
+    Record<string, { trainId?: string; direction: Direction }>
+  >({});
+
+  const trainLabel = (id: string) => {
+    const t = trains.find((x) => x.id === id);
+    return t ? `${t.number}${t.name ? " · " + t.name : ""}` : "train";
+  };
+
+  async function act(fn: () => Promise<unknown>) {
+    setBusy(true);
+    try {
+      await fn();
+      await refresh();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "action failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  const toggleBlock = (blockId: string, occupied: boolean) =>
+    act(() =>
+      apiSend("POST", "/api/track/occupancy", { blockId, occupied: !occupied }),
+    );
+
+  const allocate = (section: SectionNode) => {
+    const s = sel[section.id];
+    if (!s?.trainId) return;
+    return act(() =>
+      apiSend("POST", "/api/track/allocate", {
+        sectionIds: [section.id],
+        trainId: s.trainId,
+        direction: s.direction,
+      }),
+    );
+  };
+
+  const release = (sectionId: string) =>
+    act(() => apiSend("POST", "/api/track/release", { sectionId }));
+
+  if (loading) {
+    return <p className="text-sm text-slate-400">Loading track…</p>;
+  }
+  if (!layout) {
+    return (
+      <p className="text-sm text-slate-400">
+        No layout attached to this session. Attach one from{" "}
+        <a href="/admin/layouts" className="text-sky-400 hover:underline">
+          Layouts
+        </a>
+        .
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      {layout.districts.map((d) => (
+        <section key={d.id}>
+          <h3 className="mb-1.5 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            {d.name}
+          </h3>
+          <div className="space-y-2">
+            {d.sections.map((section) => {
+              const alloc = allocations[section.id];
+              const pending = sel[section.id] ?? { direction: "AtoB" as Direction };
+              return (
+                <div
+                  key={section.id}
+                  className="rounded-lg border border-slate-800 bg-slate-900/40 p-3"
+                >
+                  <div className="mb-2 flex items-center gap-2">
+                    <span className="font-medium text-slate-200">
+                      {section.name}
+                    </span>
+                    {section.track && (
+                      <span className="rounded bg-slate-800 px-1.5 py-0.5 text-xs text-slate-400">
+                        {section.track}
+                      </span>
+                    )}
+                    {alloc && (
+                      <span className="ml-auto rounded bg-indigo-600/20 px-2 py-0.5 text-xs font-medium text-indigo-300">
+                        {trainLabel(alloc.trainId)} · {DIR_LABEL[alloc.direction]}
+                      </span>
+                    )}
+                  </div>
+
+                  {/* Blocks */}
+                  <div className="flex flex-wrap gap-1.5">
+                    {section.blocks.length === 0 ? (
+                      <span className="text-xs text-slate-600">no blocks</span>
+                    ) : (
+                      section.blocks.map((b) => {
+                        const occ = occupancy[b.id]?.occupied ?? false;
+                        return (
+                          <button
+                            key={b.id}
+                            disabled={!canControl || busy}
+                            onClick={() => toggleBlock(b.id, occ)}
+                            title={
+                              canControl ? "Toggle occupancy" : "Occupancy"
+                            }
+                            className={`rounded px-2 py-1 text-xs font-medium transition ${
+                              occ
+                                ? "bg-red-600/30 text-red-200 ring-1 ring-red-600/50"
+                                : "bg-slate-800 text-slate-300"
+                            } ${canControl ? "hover:brightness-125" : "cursor-default"} disabled:opacity-60`}
+                          >
+                            {b.name}
+                          </button>
+                        );
+                      })
+                    )}
+                  </div>
+
+                  {/* Allocation control */}
+                  {canControl && (
+                    <div className="mt-2 flex items-center gap-2">
+                      {alloc ? (
+                        <button
+                          disabled={busy}
+                          onClick={() => release(section.id)}
+                          className="rounded-md border border-slate-700 px-2.5 py-1 text-xs font-medium text-slate-300 hover:bg-slate-800 disabled:opacity-50"
+                        >
+                          Release
+                        </button>
+                      ) : (
+                        <>
+                          <select
+                            value={pending.trainId ?? ""}
+                            onChange={(e) =>
+                              setSel((p) => ({
+                                ...p,
+                                [section.id]: {
+                                  ...pending,
+                                  trainId: e.target.value || undefined,
+                                },
+                              }))
+                            }
+                            className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-xs text-slate-100"
+                          >
+                            <option value="">Train…</option>
+                            {trains.map((t) => (
+                              <option key={t.id} value={t.id}>
+                                {t.number}
+                                {t.name ? ` · ${t.name}` : ""}
+                              </option>
+                            ))}
+                          </select>
+                          <select
+                            value={pending.direction}
+                            onChange={(e) =>
+                              setSel((p) => ({
+                                ...p,
+                                [section.id]: {
+                                  ...pending,
+                                  direction: e.target.value as Direction,
+                                },
+                              }))
+                            }
+                            className="rounded border border-slate-700 bg-slate-800 px-2 py-1 text-xs text-slate-100"
+                          >
+                            <option value="AtoB">A→B</option>
+                            <option value="BtoA">B→A</option>
+                          </select>
+                          <button
+                            disabled={busy || !pending.trainId}
+                            onClick={() => allocate(section)}
+                            className="rounded-md bg-sky-600 px-2.5 py-1 text-xs font-semibold text-white hover:bg-sky-500 disabled:opacity-40"
+                          >
+                            Allocate
+                          </button>
+                        </>
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        </section>
+      ))}
+    </div>
+  );
+}

--- a/lib/client/types.ts
+++ b/lib/client/types.ts
@@ -12,6 +12,7 @@ export interface SessionRow {
   name: string;
   date: string | null;
   venue: string | null;
+  layoutId: string | null;
   layoutConfigId: string | null;
   status: SessionStatus;
   createdAt: string;

--- a/lib/client/useTrackBoard.ts
+++ b/lib/client/useTrackBoard.ts
@@ -1,0 +1,121 @@
+/**
+ * useTrackBoard — live track model for the dispatcher view (#80).
+ *
+ * Loads the active session's layout tree + runtime state (block occupancy,
+ * section allocations), then keeps them live by subscribing to the track SSE
+ * events. Self-contained so the board can render on any surface.
+ */
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+import { apiGet } from "./api";
+
+export interface BlockNode {
+  id: string;
+  name: string;
+  moduleRecordNumber: string | null;
+}
+export interface SectionNode {
+  id: string;
+  name: string;
+  track: string | null;
+  blocks: BlockNode[];
+}
+export interface DistrictNode {
+  id: string;
+  name: string;
+  sections: SectionNode[];
+}
+export interface LayoutTree {
+  id: string;
+  name: string;
+  districts: DistrictNode[];
+}
+export interface OccupancyRow {
+  blockId: string;
+  occupied: boolean;
+  trainId: string | null;
+}
+export interface AllocationRow {
+  id: string;
+  sectionId: string;
+  trainId: string;
+  direction: "AtoB" | "BtoA";
+}
+
+const TRACK_EVENTS = [
+  "block_occupancy_changed",
+  "section_allocated",
+  "section_released",
+];
+const SESSION_EVENTS = ["session_start", "session_archived"];
+
+export interface UseTrackBoard {
+  layout: LayoutTree | null;
+  /** blockId → occupancy row (only present blocks). */
+  occupancy: Record<string, OccupancyRow>;
+  /** sectionId → active allocation. */
+  allocations: Record<string, AllocationRow>;
+  loading: boolean;
+  refresh: () => Promise<void>;
+}
+
+export function useTrackBoard(): UseTrackBoard {
+  const [layout, setLayout] = useState<LayoutTree | null>(null);
+  const [occupancy, setOccupancy] = useState<Record<string, OccupancyRow>>({});
+  const [allocations, setAllocations] = useState<Record<string, AllocationRow>>(
+    {},
+  );
+  const [loading, setLoading] = useState(true);
+
+  const loadState = useCallback(async () => {
+    const st = await apiGet<{
+      occupancy: OccupancyRow[];
+      allocations: AllocationRow[];
+    }>("/api/track/state");
+    setOccupancy(Object.fromEntries(st.occupancy.map((o) => [o.blockId, o])));
+    setAllocations(
+      Object.fromEntries(st.allocations.map((a) => [a.sectionId, a])),
+    );
+  }, []);
+
+  const loadLayout = useCallback(async () => {
+    const s = await apiGet<{ session: { layoutId: string | null } | null }>(
+      "/api/session",
+    );
+    const layoutId = s.session?.layoutId ?? null;
+    if (!layoutId) {
+      setLayout(null);
+      return;
+    }
+    const { layout } = await apiGet<{ layout: LayoutTree }>(
+      `/api/layouts/${layoutId}`,
+    );
+    setLayout(layout);
+  }, []);
+
+  const refresh = useCallback(async () => {
+    await Promise.all([loadLayout(), loadState()]);
+    setLoading(false);
+  }, [loadLayout, loadState]);
+
+  useEffect(() => {
+    // Initial load + subscribe. refresh()/loadState() setState after an await.
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    void refresh();
+
+    const es = new EventSource("/api/events");
+    const onTrack = () => void loadState();
+    const onSession = () => void refresh();
+    for (const t of TRACK_EVENTS) es.addEventListener(t, onTrack);
+    for (const t of SESSION_EVENTS) es.addEventListener(t, onSession);
+
+    return () => {
+      for (const t of TRACK_EVENTS) es.removeEventListener(t, onTrack);
+      for (const t of SESSION_EVENTS) es.removeEventListener(t, onSession);
+      es.close();
+    };
+  }, [refresh, loadState]);
+
+  return { layout, occupancy, allocations, loading, refresh };
+}


### PR DESCRIPTION
## What

The **live dispatcher track view** — the piece that turns the #80 track model into
a working dispatcher board. A shared `TrackBoard` renders the active session's
layout (District → Section → Block) with:

- **Block occupancy** — click a block to toggle occupied (turns red), manual in v1
- **Section allocation** — pick a train + direction, allocate a section; shows
  `train · direction` with a **Release**; the server enforces one active
  allocation per section

Live via a new `useTrackBoard` hook that refetches on the track SSE events
(`block_occupancy_changed`, `section_allocated`, `section_released`).

Runs on **both surfaces** (shared component): a new admin **Track** page and the
mobile **dispatch** screen.

## Verified in the browser

Seeded a session + attached the "Test Mainline" layout + a train, then on the Track
page:
- Toggled **Block 1A** → turned red (occupied) ✓
- Allocated **Section 1** to **101 · Local**, A→B → badge shown, controls collapsed
  to **Release** ✓
- **Released** → allocate controls returned ✓
- No console errors.

_(Screenshots in the PR conversation.)_

## Changes
- `lib/client/useTrackBoard.ts` — live layout + track-state hook
- `components/track/TrackBoard.tsx` — the shared board
- `app/admin/track/page.tsx` + "Track" nav
- `app/(mobile)/dispatch` — board added
- `lib/client/types.ts` — `layoutId` on `SessionRow`

## Test
Full suite (50) + typecheck + lint + `next build` green.

## Scope
Advances **#78 / #79** on the #80 model. Next candidates: multi-section route
allocation, train position (#82), virtual signals (#83).
