### PR TITLE
fix: make the host control-panel window resizable

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -174,8 +174,10 @@ function fetchServerInfo(host) {
 function createWindow() {
   win = new BrowserWindow({
     width: 520,
-    height: 640,
-    resizable: false,
+    height: 720,
+    minWidth: 420,
+    minHeight: 480,
+    resizable: true,
     title: "Free Dispatcher — Host",
     webPreferences: { preload: path.join(__dirname, "preload.js") },
   });


### PR DESCRIPTION
## What

The tray/host window was hardcoded `resizable: false` at 520×640. The update
controls added in #99 (Check now + interval) pushed the content past 640px, so it
scrolled and couldn''t be resized.

- `resizable: true`
- `minWidth: 420`, `minHeight: 480` so it can''t shrink to uselessness
- default height 640 → **720** so the content fits without scrolling out of the box

## Verification

Electron main-process config (BrowserWindow) — not exercisable in a browser
preview; `node --check` passes. Visible in the next packaged/dev run.