### PR TITLE
feat: virtual signals — APB-style aspects from occupancy + allocation (#83)

### DIFF
--- a/components/track/TrackBoard.tsx
+++ b/components/track/TrackBoard.tsx
@@ -14,6 +14,11 @@
 import { useState } from "react";
 import { apiSend } from "@/lib/client/api";
 import { useTrackBoard } from "@/lib/client/useTrackBoard";
+import {
+  deriveSectionAspect,
+  ASPECT_META,
+  ASPECT_ORDER,
+} from "@/lib/track/signals";
 import type { TrainRow } from "@/lib/client/types";
 
 type Direction = "AtoB" | "BtoA";
@@ -93,8 +98,25 @@ export function TrackBoard({
     );
   }
 
+  const occupiedBlocks = new Set(
+    Object.values(occupancy)
+      .filter((o) => o.occupied)
+      .map((o) => o.blockId),
+  );
+
   return (
     <div className="space-y-4">
+      {/* Signal legend */}
+      <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
+        <span className="font-medium text-slate-500">Signals:</span>
+        {ASPECT_ORDER.map((a) => (
+          <span key={a} className="flex items-center gap-1.5">
+            <span className={`h-2 w-2 rounded-full ${ASPECT_META[a].dot}`} />
+            {ASPECT_META[a].label}
+          </span>
+        ))}
+      </div>
+
       {/* Route allocation bar — appears once sections are selected. */}
       {canControl && selected.size > 0 && (
         <div className="sticky top-2 z-10 flex flex-wrap items-center gap-2 rounded-lg border border-sky-800/60 bg-slate-900 p-2.5 shadow-lg">
@@ -147,6 +169,11 @@ export function TrackBoard({
             {d.sections.map((section) => {
               const alloc = allocations[section.id];
               const isSelected = selected.has(section.id);
+              const aspect = deriveSectionAspect(
+                section.blocks.map((b) => b.id),
+                occupiedBlocks,
+                !!alloc,
+              );
               return (
                 <div
                   key={section.id}
@@ -155,6 +182,10 @@ export function TrackBoard({
                   }`}
                 >
                   <div className="mb-2 flex items-center gap-2">
+                    <span
+                      className={`h-2.5 w-2.5 shrink-0 rounded-full ${ASPECT_META[aspect].dot}`}
+                      title={`Signal: ${ASPECT_META[aspect].label}`}
+                    />
                     {canControl && !alloc && (
                       <input
                         type="checkbox"

--- a/lib/track/__tests__/signals.test.ts
+++ b/lib/track/__tests__/signals.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { deriveSectionAspect } from "../signals";
+
+describe("deriveSectionAspect (#83 virtual signals)", () => {
+  it("is occupied when any block is occupied — regardless of allocation", () => {
+    const occ = new Set(["b2"]);
+    expect(deriveSectionAspect(["b1", "b2"], occ, false)).toBe("occupied");
+    // occupancy wins over allocation
+    expect(deriveSectionAspect(["b1", "b2"], occ, true)).toBe("occupied");
+  });
+
+  it("is allocated when held but not occupied", () => {
+    expect(deriveSectionAspect(["b1"], new Set(), true)).toBe("allocated");
+  });
+
+  it("is clear when free and unallocated", () => {
+    expect(deriveSectionAspect(["b1"], new Set(), false)).toBe("clear");
+  });
+
+  it("treats an empty block list by allocation only", () => {
+    expect(deriveSectionAspect([], new Set(), true)).toBe("allocated");
+    expect(deriveSectionAspect([], new Set(), false)).toBe("clear");
+  });
+});

--- a/lib/track/signals.ts
+++ b/lib/track/signals.ts
@@ -1,0 +1,40 @@
+/**
+ * Virtual signals (#83) — simple APB-style indications derived from track state.
+ *
+ * v1 signals are computed, not stored: a Section's aspect follows its occupancy
+ * and allocation (no JMRI/LCC hardware; that's the later #55 layer). Pure so it
+ * unit-tests without a database.
+ *
+ *   occupied  — a Block in the Section is occupied (a train is there)  → Stop
+ *   allocated — held by a train but not yet occupied (authority granted) → protected
+ *   clear     — free and unallocated → available
+ */
+
+export type SignalAspect = "clear" | "allocated" | "occupied";
+
+/** Derive a Section's aspect from its blocks' occupancy and whether it's held. */
+export function deriveSectionAspect(
+  blockIds: string[],
+  occupiedBlockIds: ReadonlySet<string>,
+  isAllocated: boolean,
+): SignalAspect {
+  if (blockIds.some((id) => occupiedBlockIds.has(id))) return "occupied";
+  if (isAllocated) return "allocated";
+  return "clear";
+}
+
+export interface AspectMeta {
+  label: string;
+  /** Tailwind class for the signal dot. */
+  dot: string;
+  /** Tailwind class for accompanying text. */
+  text: string;
+}
+
+export const ASPECT_META: Record<SignalAspect, AspectMeta> = {
+  clear: { label: "Clear", dot: "bg-emerald-500", text: "text-emerald-300" },
+  allocated: { label: "Allocated", dot: "bg-amber-400", text: "text-amber-300" },
+  occupied: { label: "Occupied", dot: "bg-red-500", text: "text-red-300" },
+};
+
+export const ASPECT_ORDER: SignalAspect[] = ["clear", "allocated", "occupied"];


### PR DESCRIPTION
## What

Virtual **APB-style signals** on the dispatcher board — each Section shows an
aspect **auto-derived** from its live occupancy + allocation (answering #83's open
question: computed, not manually set). No hardware — that's the later #55 layer.

| Aspect | When | Colour |
|---|---|---|
| **Occupied** | a block in the section is occupied | 🔴 red |
| **Allocated** | held by a train, not yet occupied (protected) | 🟡 amber |
| **Clear** | free and unallocated | 🟢 green |

Occupancy overrides allocation. Rendered as a per-section signal dot + a legend.

## How
- `lib/track/signals.ts` — pure `deriveSectionAspect()` + aspect metadata (unit
  tested, no DB).
- `TrackBoard` computes each section's aspect from the state it already has and
  shows the dot; updates live via the existing SSE refresh.

## Verified in the browser
Allocated section → **amber**; marked a block occupied → turned **red** (overrode
allocation); released a section → **green**. Live, no console errors.

## Test
4 new signal unit tests; full suite **54** + typecheck + lint + `next build` green.

## Scope
Advances **#83** (signals). **Turnout state** is the remaining slice of #83.
