### PR TITLE
feat: turnout backend — virtual turnout state + positions (#83)

### DIFF
--- a/app/api/track/turnout/route.ts
+++ b/app/api/track/turnout/route.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/track/turnout — set a turnout's position for the active session
+ *   (Admin/Dispatcher/Yardmaster). Body: { turnoutId, position: "normal" | "reversed" }
+ *   (#83, manual in v1).
+ */
+import { NextResponse } from "next/server";
+import { trackModel } from "@/lib/server/TrackModel";
+import { requireRole } from "@/lib/server/guard";
+import type { TurnoutPosition } from "@/lib/db/schema";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+const POSITIONS: TurnoutPosition[] = ["normal", "reversed"];
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin", "dispatcher", "yardmaster"]);
+  if (!guard.ok) return guard.response;
+
+  let body: { turnoutId?: string; position?: TurnoutPosition };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  if (!body.turnoutId || !body.position || !POSITIONS.includes(body.position)) {
+    return NextResponse.json(
+      { error: "turnoutId and position ('normal' | 'reversed') are required" },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const row = await trackModel.setTurnoutPosition(
+      body.turnoutId,
+      body.position,
+      guard.claims.operatorId,
+    );
+    return NextResponse.json({ turnout: row });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : "turnout update failed";
+    return NextResponse.json({ error: message }, { status: 409 });
+  }
+}

--- a/lib/db/__tests__/migrations.test.ts
+++ b/lib/db/__tests__/migrations.test.ts
@@ -70,4 +70,37 @@ describe("database migrations", () => {
 
     await client.close();
   });
+
+  it("stores one turnout position per session (unique) — #83", async () => {
+    const client = new PGlite();
+    const db = drizzle(client);
+    await migrate(db, { migrationsFolder: "./lib/db/migrations" });
+
+    const L = "00000000-0000-0000-0000-0000000000a1";
+    const D = "00000000-0000-0000-0000-0000000000a2";
+    const TO = "00000000-0000-0000-0000-0000000000a3";
+    const SESS = "00000000-0000-0000-0000-0000000000a4";
+
+    await client.query(`insert into layouts (id, name) values ('${L}', 'L')`);
+    await client.query(`insert into districts (id, layout_id, name) values ('${D}', '${L}', 'D')`);
+    await client.query(`insert into turnouts (id, district_id, name) values ('${TO}', '${D}', 'Sw 1')`);
+    await client.query(`insert into sessions (id, name) values ('${SESS}', 'S')`);
+
+    await client.query(
+      `insert into turnout_positions (session_id, turnout_id, position) values ('${SESS}', '${TO}', 'reversed')`,
+    );
+    // A second position row for the same (session, turnout) is rejected.
+    await expect(
+      client.query(
+        `insert into turnout_positions (session_id, turnout_id, position) values ('${SESS}', '${TO}', 'normal')`,
+      ),
+    ).rejects.toThrow();
+
+    const res = await client.query<{ position: string }>(
+      `select position from turnout_positions where turnout_id = '${TO}'`,
+    );
+    expect(res.rows[0].position).toBe("reversed");
+
+    await client.close();
+  });
 });

--- a/lib/db/migrations/0006_broad_rage.sql
+++ b/lib/db/migrations/0006_broad_rage.sql
@@ -1,0 +1,22 @@
+CREATE TABLE "turnout_positions" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"session_id" uuid NOT NULL,
+	"turnout_id" uuid NOT NULL,
+	"position" text DEFAULT 'normal' NOT NULL,
+	"updated_by" text,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE "turnouts" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"district_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "turnout_positions" ADD CONSTRAINT "turnout_positions_session_id_sessions_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."sessions"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "turnout_positions" ADD CONSTRAINT "turnout_positions_turnout_id_turnouts_id_fk" FOREIGN KEY ("turnout_id") REFERENCES "public"."turnouts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "turnouts" ADD CONSTRAINT "turnouts_district_id_districts_id_fk" FOREIGN KEY ("district_id") REFERENCES "public"."districts"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE UNIQUE INDEX "turnout_positions_session_turnout" ON "turnout_positions" USING btree ("session_id","turnout_id");--> statement-breakpoint
+CREATE INDEX "turnout_positions_session_idx" ON "turnout_positions" USING btree ("session_id");--> statement-breakpoint
+CREATE INDEX "turnouts_district_idx" ON "turnouts" USING btree ("district_id");

--- a/lib/db/migrations/meta/0006_snapshot.json
+++ b/lib/db/migrations/meta/0006_snapshot.json
@@ -1,0 +1,1706 @@
+{
+  "id": "f3a8078a-085a-41c0-98a7-952c622def6c",
+  "prevId": "3c03f2cf-4692-411d-a5b9-eb177cec28fb",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authority_log": {
+      "name": "authority_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_operator": {
+          "name": "by_operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "authority_log_session_idx": {
+          "name": "authority_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authority_log_session_id_sessions_id_fk": {
+          "name": "authority_log_session_id_sessions_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authority_log_train_id_trains_id_fk": {
+          "name": "authority_log_train_id_trains_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_occupancy": {
+      "name": "block_occupancy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occupied": {
+          "name": "occupied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_occupancy_session_block": {
+          "name": "block_occupancy_session_block",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_occupancy_session_idx": {
+          "name": "block_occupancy_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "block_occupancy_session_id_sessions_id_fk": {
+          "name": "block_occupancy_session_id_sessions_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_block_id_blocks_id_fk": {
+          "name": "block_occupancy_block_id_blocks_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_train_id_trains_id_fk": {
+          "name": "block_occupancy_train_id_trains_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "module_record_number": {
+          "name": "module_record_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_section_idx": {
+          "name": "blocks_section_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_section_id_sections_id_fk": {
+          "name": "blocks_section_id_sections_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.districts": {
+      "name": "districts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "districts_layout_idx": {
+          "name": "districts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "districts_layout_id_layouts_id_fk": {
+          "name": "districts_layout_id_layouts_id_fk",
+          "tableFrom": "districts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layouts": {
+      "name": "layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_layouts": {
+      "name": "module_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "staging_end": {
+          "name": "staging_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "module_layouts_session_idx": {
+          "name": "module_layouts_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_layouts_session_id_sessions_id_fk": {
+          "name": "module_layouts_session_id_sessions_id_fk",
+          "tableFrom": "module_layouts",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "operators_session_idx": {
+          "name": "operators_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operators_device_idx": {
+          "name": "operators_device_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operators_session_id_sessions_id_fk": {
+          "name": "operators_session_id_sessions_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ops_log": {
+      "name": "ops_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ops_log_session_idx": {
+          "name": "ops_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ops_log_session_id_sessions_id_fk": {
+          "name": "ops_log_session_id_sessions_id_fk",
+          "tableFrom": "ops_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_modules": {
+      "name": "repo_modules",
+      "schema": "",
+      "columns": {
+        "record_number": {
+          "name": "record_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_type": {
+          "name": "geometry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "length_total_inches": {
+          "name": "length_total_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mainline_length_inches": {
+          "name": "mainline_length_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplate_count": {
+          "name": "endplate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_mss": {
+          "name": "has_mss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mss_type": {
+          "name": "mss_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplates": {
+          "name": "endplates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industries": {
+          "name": "industries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_updated_at": {
+          "name": "upstream_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.section_allocations": {
+      "name": "section_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allocated_by": {
+          "name": "allocated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "section_allocations_session_idx": {
+          "name": "section_allocations_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_train_idx": {
+          "name": "section_allocations_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_active_section": {
+          "name": "section_allocations_active_section",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"section_allocations\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_allocations_session_id_sessions_id_fk": {
+          "name": "section_allocations_session_id_sessions_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_section_id_sections_id_fk": {
+          "name": "section_allocations_section_id_sections_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_train_id_trains_id_fk": {
+          "name": "section_allocations_train_id_trains_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sections_district_idx": {
+          "name": "sections_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sections_district_id_districts_id_fk": {
+          "name": "sections_district_id_districts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_config_id": {
+          "name": "layout_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_one_active": {
+          "name": "sessions_one_active",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_layout_id_layouts_id_fk": {
+          "name": "sessions_layout_id_layouts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_tracks": {
+      "name": "staging_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_train_id": {
+          "name": "assigned_train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staging_tracks_layout_idx": {
+          "name": "staging_tracks_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staging_tracks_layout_id_module_layouts_id_fk": {
+          "name": "staging_tracks_layout_id_module_layouts_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "module_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staging_tracks_assigned_train_id_trains_id_fk": {
+          "name": "staging_tracks_assigned_train_id_trains_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "assigned_train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.train_statuses": {
+      "name": "train_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yard'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_authority": {
+          "name": "has_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "train_statuses_train_idx": {
+          "name": "train_statuses_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "train_statuses_session_idx": {
+          "name": "train_statuses_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "train_statuses_train_id_trains_id_fk": {
+          "name": "train_statuses_train_id_trains_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "train_statuses_session_id_sessions_id_fk": {
+          "name": "train_statuses_session_id_sessions_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trains": {
+      "name": "trains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_address": {
+          "name": "dcc_address",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_type": {
+          "name": "dcc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consist_id": {
+          "name": "consist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment_type": {
+          "name": "equipment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_operator_id": {
+          "name": "assigned_operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trains_session_idx": {
+          "name": "trains_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trains_assigned_idx": {
+          "name": "trains_assigned_idx",
+          "columns": [
+            {
+              "expression": "assigned_operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trains_session_id_sessions_id_fk": {
+          "name": "trains_session_id_sessions_id_fk",
+          "tableFrom": "trains",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnout_positions": {
+      "name": "turnout_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turnout_id": {
+          "name": "turnout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnout_positions_session_turnout": {
+          "name": "turnout_positions_session_turnout",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turnout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "turnout_positions_session_idx": {
+          "name": "turnout_positions_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnout_positions_session_id_sessions_id_fk": {
+          "name": "turnout_positions_session_id_sessions_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turnout_positions_turnout_id_turnouts_id_fk": {
+          "name": "turnout_positions_turnout_id_turnouts_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "turnouts",
+          "columnsFrom": [
+            "turnout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnouts": {
+      "name": "turnouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnouts_district_idx": {
+          "name": "turnouts_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnouts_district_id_districts_id_fk": {
+          "name": "turnouts_district_id_districts_id_fk",
+          "tableFrom": "turnouts",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1783115633026,
       "tag": "0005_fluffy_omega_sentinel",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1783128090425,
+      "tag": "0006_broad_rage",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -40,6 +40,8 @@ export type StagingEnd = "A" | "B";
 // or reverse). Set per allocation (#80) so single-track sections work both ways
 // for meets and double-track mains carry parallel chains.
 export type SectionDirection = "AtoB" | "BtoA";
+// Virtual turnout state (#83) — normal (straight/main) or reversed (diverging).
+export type TurnoutPosition = "normal" | "reversed";
 
 // ---- layouts -------------------------------------------------------------
 // A layout is the reusable, static definition of a physical layout: its track
@@ -381,6 +383,55 @@ export const sectionAllocations = pgTable(
   ],
 );
 
+// ---- turnouts ------------------------------------------------------------
+// Static, layout-scoped turnouts within a District (#83). The switch position
+// itself is per-session runtime state (turnout_positions), like block occupancy.
+export const turnouts = pgTable(
+  "turnouts",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    districtId: uuid("district_id")
+      .notNull()
+      .references(() => districts.id, { onDelete: "cascade" }),
+    name: text("name").notNull(),
+    createdAt: timestamp("created_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [index("turnouts_district_idx").on(t.districtId)],
+);
+
+// ---- turnout_positions ---------------------------------------------------
+// This session's live position of a turnout (manual in v1). One row per
+// (session, turnout).
+export const turnoutPositions = pgTable(
+  "turnout_positions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    sessionId: uuid("session_id")
+      .notNull()
+      .references(() => sessions.id, { onDelete: "cascade" }),
+    turnoutId: uuid("turnout_id")
+      .notNull()
+      .references(() => turnouts.id, { onDelete: "cascade" }),
+    position: text("position")
+      .$type<TurnoutPosition>()
+      .notNull()
+      .default("normal"),
+    updatedBy: text("updated_by"),
+    updatedAt: timestamp("updated_at", { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+  },
+  (t) => [
+    uniqueIndex("turnout_positions_session_turnout").on(
+      t.sessionId,
+      t.turnoutId,
+    ),
+    index("turnout_positions_session_idx").on(t.sessionId),
+  ],
+);
+
 // ---- app_settings --------------------------------------------------------
 // Singleton-ish key/value store for Admin configuration (WiThrottle, server).
 // Not in spec §9 but required by the §3.3 settings screens; persisted
@@ -408,6 +459,8 @@ export const schema = {
   blocks,
   blockOccupancy,
   sectionAllocations,
+  turnouts,
+  turnoutPositions,
   appSettings,
   repoModules,
 };

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -21,7 +21,10 @@ import {
   blocks,
   blockOccupancy,
   sectionAllocations,
+  turnouts,
+  turnoutPositions,
   type SectionDirection,
+  type TurnoutPosition,
 } from "@/lib/db/schema";
 import { sessionManager } from "./SessionManager";
 
@@ -38,10 +41,14 @@ export interface SectionInput {
   position?: number;
   blocks?: BlockInput[];
 }
+export interface TurnoutInput {
+  name: string;
+}
 export interface DistrictInput {
   name: string;
   position?: number;
   sections?: SectionInput[];
+  turnouts?: TurnoutInput[];
 }
 export interface LayoutInput {
   name: string;
@@ -53,10 +60,12 @@ type BlockRow = typeof blocks.$inferSelect;
 type SectionRow = typeof sections.$inferSelect;
 type DistrictRow = typeof districts.$inferSelect;
 type LayoutRow = typeof layouts.$inferSelect;
+type TurnoutRow = typeof turnouts.$inferSelect;
 
 export interface LayoutTree extends LayoutRow {
   districts: (DistrictRow & {
     sections: (SectionRow & { blocks: BlockRow[] })[];
+    turnouts: TurnoutRow[];
   })[];
 }
 
@@ -80,12 +89,13 @@ export function assertSingleDistrict(
   return [...districtIds][0];
 }
 
-/** Nest flat district/section/block rows under a layout into a tree. */
+/** Nest flat district/section/block/turnout rows under a layout into a tree. */
 export function buildLayoutTree(
   layout: LayoutRow,
   districtRows: DistrictRow[],
   sectionRows: SectionRow[],
   blockRows: BlockRow[],
+  turnoutRows: TurnoutRow[] = [],
 ): LayoutTree {
   const byPos = <T extends { position: number }>(a: T, b: T) =>
     a.position - b.position;
@@ -101,6 +111,12 @@ export function buildLayoutTree(
     arr.push(s);
     sectionsByDistrict.set(s.districtId, arr);
   }
+  const turnoutsByDistrict = new Map<string, TurnoutRow[]>();
+  for (const t of turnoutRows) {
+    const arr = turnoutsByDistrict.get(t.districtId) ?? [];
+    arr.push(t);
+    turnoutsByDistrict.set(t.districtId, arr);
+  }
   return {
     ...layout,
     districts: [...districtRows].sort(byPos).map((d) => ({
@@ -109,6 +125,7 @@ export function buildLayoutTree(
         ...s,
         blocks: (blocksBySection.get(s.id) ?? []).sort(byPos),
       })),
+      turnouts: turnoutsByDistrict.get(d.id) ?? [],
     })),
   };
 }
@@ -154,6 +171,12 @@ class TrackModel {
             );
           }
         }
+
+        if (d.turnouts?.length) {
+          await tx.insert(turnouts).values(
+            d.turnouts.map((t) => ({ districtId: district.id, name: t.name })),
+          );
+        }
       }
       return layout.id;
     });
@@ -187,8 +210,11 @@ class TrackModel {
     const blockRows = sectionIds.length
       ? await db.select().from(blocks).where(inArray(blocks.sectionId, sectionIds))
       : [];
+    const turnoutRows = districtIds.length
+      ? await db.select().from(turnouts).where(inArray(turnouts.districtId, districtIds))
+      : [];
 
-    return buildLayoutTree(layout, districtRows, sectionRows, blockRows);
+    return buildLayoutTree(layout, districtRows, sectionRows, blockRows, turnoutRows);
   }
 
   // -- Runtime (active-session-scoped) ----------------------------------
@@ -214,6 +240,31 @@ class TrackModel {
 
     await sessionManager.broadcast(
       { type: "block_occupancy_changed", blockId, occupied, trainId },
+      session.id,
+    );
+    return row;
+  }
+
+  /** Set a turnout's position for the active session (upsert). */
+  async setTurnoutPosition(
+    turnoutId: string,
+    position: TurnoutPosition,
+    updatedBy: string | null,
+  ) {
+    const session = await sessionManager.getActiveSession();
+    if (!session) throw new Error("no active session");
+
+    const [row] = await db
+      .insert(turnoutPositions)
+      .values({ sessionId: session.id, turnoutId, position, updatedBy })
+      .onConflictDoUpdate({
+        target: [turnoutPositions.sessionId, turnoutPositions.turnoutId],
+        set: { position, updatedBy, updatedAt: new Date() },
+      })
+      .returning();
+
+    await sessionManager.broadcast(
+      { type: "turnout_changed", turnoutId, position },
       session.id,
     );
     return row;
@@ -310,12 +361,12 @@ class TrackModel {
     return released;
   }
 
-  /** Live occupancy + active allocations for the active session. */
+  /** Live occupancy + active allocations + turnout positions for the session. */
   async getSessionTrackState() {
     const session = await sessionManager.getActiveSession();
-    if (!session) return { occupancy: [], allocations: [] };
+    if (!session) return { occupancy: [], allocations: [], turnouts: [] };
 
-    const [occupancy, allocations] = await Promise.all([
+    const [occupancy, allocations, turnoutRows] = await Promise.all([
       db.select().from(blockOccupancy).where(eq(blockOccupancy.sessionId, session.id)),
       db
         .select()
@@ -326,8 +377,12 @@ class TrackModel {
             eq(sectionAllocations.active, true),
           ),
         ),
+      db
+        .select()
+        .from(turnoutPositions)
+        .where(eq(turnoutPositions.sessionId, session.id)),
     ]);
-    return { occupancy, allocations };
+    return { occupancy, allocations, turnouts: turnoutRows };
   }
 }
 

--- a/lib/server/__tests__/TrackModel.test.ts
+++ b/lib/server/__tests__/TrackModel.test.ts
@@ -51,6 +51,7 @@ describe("buildLayoutTree (#80)", () => {
         { id: "b1", sectionId: "s0", name: "Blk 2", position: 1, moduleRecordNumber: null, createdAt: new Date() },
         { id: "b0", sectionId: "s0", name: "Blk 1", position: 0, moduleRecordNumber: null, createdAt: new Date() },
       ],
+      [{ id: "t1", districtId: "d1", name: "Sw 1", createdAt: new Date() }],
     );
 
     // Districts sorted by position.
@@ -62,7 +63,10 @@ describe("buildLayoutTree (#80)", () => {
       "Blk 1",
       "Blk 2",
     ]);
-    // Empty district still renders with no sections.
+    // Turnouts nest under their district.
+    expect(tree.districts[0].turnouts.map((t) => t.name)).toEqual(["Sw 1"]);
+    // Empty district still renders with no sections or turnouts.
     expect(tree.districts[1].sections).toEqual([]);
+    expect(tree.districts[1].turnouts).toEqual([]);
   });
 });

--- a/lib/server/events.ts
+++ b/lib/server/events.ts
@@ -6,6 +6,7 @@ import type {
   OperatorRole,
   TrainStatus,
   SectionDirection,
+  TurnoutPosition,
 } from "@/lib/db/schema";
 
 export type FdEvent =
@@ -30,6 +31,7 @@ export type FdEvent =
       sectionId: string;
       trainId: string;
     }
+  | { type: "turnout_changed"; turnoutId: string; position: TurnoutPosition }
   | {
       type: "train_status_changed";
       trainId: string;


### PR DESCRIPTION
## What

The backend for **virtual turnouts** — the remaining slice of #83 (signals shipped
in #105). Backend first, mirroring the blocks/occupancy split; the board + authoring
UI follow in a second PR.

### Schema (migration 0006)
- **`turnouts`** — static, per-District (authored with the layout)
- **`turnout_positions`** — session-scoped, one row per (session, turnout), upsert;
  `normal | reversed`

### Service / API / SSE
- `TrackModel`: turnouts nest in the layout tree; `createLayout` accepts turnouts;
  `setTurnoutPosition` (upsert + broadcast); positions included in session track state.
- **`POST /api/track/turnout`** `{ turnoutId, position }` (role-gated)
- **`turnout_changed`** SSE event

## Test
- `buildLayoutTree` nests turnouts under their district.
- Migration test proves the tables apply and enforce **one position per
  session/turnout**.
- Full suite **55** + typecheck + lint + `next build` (route compiles) green.

## Scope
Advances **#83**. Follow-up PR: turnout authoring (in the Layouts page) + turnout
display/toggle on the dispatcher board.
