### PR TITLE
feat: turnout UI — author + toggle virtual turnouts (closes #83)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -22,10 +22,15 @@ interface SectionNode {
   track: string | null;
   blocks: BlockNode[];
 }
+interface TurnoutNode {
+  id: string;
+  name: string;
+}
 interface DistrictNode {
   id: string;
   name: string;
   sections: SectionNode[];
+  turnouts: TurnoutNode[];
 }
 interface LayoutTree extends LayoutRow {
   districts: DistrictNode[];
@@ -41,9 +46,13 @@ interface SectionDraft {
   track: string;
   blocks: BlockDraft[];
 }
+interface TurnoutDraft {
+  name: string;
+}
 interface DistrictDraft {
   name: string;
   sections: SectionDraft[];
+  turnouts: TurnoutDraft[];
 }
 interface LayoutDraft {
   name: string;
@@ -145,6 +154,9 @@ export default function AdminLayouts() {
                   moduleRecordNumber: b.moduleRecordNumber.trim() || undefined,
                 })),
             })),
+          turnouts: di.turnouts
+            .filter((t) => t.name.trim())
+            .map((t) => ({ name: t.name.trim() })),
         })),
     };
   }
@@ -247,6 +259,12 @@ export default function AdminLayouts() {
                                     </span>
                                   </li>
                                 ))}
+                                {d.turnouts.length > 0 && (
+                                  <li className="text-xs text-slate-500">
+                                    Turnouts:{" "}
+                                    {d.turnouts.map((t) => t.name).join(" · ")}
+                                  </li>
+                                )}
                               </ul>
                             </li>
                           ))}
@@ -440,13 +458,57 @@ export default function AdminLayouts() {
                     + Section
                   </button>
                 </div>
+
+                {/* Turnouts */}
+                <div className="mt-2 flex flex-wrap items-center gap-2 pl-4">
+                  <span className="text-xs uppercase text-slate-500">
+                    Turnouts
+                  </span>
+                  {district.turnouts.map((to, ti) => (
+                    <span key={ti} className="flex items-center gap-1">
+                      <input
+                        className={`${smInput} max-w-[8rem]`}
+                        placeholder="Name"
+                        value={to.name}
+                        onChange={(e) =>
+                          mutate(
+                            (d) =>
+                              (d.districts[di].turnouts[ti].name =
+                                e.target.value),
+                          )
+                        }
+                      />
+                      <button
+                        type="button"
+                        className={xBtn}
+                        onClick={() =>
+                          mutate((d) => d.districts[di].turnouts.splice(ti, 1))
+                        }
+                        title="Remove turnout"
+                      >
+                        ✕
+                      </button>
+                    </span>
+                  ))}
+                  <button
+                    type="button"
+                    className={addBtn}
+                    onClick={() =>
+                      mutate((d) => d.districts[di].turnouts.push({ name: "" }))
+                    }
+                  >
+                    + Turnout
+                  </button>
+                </div>
               </div>
             ))}
             <button
               type="button"
               className={addBtn}
               onClick={() =>
-                mutate((d) => d.districts.push({ name: "", sections: [] }))
+                mutate((d) =>
+                  d.districts.push({ name: "", sections: [], turnouts: [] }),
+                )
               }
             >
               + District

--- a/components/track/TrackBoard.tsx
+++ b/components/track/TrackBoard.tsx
@@ -31,7 +31,8 @@ export function TrackBoard({
   trains: TrainRow[];
   canControl: boolean;
 }) {
-  const { layout, occupancy, allocations, loading, refresh } = useTrackBoard();
+  const { layout, occupancy, allocations, turnoutPositions, loading, refresh } =
+    useTrackBoard();
   const [busy, setBusy] = useState(false);
   const [selected, setSelected] = useState<Set<string>>(new Set());
   const [routeTrainId, setRouteTrainId] = useState("");
@@ -82,6 +83,14 @@ export function TrackBoard({
 
   const release = (sectionId: string) =>
     act(() => apiSend("POST", "/api/track/release", { sectionId }));
+
+  const toggleTurnout = (turnoutId: string, current: "normal" | "reversed") =>
+    act(() =>
+      apiSend("POST", "/api/track/turnout", {
+        turnoutId,
+        position: current === "normal" ? "reversed" : "normal",
+      }),
+    );
 
   if (loading) {
     return <p className="text-sm text-slate-400">Loading track…</p>;
@@ -250,6 +259,34 @@ export function TrackBoard({
               );
             })}
           </div>
+
+          {/* Turnouts */}
+          {d.turnouts.length > 0 && (
+            <div className="mt-2 flex flex-wrap items-center gap-1.5">
+              <span className="text-xs text-slate-500">Turnouts:</span>
+              {d.turnouts.map((t) => {
+                const pos = turnoutPositions[t.id] ?? "normal";
+                const reversed = pos === "reversed";
+                return (
+                  <button
+                    key={t.id}
+                    disabled={!canControl || busy}
+                    onClick={() => toggleTurnout(t.id, pos)}
+                    title={`${t.name} — ${reversed ? "Reversed" : "Normal"}${
+                      canControl ? " (click to flip)" : ""
+                    }`}
+                    className={`rounded px-2 py-1 text-xs font-medium transition ${
+                      reversed
+                        ? "bg-amber-600/30 text-amber-200 ring-1 ring-amber-600/50"
+                        : "bg-slate-800 text-slate-300"
+                    } ${canControl ? "hover:brightness-125" : "cursor-default"} disabled:opacity-60`}
+                  >
+                    {t.name} · {reversed ? "R" : "N"}
+                  </button>
+                );
+              })}
+            </div>
+          )}
         </section>
       ))}
     </div>

--- a/lib/client/useTrackBoard.ts
+++ b/lib/client/useTrackBoard.ts
@@ -21,11 +21,17 @@ export interface SectionNode {
   track: string | null;
   blocks: BlockNode[];
 }
+export interface TurnoutNode {
+  id: string;
+  name: string;
+}
 export interface DistrictNode {
   id: string;
   name: string;
   sections: SectionNode[];
+  turnouts: TurnoutNode[];
 }
+export type TurnoutPosition = "normal" | "reversed";
 export interface LayoutTree {
   id: string;
   name: string;
@@ -42,11 +48,16 @@ export interface AllocationRow {
   trainId: string;
   direction: "AtoB" | "BtoA";
 }
+export interface TurnoutPositionRow {
+  turnoutId: string;
+  position: TurnoutPosition;
+}
 
 const TRACK_EVENTS = [
   "block_occupancy_changed",
   "section_allocated",
   "section_released",
+  "turnout_changed",
 ];
 const SESSION_EVENTS = ["session_start", "session_archived"];
 
@@ -56,6 +67,8 @@ export interface UseTrackBoard {
   occupancy: Record<string, OccupancyRow>;
   /** sectionId → active allocation. */
   allocations: Record<string, AllocationRow>;
+  /** turnoutId → position (only turnouts that have been set). */
+  turnoutPositions: Record<string, TurnoutPosition>;
   loading: boolean;
   refresh: () => Promise<void>;
 }
@@ -66,16 +79,23 @@ export function useTrackBoard(): UseTrackBoard {
   const [allocations, setAllocations] = useState<Record<string, AllocationRow>>(
     {},
   );
+  const [turnoutPositions, setTurnoutPositions] = useState<
+    Record<string, TurnoutPosition>
+  >({});
   const [loading, setLoading] = useState(true);
 
   const loadState = useCallback(async () => {
     const st = await apiGet<{
       occupancy: OccupancyRow[];
       allocations: AllocationRow[];
+      turnouts: TurnoutPositionRow[];
     }>("/api/track/state");
     setOccupancy(Object.fromEntries(st.occupancy.map((o) => [o.blockId, o])));
     setAllocations(
       Object.fromEntries(st.allocations.map((a) => [a.sectionId, a])),
+    );
+    setTurnoutPositions(
+      Object.fromEntries(st.turnouts.map((t) => [t.turnoutId, t.position])),
     );
   }, []);
 
@@ -117,5 +137,5 @@ export function useTrackBoard(): UseTrackBoard {
     };
   }, [refresh, loadState]);
 
-  return { layout, occupancy, allocations, loading, refresh };
+  return { layout, occupancy, allocations, turnoutPositions, loading, refresh };
 }


### PR DESCRIPTION
## What

The turnout UI on top of the #106 backend — and the piece that **closes #83**
(virtual signals shipped in #105).

- **Authoring** (Layouts page): add turnouts per district in the builder
  (**+ Turnout**); the expanded layout tree lists them.
- **Dispatcher board**: each district's turnouts render as chips with a
  **color-coded position** — normal (slate) / reversed (amber) — click to flip.
  Live via the `turnout_changed` SSE event.

## Verified in the browser

Authored **Turnout Test** (Yard → Lead, turnouts **Sw 7 / Sw 9**), attached it,
then on the board flipped **Sw 7 → Reversed (amber)** live while **Sw 9** stayed
Normal (slate). Authoring builder + layout tree both show the turnouts. No console
errors.

## Test
Full suite **55** + typecheck + lint + `next build` green.

## Closes
Closes #83 — virtual signals (#105) + turnouts, both auto/live on the dispatcher
board. The real (hardware) signal/turnout control remains the later #55 / LCC layer.
