### PR TITLE
fix: let a layout be removed from a session (pure detach, state preserved)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -114,13 +114,13 @@ export default function AdminLayouts() {
     }
   }
 
-  async function attachToSession(id: string) {
+  async function setSessionLayout(id: string | null) {
     setBusy(true);
     try {
       await apiSend("PATCH", "/api/session", { layoutId: id });
       await load();
     } catch (e) {
-      alert(e instanceof Error ? e.message : "attach failed");
+      alert(e instanceof Error ? e.message : "update failed");
     } finally {
       setBusy(false);
     }
@@ -216,18 +216,31 @@ export default function AdminLayouts() {
                         </span>
                       )}
                     </button>
-                    <button
-                      disabled={busy || isCurrent || !hasSession}
-                      onClick={() => attachToSession(l.id)}
-                      title={
-                        !hasSession
-                          ? "Start a session first"
-                          : "Attach this layout to the active session"
-                      }
-                      className="shrink-0 rounded-md border border-sky-700/60 px-2.5 py-1 text-xs font-medium text-sky-300 hover:bg-sky-900/30 disabled:opacity-40"
-                    >
-                      {isCurrent ? "Current" : "Use in session"}
-                    </button>
+                    {isCurrent ? (
+                      <button
+                        disabled={busy}
+                        onClick={() => setSessionLayout(null)}
+                        title="Remove this layout from the active session"
+                        className="shrink-0 rounded-md border border-slate-600 px-2.5 py-1 text-xs font-medium text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+                      >
+                        Remove from session
+                      </button>
+                    ) : (
+                      <button
+                        disabled={busy || !hasSession}
+                        onClick={() => setSessionLayout(l.id)}
+                        title={
+                          !hasSession
+                            ? "Start a session first"
+                            : sessionLayoutId
+                              ? "Switch the session to this layout"
+                              : "Attach this layout to the active session"
+                        }
+                        className="shrink-0 rounded-md border border-sky-700/60 px-2.5 py-1 text-xs font-medium text-sky-300 hover:bg-sky-900/30 disabled:opacity-40"
+                      >
+                        {sessionLayoutId ? "Switch to this" : "Use in session"}
+                      </button>
+                    )}
                   </div>
                   {expanded.has(l.id) && (
                     <div className="mt-2 pl-5 text-sm">

--- a/app/api/session/route.ts
+++ b/app/api/session/route.ts
@@ -81,10 +81,15 @@ export async function PATCH(req: Request) {
     return NextResponse.json({ error: "no active session" }, { status: 409 });
   }
 
+  // Pure attach/detach: the layout stays in the layouts list and the session's
+  // occupancy/allocations/turnouts are preserved, so re-attaching resumes them.
+  const layoutId = body.layoutId ?? null;
   const [updated] = await db
     .update(sessions)
-    .set({ layoutId: body.layoutId ?? null })
+    .set({ layoutId })
     .where(eq(sessions.id, session.id))
     .returning();
+
+  await sessionManager.broadcast({ type: "layout_changed", layoutId }, session.id);
   return NextResponse.json({ session: updated });
 }

--- a/lib/client/useTrackBoard.ts
+++ b/lib/client/useTrackBoard.ts
@@ -59,7 +59,7 @@ const TRACK_EVENTS = [
   "section_released",
   "turnout_changed",
 ];
-const SESSION_EVENTS = ["session_start", "session_archived"];
+const SESSION_EVENTS = ["session_start", "session_archived", "layout_changed"];
 
 export interface UseTrackBoard {
   layout: LayoutTree | null;

--- a/lib/server/events.ts
+++ b/lib/server/events.ts
@@ -12,6 +12,7 @@ import type {
 export type FdEvent =
   | { type: "session_start"; sessionId: string }
   | { type: "session_archived"; sessionId: string }
+  | { type: "layout_changed"; layoutId: string | null }
   | {
       type: "block_occupancy_changed";
       blockId: string;


### PR DESCRIPTION
## What

You couldn't remove a layout once it was attached to a session — the Layouts page
only offered attach/switch, and the attached one showed a disabled "Current". This
adds the missing detach.

- **"Remove from session"** button on the attached layout (PATCH `layoutId: null`).
- Other layouts read **"Switch to this"** when one is already attached.

## Pure detach — nothing is deleted

Removing (or switching) a layout is a **pure detach**:
- the layout **stays in the Layouts list**, and
- the session's **occupancy, section allocations and turnout positions are
  preserved** — so re-attaching the layout resumes exactly where you left off.

A `layout_changed` SSE event is broadcast so open dispatcher boards refresh to
show/hide the layout.

## Verified in the browser

Attached a layout, created state (1 allocation + 1 occupied block + 1 reversed
turnout), then removed the layout:
- `session.layoutId` → **null**, board shows "No layout attached"
- layout **still in the Layouts list**
- session state **preserved** (1 / 1 / 1 unchanged)

## Test
Full suite **55** + typecheck + lint + `next build` green.
