### PR TITLE
feat: drag-and-drop reorder of a layout's module sequence (#75)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -91,6 +91,9 @@ export default function AdminLayouts() {
   const [catalog, setCatalog] = useState<CatalogModule[]>([]);
   const [modQuery, setModQuery] = useState<Record<string, string>>({});
   const [modChecked, setModChecked] = useState<Record<string, string[]>>({});
+  const [drag, setDrag] = useState<{ layoutId: string; from: number } | null>(
+    null,
+  );
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -187,6 +190,28 @@ export default function AdminLayouts() {
       await Promise.all([reloadTree(layoutId), load()]);
     } catch (e) {
       alert(e instanceof Error ? e.message : "remove failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Reorder the module sequence after a drag from index → to index. */
+  async function moveModule(
+    layoutId: string,
+    ids: string[],
+    from: number,
+    to: number,
+  ) {
+    if (from === to || from < 0 || to < 0) return;
+    const orderedIds = [...ids];
+    const [moved] = orderedIds.splice(from, 1);
+    orderedIds.splice(to, 0, moved);
+    setBusy(true);
+    try {
+      await apiSend("POST", "/api/modules/reorder", { layoutId, orderedIds });
+      await Promise.all([reloadTree(layoutId), load()]);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "reorder failed");
     } finally {
       setBusy(false);
     }
@@ -336,8 +361,34 @@ export default function AdminLayouts() {
                                 {tree.modules.map((m, i) => (
                                   <li
                                     key={m.id}
-                                    className="flex items-center gap-2 rounded border border-slate-700 bg-slate-800/60 px-2 py-1"
+                                    draggable={!busy}
+                                    onDragStart={() =>
+                                      setDrag({ layoutId: l.id, from: i })
+                                    }
+                                    onDragOver={(e) => e.preventDefault()}
+                                    onDrop={() => {
+                                      if (drag && drag.layoutId === l.id)
+                                        moveModule(
+                                          l.id,
+                                          tree.modules.map((x) => x.id),
+                                          drag.from,
+                                          i,
+                                        );
+                                      setDrag(null);
+                                    }}
+                                    onDragEnd={() => setDrag(null)}
+                                    className={`flex items-center gap-2 rounded border border-slate-700 bg-slate-800/60 px-2 py-1 ${
+                                      drag?.layoutId === l.id && drag.from === i
+                                        ? "opacity-50"
+                                        : ""
+                                    }`}
                                   >
+                                    <span
+                                      className="shrink-0 cursor-grab select-none text-slate-600"
+                                      title="Drag to reorder"
+                                    >
+                                      ⠿
+                                    </span>
                                     <span className="w-5 shrink-0 text-right text-xs text-slate-500">
                                       {i + 1}
                                     </span>

--- a/app/api/modules/reorder/route.ts
+++ b/app/api/modules/reorder/route.ts
@@ -1,0 +1,44 @@
+/**
+ * POST /api/modules/reorder — set the module sequence order for a layout (Admin).
+ * Body: { layoutId, orderedIds: string[] } — module_layout row ids in the new
+ * order; each row's positionIndex is set to its index. Atomic (#75).
+ */
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { moduleLayouts } from "@/lib/db/schema";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+
+  let body: { layoutId?: string; orderedIds?: string[] };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  if (!body.layoutId?.trim() || !Array.isArray(body.orderedIds)) {
+    return NextResponse.json(
+      { error: "layoutId and orderedIds[] are required" },
+      { status: 400 },
+    );
+  }
+
+  const layoutId = body.layoutId.trim();
+  await db.transaction(async (tx) => {
+    for (const [index, id] of body.orderedIds!.entries()) {
+      await tx
+        .update(moduleLayouts)
+        .set({ positionIndex: index })
+        .where(
+          and(eq(moduleLayouts.id, id), eq(moduleLayouts.layoutId, layoutId)),
+        );
+    }
+  });
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## What

**Increment 1 of the drag-and-drop layout builder** (#75): the assigned modules in
a layout's editor are now **draggable to reorder** the sequence.

- Each assigned module row has a grip handle (⠿) and is `draggable`.
- Drop persists the new order via **`POST /api/modules/reorder`** `{ layoutId,
  orderedIds }`, which sets each `module_layout.positionIndex` atomically.
- Native HTML5 drag-and-drop — **no new dependency**.
- The form-based add/remove/staging controls are unchanged.

## Verified in the browser

Dragged a module from position 1 → 3 → the sequence persisted (**FMN-0001,
FMN-0003, FMN-0042**) and re-rendered live. No console errors.

## Test
Full suite **58** + typecheck + lint + `next build` green.

## Next (this initiative)
2. Drag sections/blocks between districts (#76)
3. To-scale schematic canvas (WYSIWYG epic)
4. Playwright end-to-end covering the whole flow
