### PR TITLE
feat: drag sections between and within districts (#76)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -94,6 +94,10 @@ export default function AdminLayouts() {
   const [drag, setDrag] = useState<{ layoutId: string; from: number } | null>(
     null,
   );
+  const [dragSection, setDragSection] = useState<{
+    layoutId: string;
+    sectionId: string;
+  } | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -190,6 +194,41 @@ export default function AdminLayouts() {
       await Promise.all([reloadTree(layoutId), load()]);
     } catch (e) {
       alert(e instanceof Error ? e.message : "remove failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Move a section to a district at an index; posts the full new arrangement. */
+  async function moveSection(
+    layoutId: string,
+    tree: LayoutTree,
+    sectionId: string,
+    toDistrictId: string,
+    toIndex: number,
+  ) {
+    const byDistrict = new Map<string, string[]>();
+    for (const d of tree.districts) byDistrict.set(d.id, d.sections.map((s) => s.id));
+    for (const ids of byDistrict.values()) {
+      const idx = ids.indexOf(sectionId);
+      if (idx >= 0) ids.splice(idx, 1);
+    }
+    const target = byDistrict.get(toDistrictId) ?? [];
+    target.splice(Math.min(Math.max(toIndex, 0), target.length), 0, sectionId);
+    byDistrict.set(toDistrictId, target);
+
+    const placements: { id: string; districtId: string; position: number }[] = [];
+    for (const [districtId, ids] of byDistrict)
+      ids.forEach((id, position) => placements.push({ id, districtId, position }));
+
+    setBusy(true);
+    try {
+      await apiSend("POST", "/api/track/sections/arrange", {
+        sections: placements,
+      });
+      await reloadTree(layoutId);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "move failed");
     } finally {
       setBusy(false);
     }
@@ -534,28 +573,93 @@ export default function AdminLayouts() {
                             ) : (
                               <ul className="space-y-1.5">
                                 {tree.districts.map((d) => (
-                                  <li key={d.id}>
+                                  <li
+                                    key={d.id}
+                                    onDragOver={(e) => {
+                                      if (dragSection?.layoutId === l.id)
+                                        e.preventDefault();
+                                    }}
+                                    onDrop={() => {
+                                      if (dragSection?.layoutId === l.id)
+                                        moveSection(
+                                          l.id,
+                                          tree,
+                                          dragSection.sectionId,
+                                          d.id,
+                                          d.sections.length,
+                                        );
+                                      setDragSection(null);
+                                    }}
+                                    className={`rounded ${
+                                      dragSection?.layoutId === l.id
+                                        ? "ring-1 ring-slate-700"
+                                        : ""
+                                    }`}
+                                  >
                                     <div className="font-medium text-slate-300">
                                       {d.name}
                                     </div>
                                     <ul className="ml-3 space-y-0.5 text-slate-400">
-                                      {d.sections.map((s) => (
-                                        <li key={s.id}>
+                                      {d.sections.map((s, si) => (
+                                        <li
+                                          key={s.id}
+                                          draggable={!busy}
+                                          onDragStart={(e) => {
+                                            e.stopPropagation();
+                                            setDragSection({
+                                              layoutId: l.id,
+                                              sectionId: s.id,
+                                            });
+                                          }}
+                                          onDragOver={(e) => {
+                                            if (dragSection?.layoutId === l.id)
+                                              e.preventDefault();
+                                          }}
+                                          onDrop={(e) => {
+                                            e.stopPropagation();
+                                            if (
+                                              dragSection?.layoutId === l.id &&
+                                              dragSection.sectionId !== s.id
+                                            )
+                                              moveSection(
+                                                l.id,
+                                                tree,
+                                                dragSection.sectionId,
+                                                d.id,
+                                                si,
+                                              );
+                                            setDragSection(null);
+                                          }}
+                                          onDragEnd={() => setDragSection(null)}
+                                          className={`flex items-center gap-1.5 rounded px-1 ${
+                                            dragSection?.sectionId === s.id
+                                              ? "opacity-50"
+                                              : "hover:bg-slate-800/40"
+                                          }`}
+                                        >
+                                          <span className="cursor-grab select-none text-slate-600">
+                                            ⠿
+                                          </span>
                                           <span className="text-slate-300">
                                             {s.name}
                                           </span>
                                           {s.track && (
-                                            <span className="ml-1 text-xs text-slate-500">
+                                            <span className="text-xs text-slate-500">
                                               ({s.track})
                                             </span>
                                           )}
-                                          <span className="ml-2 text-xs text-slate-500">
+                                          <span className="text-xs text-slate-500">
                                             {s.blocks
                                               .map((b) => b.name)
                                               .join(" · ") || "no blocks"}
                                           </span>
                                         </li>
                                       ))}
+                                      {d.sections.length === 0 && (
+                                        <li className="text-xs italic text-slate-600">
+                                          (drop a section here)
+                                        </li>
+                                      )}
                                       {d.turnouts.length > 0 && (
                                         <li className="text-xs text-slate-500">
                                           Turnouts:{" "}

--- a/app/api/track/sections/arrange/route.ts
+++ b/app/api/track/sections/arrange/route.ts
@@ -1,0 +1,54 @@
+/**
+ * POST /api/track/sections/arrange — re-parent and re-order sections across a
+ * layout's districts in one shot (Admin, #76). Body:
+ *   { sections: { id, districtId, position }[] }
+ * Applied atomically; the client sends the full new arrangement after a drag.
+ */
+import { NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db/client";
+import { sections } from "@/lib/db/schema";
+import { requireRole } from "@/lib/server/guard";
+
+export const dynamic = "force-dynamic";
+export const runtime = "nodejs";
+
+interface Placement {
+  id: string;
+  districtId: string;
+  position: number;
+}
+
+export async function POST(req: Request) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+
+  let body: { sections?: Placement[] };
+  try {
+    body = await req.json();
+  } catch {
+    return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
+  }
+  const placements = body.sections;
+  if (
+    !Array.isArray(placements) ||
+    placements.some(
+      (p) => !p?.id || !p?.districtId || typeof p.position !== "number",
+    )
+  ) {
+    return NextResponse.json(
+      { error: "sections[] of { id, districtId, position } is required" },
+      { status: 400 },
+    );
+  }
+
+  await db.transaction(async (tx) => {
+    for (const p of placements) {
+      await tx
+        .update(sections)
+        .set({ districtId: p.districtId, position: p.position })
+        .where(eq(sections.id, p.id));
+    }
+  });
+  return NextResponse.json({ ok: true });
+}


### PR DESCRIPTION
## What

**Increment 2 of the drag-and-drop layout builder** (#76): configure districts by
dragging sections. A layout's expanded **Track** view is now interactive.

- Each **section** has a grip (⠿) and is draggable.
- **Districts** and **sections** are drop targets: drop on a district appends the
  section there; drop on a section inserts before it — **re-parent + re-order** in
  one gesture. Empty districts show a *"(drop a section here)"* hint.
- New **`POST /api/track/sections/arrange`** applies the full new arrangement
  (`id, districtId, position`) atomically.
- Native HTML5 drag-and-drop — no new dependency. Form-based authoring unchanged.

## Verified in the browser

Built a 2-district layout (North→Sec 1, South→Sec 2), dragged **Sec 1 → South**:
North went empty, South became **[Sec 2, Sec 1]**, persisted. No console errors.

## Test
Full suite **58** + typecheck + lint + `next build` green.

## Next (this initiative)
3. To-scale schematic canvas (WYSIWYG epic)
4. Playwright end-to-end covering the whole flow
