### PR TITLE
feat: to-scale layout schematic (WYSIWYG canvas, phase 1) (#115)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { apiGet, apiSend } from "@/lib/client/api";
 import { Panel } from "@/components/admin/ui";
 import { moduleMatches } from "@/lib/client/moduleSearch";
+import { LayoutSchematic } from "@/components/layout/LayoutSchematic";
 import type { CatalogModule } from "@/lib/client/types";
 import type { StagingEnd } from "@/lib/db/schema";
 
@@ -41,6 +42,9 @@ interface LayoutModuleNode {
   positionIndex: number;
   stagingEnd: StagingEnd | null;
   moduleName: string | null;
+  lengthTotalInches: number | null;
+  mainlineLengthInches: number | null;
+  hasMss: boolean | null;
 }
 interface LayoutTree extends LayoutRow {
   modules: LayoutModuleNode[];
@@ -561,6 +565,14 @@ export default function AdminLayouts() {
                                 </ul>
                               </div>
                             )}
+                          </div>
+
+                          {/* Schematic (to-scale) */}
+                          <div>
+                            <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
+                              Schematic
+                            </div>
+                            <LayoutSchematic modules={tree.modules} />
                           </div>
 
                           {/* Track */}

--- a/components/layout/LayoutSchematic.tsx
+++ b/components/layout/LayoutSchematic.tsx
@@ -1,0 +1,91 @@
+/**
+ * LayoutSchematic (#115, phase 1) — a to-scale linear view of a layout's module
+ * sequence. Each module is drawn proportional to its total length; staging
+ * modules are tinted, MSS is dotted, and modules with no catalogued length fall
+ * back to a default width (marked "?"). Geometry-aware (curved) rendering is a
+ * later phase.
+ */
+"use client";
+
+export interface SchematicModule {
+  id: string;
+  moduleId: string;
+  moduleName: string | null;
+  stagingEnd: "A" | "B" | null;
+  lengthTotalInches: number | null;
+  hasMss: boolean | null;
+}
+
+const DEFAULT_LEN = 24; // fallback inches for a module missing a length
+
+export function LayoutSchematic({ modules }: { modules: SchematicModule[] }) {
+  if (modules.length === 0) {
+    return <p className="text-xs text-slate-600">No modules to draw yet.</p>;
+  }
+
+  const lengths = modules.map((m) =>
+    m.lengthTotalInches && m.lengthTotalInches > 0
+      ? m.lengthTotalInches
+      : DEFAULT_LEN,
+  );
+  const total = lengths.reduce((a, b) => a + b, 0);
+  const feet = Math.round((total / 12) * 10) / 10;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
+        <span>
+          {modules.length} module{modules.length === 1 ? "" : "s"}
+        </span>
+        <span>{feet} ft total</span>
+      </div>
+      <div className="flex h-16 w-full overflow-hidden rounded-md border border-slate-700 bg-slate-900">
+        {modules.map((m, i) => {
+          const noLen = !(m.lengthTotalInches && m.lengthTotalInches > 0);
+          return (
+            <div
+              key={m.id}
+              title={`${m.moduleName ?? m.moduleId} · ${m.moduleId}${
+                noLen ? " · no length" : ` · ${Math.round(lengths[i])}"`
+              }`}
+              style={{ width: `${(lengths[i] / total) * 100}%` }}
+              className={`relative flex min-w-0 flex-col justify-center border-r border-slate-700 px-1 last:border-r-0 ${
+                m.stagingEnd ? "bg-indigo-900/40" : "bg-slate-800/60"
+              }`}
+            >
+              <span className="truncate text-[10px] font-medium text-slate-200">
+                {m.moduleName ?? m.moduleId}
+              </span>
+              <span className="truncate text-[9px] text-slate-500">
+                {m.moduleId}
+              </span>
+              {m.stagingEnd && (
+                <span className="absolute right-0.5 top-0.5 rounded bg-indigo-600/40 px-0.5 text-[8px] text-indigo-200">
+                  stg {m.stagingEnd}
+                </span>
+              )}
+              {m.hasMss && (
+                <span
+                  title="MSS"
+                  className="absolute bottom-0.5 right-0.5 h-1.5 w-1.5 rounded-full bg-emerald-500"
+                />
+              )}
+              {noLen && (
+                <span
+                  title="No length in catalog"
+                  className="absolute left-0.5 top-0.5 text-[8px] text-amber-400"
+                >
+                  ?
+                </span>
+              )}
+            </div>
+          );
+        })}
+      </div>
+      <p className="mt-1 text-[10px] text-slate-600">
+        To scale by module length. Modules with no catalogued length use a
+        default width (?).
+      </p>
+    </div>
+  );
+}

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -71,6 +71,9 @@ export interface LayoutModule {
   positionIndex: number;
   stagingEnd: StagingEnd | null;
   moduleName: string | null;
+  lengthTotalInches: number | null;
+  mainlineLengthInches: number | null;
+  hasMss: boolean | null;
 }
 
 export interface LayoutTree extends LayoutRow {
@@ -234,6 +237,9 @@ class TrackModel {
         positionIndex: moduleLayouts.positionIndex,
         stagingEnd: moduleLayouts.stagingEnd,
         moduleName: repoModules.moduleName,
+        lengthTotalInches: repoModules.lengthTotalInches,
+        mainlineLengthInches: repoModules.mainlineLengthInches,
+        hasMss: repoModules.hasMss,
       })
       .from(moduleLayouts)
       .leftJoin(repoModules, eq(moduleLayouts.moduleId, repoModules.recordNumber))


### PR DESCRIPTION
## What

**Phase 1 of the WYSIWYG schematic canvas** (epic #115): a **to-scale** linear view
of a layout's module sequence, in the Layouts editor.

- Each module is drawn **proportional to its total length**; staging modules are
  tinted, MSS is dotted, and a module with no catalogued length falls back to a
  default width (marked **?**). Shows module count + **total feet**.
- `LayoutSchematic` component — a flex strip, **no new dependency**.
- `getLayout` now returns each module's length + MSS from the catalog.

The form + drag-list builders are unchanged; this is a read-only visual (drag-place
and geometry-aware curves are later phases of #115).

## Verified in the browser

*Test Mainline* renders **3 modules to scale** — Columbia River Gorge widest
(longest), Multnomah Curve narrower, and the manually-typed **FMN-0042** marked
**?** (no length). "8.5 ft total". No console errors.

## Test
Full suite **58** + typecheck + lint + `next build` green.

## Next
- #115 phase 2: geometry-aware (curved) render
- Playwright end-to-end
