### PR TITLE
test: end-to-end full-flow test with Playwright

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,33 @@ jobs:
 
       - name: Build
         run: npm run build
+
+  e2e:
+    name: E2E (Playwright)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: "22"
+          cache: "npm"
+
+      - name: Install dependencies
+        env:
+          ELECTRON_SKIP_BINARY_DOWNLOAD: "1"
+        run: npm install --no-audit --no-fund
+
+      - name: Install Playwright browser
+        run: npx playwright install --with-deps chromium
+
+      - name: Run e2e
+        run: npm run e2e
+
+      - name: Upload report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7

--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,11 @@ next-env.d.ts
 # Local PGlite data dir
 /.data/
 
+# Playwright e2e artifacts
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/
+
 # Zello credentials (issuer + private key) — never commit
 zello-credentials.json

--- a/e2e/full-flow.spec.ts
+++ b/e2e/full-flow.spec.ts
@@ -1,0 +1,78 @@
+import { test, expect, type APIRequestContext } from "@playwright/test";
+
+/**
+ * End-to-end: the whole chain a dispatcher-host runs through —
+ *   build a layout (districts/sections/blocks) → attach it to a session →
+ *   add a train → dispatch (mark occupancy, allocate a section).
+ *
+ * Deterministic setup goes through the authenticated API; the dispatcher board
+ * and the layout view are exercised through the real UI.
+ */
+
+async function adminHeaders(request: APIRequestContext) {
+  const res = await request.get("/api/admin/token");
+  const { sessionToken } = await res.json();
+  return {
+    Authorization: `Bearer ${sessionToken}`,
+    "Content-Type": "application/json",
+  };
+}
+
+test("build a layout, attach to a session, and dispatch on it", async ({
+  page,
+  request,
+}) => {
+  const ts = Date.now();
+  const H = await adminHeaders(request);
+
+  // 1) Build a layout with one district → section → block.
+  const layoutRes = await request.post("/api/layouts", {
+    headers: H,
+    data: {
+      name: `E2E Layout ${ts}`,
+      districts: [
+        { name: "Div 1", sections: [{ name: "Sec 1", blocks: [{ name: "B1" }] }] },
+      ],
+    },
+  });
+  expect(layoutRes.ok()).toBeTruthy();
+  const { layout } = await layoutRes.json();
+
+  // 2) Start a session, attach the layout, add a train.
+  await request.post("/api/session", {
+    headers: H,
+    data: { name: `E2E Session ${ts}` },
+  });
+  await request.patch("/api/session", { headers: H, data: { layoutId: layout.id } });
+  const trainRes = await request.post("/api/trains", {
+    headers: H,
+    data: { number: "E2E1", name: "E2E Train" },
+  });
+  expect(trainRes.ok()).toBeTruthy();
+
+  // 3) The Layouts view shows the layout + its to-scale schematic section.
+  await page.goto("/admin/layouts");
+  await expect(page.getByText(`E2E Layout ${ts}`)).toBeVisible();
+
+  // 4) The dispatcher board renders the attached layout.
+  await page.goto("/admin/track");
+  await expect(page.getByRole("heading", { name: "Track" })).toBeVisible();
+  await expect(page.getByText("Div 1")).toBeVisible();
+  await expect(page.getByText("Sec 1")).toBeVisible();
+
+  // Mark block B1 occupied → it turns red.
+  const block = page.getByRole("button", { name: "B1", exact: true });
+  await block.click();
+  await expect(block).toHaveClass(/red-600/);
+
+  // Allocate Sec 1 to the train: select it, pick the train, allocate the route.
+  await page.getByTitle("Select for a route").check();
+  await page
+    .locator("select")
+    .filter({ hasText: "E2E1" })
+    .selectOption({ label: "E2E1 · E2E Train" });
+  await page.getByRole("button", { name: "Allocate route" }).click();
+
+  // The section now shows the allocation badge.
+  await expect(page.getByText("E2E1 · E2E Train · A→B")).toBeVisible();
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "react-dom": "19.2.4"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4",
         "@types/node": "^20",
         "@types/qrcode": "^1.5.6",
@@ -2780,6 +2781,22 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -10415,6 +10432,52 @@
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/plist": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "db:migrate": "tsx lib/db/migrate.ts",
     "db:seed": "tsx lib/db/seed.ts",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
@@ -31,6 +32,7 @@
     "react-dom": "19.2.4"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/qrcode": "^1.5.6",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,35 @@
+import { defineConfig, devices } from "@playwright/test";
+
+/**
+ * End-to-end tests (#... full-flow). Boots the real app against a throwaway DB
+ * (FD_DB_DIR) on its own port, then drives the browser through the whole chain:
+ * build a layout → attach to a session → dispatch.
+ */
+const PORT = 3100;
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  workers: 1,
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  reporter: "line",
+  use: {
+    baseURL: `http://localhost:${PORT}`,
+    trace: "on-first-retry",
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    // Run the dev server: it's development mode (so /api/admin/token is issued
+    // without SERVER_MODE, and no mDNS advertising is started) and turbopack
+    // compiles routes on demand quickly. A throwaway DB keeps runs isolated.
+    command: "npm run dev",
+    port: PORT,
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      PORT: String(PORT),
+      FD_DB_DIR: "./.data/e2e",
+    },
+  },
+});


### PR DESCRIPTION
## What

The **end-to-end wrap-up** you asked for — a Playwright test that drives the whole
chain in a real browser:

1. Build a **layout** (district → section → block)
2. Start a **session** and **attach** the layout
3. Add a **train**
4. On the dispatcher **board**: mark a block occupied (it turns red) and **allocate**
   the section to the train (allocation badge appears)

## How
- `playwright.config.ts` boots the **dev server** on a throwaway DB (`FD_DB_DIR`) on
  its own port. Dev mode is deliberate: `/api/admin/token` is issued without
  `SERVER_MODE` and no mDNS advertising starts; turbopack compiles routes on demand.
- Setup goes through the authenticated API; the board + layout view are exercised
  through the **real UI**.
- New **"E2E (Playwright)"** CI job installs chromium and runs the flow next to
  Lint · Types · Build. `npm run e2e` runs it locally.

## Adds
- dev dependency **`@playwright/test`** + a bundled chromium (CI installs it), and a
  **new CI job** — as flagged.

## Verified
Passes locally in CI mode (fresh server + fresh DB, ~8s). Unit suite (58) still green.
