### PR TITLE
feat: drag a module from the catalog onto the schematic to place it (#115 phase 3b)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -4,7 +4,10 @@ import { useCallback, useEffect, useState } from "react";
 import { apiGet, apiSend } from "@/lib/client/api";
 import { Panel } from "@/components/admin/ui";
 import { moduleMatches } from "@/lib/client/moduleSearch";
-import { LayoutSchematic } from "@/components/layout/LayoutSchematic";
+import {
+  LayoutSchematic,
+  MODULE_DRAG_MIME,
+} from "@/components/layout/LayoutSchematic";
 import type { CatalogModule } from "@/lib/client/types";
 import type { StagingEnd } from "@/lib/db/schema";
 
@@ -189,6 +192,19 @@ export default function AdminLayouts() {
       await reloadTree(layoutId);
     } catch (e) {
       alert(e instanceof Error ? e.message : "update failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  async function dropAddModule(layoutId: string, rec: string) {
+    if (trees[layoutId]?.modules.some((m) => m.moduleId === rec)) return;
+    setBusy(true);
+    try {
+      await apiSend("POST", "/api/modules", { layoutId, moduleIds: [rec] });
+      await Promise.all([reloadTree(layoutId), load()]);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "add failed");
     } finally {
       setBusy(false);
     }
@@ -558,10 +574,24 @@ export default function AdminLayouts() {
                                       return (
                                         <li key={m.recordNumber}>
                                           <label
+                                            draggable={!isAssigned && !busy}
+                                            onDragStart={(e) => {
+                                              if (isAssigned) return;
+                                              e.dataTransfer.setData(
+                                                MODULE_DRAG_MIME,
+                                                m.recordNumber,
+                                              );
+                                              e.dataTransfer.effectAllowed = "copy";
+                                            }}
+                                            title={
+                                              isAssigned
+                                                ? undefined
+                                                : "Check to batch-add, or drag onto the schematic"
+                                            }
                                             className={`flex items-center gap-2 rounded px-1.5 py-1 text-sm ${
                                               isAssigned
                                                 ? "opacity-50"
-                                                : "cursor-pointer hover:bg-slate-800/60"
+                                                : "cursor-grab hover:bg-slate-800/60"
                                             }`}
                                           >
                                             <input
@@ -608,7 +638,10 @@ export default function AdminLayouts() {
                             <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
                               Schematic
                             </div>
-                            <LayoutSchematic modules={tree.modules} />
+                            <LayoutSchematic
+                              modules={tree.modules}
+                              onDropModule={(rec) => dropAddModule(l.id, rec)}
+                            />
                           </div>
 
                           {/* Track */}

--- a/components/layout/LayoutSchematic.tsx
+++ b/components/layout/LayoutSchematic.tsx
@@ -7,11 +7,52 @@
  */
 "use client";
 
+import { useState } from "react";
 import { buildSchematic, type SchematicInput } from "@/lib/track/schematic";
 
-export function LayoutSchematic({ modules }: { modules: SchematicInput[] }) {
+/** Drag payload MIME for dropping a catalog module onto the schematic. */
+export const MODULE_DRAG_MIME = "application/x-fd-module";
+
+export function LayoutSchematic({
+  modules,
+  onDropModule,
+}: {
+  modules: SchematicInput[];
+  /** Called with a catalog record # when one is dropped onto the schematic. */
+  onDropModule?: (recordNumber: string) => void;
+}) {
+  const [over, setOver] = useState(false);
+
+  const dropProps = onDropModule
+    ? {
+        onDragOver: (e: React.DragEvent) => {
+          if (e.dataTransfer.types.includes(MODULE_DRAG_MIME)) {
+            e.preventDefault();
+            setOver(true);
+          }
+        },
+        onDragLeave: () => setOver(false),
+        onDrop: (e: React.DragEvent) => {
+          setOver(false);
+          const rec = e.dataTransfer.getData(MODULE_DRAG_MIME);
+          if (rec) onDropModule(rec);
+        },
+      }
+    : {};
+
+  const ring = over ? "ring-2 ring-sky-500" : "";
+
   if (modules.length === 0) {
-    return <p className="text-xs text-slate-600">No modules to draw yet.</p>;
+    return (
+      <div
+        {...dropProps}
+        className={`flex h-16 items-center justify-center rounded-md border border-dashed border-slate-700 text-xs text-slate-600 ${ring}`}
+      >
+        {onDropModule
+          ? "No modules yet — drag one from the list, or use Add."
+          : "No modules to draw yet."}
+      </div>
+    );
   }
 
   const schem = buildSchematic(modules);
@@ -34,11 +75,12 @@ export function LayoutSchematic({ modules }: { modules: SchematicInput[] }) {
         <span>{feet} ft total</span>
       </div>
       <svg
+        {...dropProps}
         viewBox={viewBox}
         width="100%"
         height="150"
         preserveAspectRatio="xMidYMid meet"
-        className="rounded-md border border-slate-700 bg-slate-900"
+        className={`rounded-md border border-slate-700 bg-slate-900 ${ring}`}
       >
         {schem.segments.map((seg) => {
           const noLen = !(


### PR DESCRIPTION
## What

**Phase 3b of the schematic canvas** (#115): **drag-place**. The schematic is now a
drop target — drag a module from the catalog list and drop it on the schematic to
append it to the layout.

- Catalog rows are **draggable** (an `application/x-fd-module` payload carries the
  record #); the schematic **highlights** while a module is dragged over it, and
  the empty-state schematic accepts the first module too.
- Drop appends via the existing bulk-add endpoint; the checkbox batch-add is
  unchanged.
- Native HTML5 drag-and-drop — no new dependency.

## Verified in the browser
Dragged **Cascade Lumber & Grain** from the catalog onto the schematic → it was
appended (schematic went to **4 modules · 18.8 ft**, extending the L) and marked
**added** in the list. No console errors.

## Test
Full suite **63** + typecheck + lint + build green.

## Next
- Endplate **snap** (connect A↔B) and drag-to-insert at a position
- Phase 4: district paint
