### PR TITLE
feat: flag endplate connection mismatches in the layout schematic (#115)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -57,6 +57,7 @@ interface LayoutModuleNode {
   geometryType: string | null;
   geometryDegrees: number | null;
   flipped: boolean;
+  endplates: { label?: string | null; track_config?: string | null }[] | null;
 }
 interface LayoutTree extends LayoutRow {
   modules: LayoutModuleNode[];

--- a/components/layout/LayoutSchematic.tsx
+++ b/components/layout/LayoutSchematic.tsx
@@ -9,6 +9,7 @@
 
 import { useState } from "react";
 import { buildSchematic, type SchematicInput } from "@/lib/track/schematic";
+import { endplateConnections } from "@/lib/track/endplates";
 
 /** Drag payload MIME for dropping a catalog module onto the schematic. */
 export const MODULE_DRAG_MIME = "application/x-fd-module";
@@ -57,6 +58,11 @@ export function LayoutSchematic({
 
   const schem = buildSchematic(modules);
   const { bbox, totalInches } = schem;
+  // Endplate connection checks (#115): the join before segment i is
+  // connections[i-1]. Mismatches (e.g. single↔double) are flagged.
+  const connections = endplateConnections(modules);
+  const mismatches = connections.filter((c) => c.status === "mismatch");
+  const label = (i: number) => modules[i]?.moduleName ?? modules[i]?.moduleId;
   const w = Math.max(bbox.maxX - bbox.minX, 1);
   const h = Math.max(bbox.maxY - bbox.minY, 1);
   const pad = Math.max(w, h) * 0.06 + 6;
@@ -106,23 +112,50 @@ export function LayoutSchematic({
             </polyline>
           );
         })}
-        {/* Endplate boundaries. */}
-        {schem.segments.map((seg) => (
-          <circle
-            key={`${seg.input.id}-c`}
-            cx={seg.points[0].x}
-            cy={seg.points[0].y}
-            r={stroke * 1.1}
-            fill="#0f172a"
-            stroke="#475569"
-            strokeWidth={stroke * 0.3}
-          />
-        ))}
+        {/* Endplate boundaries; joins tinted red on a track-config mismatch. */}
+        {schem.segments.map((seg, i) => {
+          const conn = i > 0 ? connections[i - 1] : undefined;
+          const bad = conn?.status === "mismatch";
+          return (
+            <circle
+              key={`${seg.input.id}-c`}
+              cx={seg.points[0].x}
+              cy={seg.points[0].y}
+              r={stroke * (bad ? 1.5 : 1.1)}
+              fill={bad ? "#7f1d1d" : "#0f172a"}
+              stroke={bad ? "#ef4444" : "#475569"}
+              strokeWidth={stroke * (bad ? 0.5 : 0.3)}
+            >
+              {conn && (
+                <title>
+                  {`${label(conn.fromIndex)} (${conn.fromConfig ?? "?"}) ↔ ${label(
+                    conn.toIndex,
+                  )} (${conn.toConfig ?? "?"})${bad ? " — mismatch" : ""}`}
+                </title>
+              )}
+            </circle>
+          );
+        })}
       </svg>
+      {mismatches.length > 0 && (
+        <div className="mt-1 rounded-md border border-red-900/60 bg-red-950/30 px-2 py-1 text-[11px] text-red-300">
+          <span className="font-semibold">
+            {mismatches.length} endplate{" "}
+            {mismatches.length === 1 ? "mismatch" : "mismatches"}:
+          </span>{" "}
+          {mismatches.map((c, i) => (
+            <span key={`${c.fromId}-${c.toId}`}>
+              {i > 0 && "; "}
+              {label(c.fromIndex)} ({c.fromConfig}) ↔ {label(c.toIndex)} (
+              {c.toConfig})
+            </span>
+          ))}
+        </div>
+      )}
       <p className="mt-1 text-[10px] text-slate-600">
         To scale, following each module&rsquo;s geometry (straights, curves, 90°
-        corners). Staging tinted, unknown-length amber; curve orientation is
-        approximate.
+        corners). Staging tinted, unknown-length amber; red joins flag an endplate
+        track-config mismatch; curve orientation is approximate.
       </p>
     </div>
   );

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -79,6 +79,7 @@ export interface LayoutModule {
   geometryType: string | null;
   geometryDegrees: number | null;
   flipped: boolean;
+  endplates: unknown;
 }
 
 export interface LayoutTree extends LayoutRow {
@@ -252,6 +253,7 @@ class TrackModel {
         hasMss: repoModules.hasMss,
         geometryType: repoModules.geometryType,
         geometryDegrees: repoModules.geometryDegrees,
+        endplates: repoModules.endplates,
       })
       .from(moduleLayouts)
       .leftJoin(repoModules, eq(moduleLayouts.moduleId, repoModules.recordNumber))

--- a/lib/track/__tests__/endplates.test.ts
+++ b/lib/track/__tests__/endplates.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import {
+  endplateConnections,
+  endplateMismatches,
+  inConfig,
+  outConfig,
+  type ModuleEndplates,
+} from "../endplates";
+
+const mod = (
+  id: string,
+  a: string | null,
+  b: string | null,
+  flipped = false,
+): ModuleEndplates => ({
+  id,
+  flipped,
+  endplates: [
+    { label: "EP-1", track_config: a },
+    { label: "EP-2", track_config: b },
+  ],
+});
+
+describe("in/outConfig", () => {
+  it("out faces the next module (last endplate), in the previous (first)", () => {
+    const m = mod("m", "single", "double");
+    expect(inConfig(m)).toBe("single");
+    expect(outConfig(m)).toBe("double");
+  });
+
+  it("flip swaps which endplate is in vs out", () => {
+    const m = mod("m", "single", "double", true);
+    expect(inConfig(m)).toBe("double");
+    expect(outConfig(m)).toBe("single");
+  });
+
+  it("normalises case/whitespace and treats blank as null", () => {
+    expect(inConfig(mod("m", "  Single ", "double"))).toBe("single");
+    expect(inConfig(mod("m", "", "double"))).toBeNull();
+    expect(inConfig({ id: "m", endplates: [] })).toBeNull();
+    expect(inConfig({ id: "m" })).toBeNull();
+  });
+});
+
+describe("endplateConnections", () => {
+  it("flags a single→double join as a mismatch and matching as ok", () => {
+    const conns = endplateConnections([
+      mod("a", "single", "single"),
+      mod("b", "double", "double"),
+      mod("c", "double", "double"),
+    ]);
+    expect(conns.map((c) => c.status)).toEqual(["mismatch", "ok"]);
+    expect(conns[0]).toMatchObject({
+      fromId: "a",
+      toId: "b",
+      fromConfig: "single",
+      toConfig: "double",
+    });
+  });
+
+  it("is unknown when either side lacks a track_config", () => {
+    const conns = endplateConnections([
+      mod("a", "single", null),
+      mod("b", "single", "single"),
+    ]);
+    expect(conns[0].status).toBe("unknown");
+  });
+
+  it("respects flip when picking the facing endplates", () => {
+    // b flipped: its incoming end becomes EP-2 (single), matching a's out.
+    const conns = endplateConnections([
+      mod("a", "single", "single"),
+      mod("b", "double", "single", true),
+    ]);
+    expect(conns[0].status).toBe("ok");
+  });
+
+  it("returns no connections for 0 or 1 modules", () => {
+    expect(endplateConnections([])).toEqual([]);
+    expect(endplateConnections([mod("a", "single", "single")])).toEqual([]);
+  });
+});
+
+describe("endplateMismatches", () => {
+  it("returns only the mismatched joins", () => {
+    const mismatches = endplateMismatches([
+      mod("a", "single", "single"),
+      mod("b", "double", "double"),
+      mod("c", "double", "double"),
+    ]);
+    expect(mismatches).toHaveLength(1);
+    expect(mismatches[0].fromId).toBe("a");
+  });
+});

--- a/lib/track/endplates.ts
+++ b/lib/track/endplates.ts
@@ -1,0 +1,95 @@
+/**
+ * Endplate connection checks (#115) — when a layout's modules are chained in
+ * sequence, each module's outgoing endplate meets the next module's incoming
+ * endplate. A single-track end meeting a double-track end (or any track_config
+ * mismatch) is a real assembly problem, so we surface it in the builder.
+ *
+ * Pure so it can be unit-tested; the schematic and list just render the result.
+ * This is also the seam the owner-authored module schematic (#122) plugs into:
+ * richer per-endplate track configs authored upstream validate here unchanged.
+ */
+
+export interface EndplateInfo {
+  label?: string | null;
+  track_config?: string | null;
+}
+
+export interface ModuleEndplates {
+  id: string;
+  moduleName?: string | null;
+  moduleId?: string | null;
+  endplates?: EndplateInfo[] | null;
+  /** Mirrors the placement, swapping which endplate faces each neighbour. */
+  flipped?: boolean | null;
+}
+
+export type ConnectionStatus = "ok" | "mismatch" | "unknown";
+
+export interface Connection {
+  /** Index of the earlier module in the sequence (the join sits before to). */
+  fromIndex: number;
+  toIndex: number;
+  fromId: string;
+  toId: string;
+  fromConfig: string | null;
+  toConfig: string | null;
+  status: ConnectionStatus;
+}
+
+function norm(v: string | null | undefined): string | null {
+  const t = (v ?? "").trim().toLowerCase();
+  return t.length > 0 ? t : null;
+}
+
+/** Endplates in facing order (flip reverses which end is in vs out). */
+function ordered(m: ModuleEndplates): EndplateInfo[] {
+  const eps = m.endplates ?? [];
+  return m.flipped ? [...eps].reverse() : eps;
+}
+
+/** The track_config of the endplate that faces the NEXT module. */
+export function outConfig(m: ModuleEndplates): string | null {
+  const eps = ordered(m);
+  return eps.length > 0 ? norm(eps[eps.length - 1].track_config) : null;
+}
+
+/** The track_config of the endplate that faces the PREVIOUS module. */
+export function inConfig(m: ModuleEndplates): string | null {
+  const eps = ordered(m);
+  return eps.length > 0 ? norm(eps[0].track_config) : null;
+}
+
+/**
+ * Compatibility of every adjacent join in the sequence. `unknown` when either
+ * side's track_config is missing (nothing to compare), never a false alarm.
+ */
+export function endplateConnections(modules: ModuleEndplates[]): Connection[] {
+  const out: Connection[] = [];
+  for (let i = 0; i < modules.length - 1; i++) {
+    const a = modules[i];
+    const b = modules[i + 1];
+    const fromConfig = outConfig(a);
+    const toConfig = inConfig(b);
+    const status: ConnectionStatus =
+      fromConfig == null || toConfig == null
+        ? "unknown"
+        : fromConfig === toConfig
+          ? "ok"
+          : "mismatch";
+    out.push({
+      fromIndex: i,
+      toIndex: i + 1,
+      fromId: a.id,
+      toId: b.id,
+      fromConfig,
+      toConfig,
+      status,
+    });
+  }
+  return out;
+}
+
+/** Just the mismatched joins, for a warning summary. */
+export function endplateMismatches(modules: ModuleEndplates[]): Connection[] {
+  return endplateConnections(modules).filter((c) => c.status === "mismatch");
+}

--- a/lib/track/schematic.ts
+++ b/lib/track/schematic.ts
@@ -20,6 +20,8 @@ export interface SchematicInput {
   geometryDegrees: number | null;
   /** Mirror the placement so the curve bends the other way. */
   flipped?: boolean | null;
+  /** Endplate track configs, used for connection checks (#115). */
+  endplates?: { label?: string | null; track_config?: string | null }[] | null;
 }
 
 export interface Pt {


### PR DESCRIPTION
## What

Continues the builder (#115) with **endplate connection checking** — the "snap"
that tells you modules actually fit together.

When modules are chained in sequence, each module's outgoing endplate meets the
next module's incoming endplate. A **single-track end meeting a double-track end**
(or any `track_config` mismatch) is a real assembly problem, now surfaced in the
builder.

- **`lib/track/endplates.ts`** — pure `endplateConnections()` compares each
  adjacent join's `track_config`, respecting `flipped` (which swaps the facing
  ends). `unknown` when either side lacks a config, so no false alarms. **8 unit
  tests.**
- `getLayout` threads each module's endplates through; the schematic **tints the
  join dot red** on a mismatch (with a hover title showing both configs) and
  renders a **summary banner** listing the offending pairs.

## Why this order
This is the seam the **owner-authored module schematic (#122)** plugs into:
richer per-endplate track configs authored upstream validate here unchanged.

## Verified in the browser
A real single↔double join (**Cascade Lumber (double) ↔ Multnomah Curve (single)**)
renders a red join dot and a **"1 endplate mismatch: …"** banner; other joins stay
grey. No console errors.

## Test
71 unit tests (8 new) + typecheck + lint + production build all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
