### PR TITLE
feat: paint the layout schematic by district territory (#115)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -766,6 +766,7 @@ export default function AdminLayouts() {
                             </div>
                             <LayoutSchematic
                               modules={tree.modules}
+                              districts={tree.districts}
                               onDropModule={(rec) => dropAddModule(l.id, rec)}
                             />
                           </div>

--- a/components/layout/LayoutSchematic.tsx
+++ b/components/layout/LayoutSchematic.tsx
@@ -10,15 +10,24 @@
 import { useState } from "react";
 import { buildSchematic, type SchematicInput } from "@/lib/track/schematic";
 import { endplateConnections } from "@/lib/track/endplates";
+import {
+  districtColor,
+  districtLegend,
+  moduleDistrictMap,
+  type DistrictLite,
+} from "@/lib/track/districts";
 
 /** Drag payload MIME for dropping a catalog module onto the schematic. */
 export const MODULE_DRAG_MIME = "application/x-fd-module";
 
 export function LayoutSchematic({
   modules,
+  districts,
   onDropModule,
 }: {
   modules: SchematicInput[];
+  /** Layout districts, used to paint modules by dispatcher territory (#115). */
+  districts?: DistrictLite[];
   /** Called with a catalog record # when one is dropped onto the schematic. */
   onDropModule?: (recordNumber: string) => void;
 }) {
@@ -63,6 +72,9 @@ export function LayoutSchematic({
   const connections = endplateConnections(modules);
   const mismatches = connections.filter((c) => c.status === "mismatch");
   const label = (i: number) => modules[i]?.moduleName ?? modules[i]?.moduleId;
+  // District painting (#115, phase 4): colour each module by its territory.
+  const dmap = districts ? moduleDistrictMap(districts) : new Map();
+  const legend = districts ? districtLegend(districts) : [];
   const w = Math.max(bbox.maxX - bbox.minX, 1);
   const h = Math.max(bbox.maxY - bbox.minY, 1);
   const pad = Math.max(w, h) * 0.06 + 6;
@@ -92,14 +104,24 @@ export function LayoutSchematic({
           const noLen = !(
             seg.input.lengthTotalInches && seg.input.lengthTotalInches > 0
           );
+          const dist = seg.input.moduleId
+            ? dmap.get(seg.input.moduleId)
+            : undefined;
+          // District colour wins; otherwise staging (indigo) / no-length
+          // (amber) / plain (slate, so painted districts stand out).
+          const color = dist
+            ? districtColor(dist.index)
+            : seg.input.stagingEnd
+              ? "#818cf8"
+              : noLen
+                ? "#f59e0b"
+                : "#64748b";
           return (
             <polyline
               key={seg.input.id}
               points={seg.points.map((p) => `${p.x},${p.y}`).join(" ")}
               fill="none"
-              stroke={
-                seg.input.stagingEnd ? "#818cf8" : noLen ? "#f59e0b" : "#38bdf8"
-              }
+              stroke={color}
               strokeWidth={stroke}
               strokeLinecap="round"
               strokeLinejoin="round"
@@ -107,7 +129,9 @@ export function LayoutSchematic({
               <title>
                 {`${seg.input.moduleName ?? seg.input.moduleId} · ${
                   seg.input.moduleId
-                }${seg.input.geometryType ? ` · ${seg.input.geometryType}` : ""}`}
+                }${seg.input.geometryType ? ` · ${seg.input.geometryType}` : ""}${
+                  dist ? ` · ${dist.name}` : ""
+                }`}
               </title>
             </polyline>
           );
@@ -137,6 +161,19 @@ export function LayoutSchematic({
           );
         })}
       </svg>
+      {legend.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-slate-400">
+          {legend.map((d) => (
+            <span key={d.id} className="flex items-center gap-1">
+              <span
+                className="inline-block h-2.5 w-2.5 rounded-sm"
+                style={{ backgroundColor: d.color }}
+              />
+              {d.name}
+            </span>
+          ))}
+        </div>
+      )}
       {mismatches.length > 0 && (
         <div className="mt-1 rounded-md border border-red-900/60 bg-red-950/30 px-2 py-1 text-[11px] text-red-300">
           <span className="font-semibold">
@@ -154,8 +191,9 @@ export function LayoutSchematic({
       )}
       <p className="mt-1 text-[10px] text-slate-600">
         To scale, following each module&rsquo;s geometry (straights, curves, 90°
-        corners). Staging tinted, unknown-length amber; red joins flag an endplate
-        track-config mismatch; curve orientation is approximate.
+        corners). Modules are coloured by district where assigned (else staging
+        indigo, unknown-length amber); red joins flag an endplate track-config
+        mismatch; curve orientation is approximate.
       </p>
     </div>
   );

--- a/lib/track/__tests__/districts.test.ts
+++ b/lib/track/__tests__/districts.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import {
+  districtColor,
+  districtLegend,
+  moduleDistrictMap,
+  DISTRICT_COLORS,
+  type DistrictLite,
+} from "../districts";
+
+const d = (
+  id: string,
+  name: string,
+  ...mods: (string | null)[]
+): DistrictLite => ({
+  id,
+  name,
+  sections: [{ blocks: mods.map((moduleRecordNumber) => ({ moduleRecordNumber })) }],
+});
+
+describe("moduleDistrictMap", () => {
+  it("maps a module to the district whose block links it", () => {
+    const map = moduleDistrictMap([
+      d("d1", "North", "FMN-0001", "FMN-0002"),
+      d("d2", "South", "FMN-0003"),
+    ]);
+    expect(map.get("FMN-0001")).toMatchObject({ districtId: "d1", name: "North", index: 0 });
+    expect(map.get("FMN-0003")).toMatchObject({ districtId: "d2", index: 1 });
+    expect(map.has("FMN-9999")).toBe(false);
+  });
+
+  it("ignores blank/null block links", () => {
+    const map = moduleDistrictMap([d("d1", "North", null, "  ", "FMN-0001")]);
+    expect(map.size).toBe(1);
+    expect(map.has("FMN-0001")).toBe(true);
+  });
+
+  it("keeps the first district when a module is linked from two", () => {
+    const map = moduleDistrictMap([
+      d("d1", "North", "FMN-0001"),
+      d("d2", "South", "FMN-0001"),
+    ]);
+    expect(map.get("FMN-0001")?.districtId).toBe("d1");
+  });
+});
+
+describe("districtColor", () => {
+  it("is stable by index and wraps past the palette", () => {
+    expect(districtColor(0)).toBe(DISTRICT_COLORS[0]);
+    expect(districtColor(DISTRICT_COLORS.length)).toBe(DISTRICT_COLORS[0]);
+  });
+});
+
+describe("districtLegend", () => {
+  it("lists only districts that own a module, with their colour", () => {
+    const legend = districtLegend([
+      d("d1", "North", "FMN-0001"),
+      d("d2", "South", null), // owns nothing
+      d("d3", "East", "FMN-0002"),
+    ]);
+    expect(legend).toEqual([
+      { id: "d1", name: "North", color: DISTRICT_COLORS[0] },
+      { id: "d3", name: "East", color: DISTRICT_COLORS[2] },
+    ]);
+  });
+});

--- a/lib/track/districts.ts
+++ b/lib/track/districts.ts
@@ -1,0 +1,74 @@
+/**
+ * District colouring (#115, phase 4) — paint the schematic by dispatcher
+ * territory. A district owns sections, which hold blocks, and a block may map to
+ * a module (blocks.moduleRecordNumber). So a module's district is derived by
+ * walking district → section → block and matching the module's record number.
+ *
+ * Pure so it can be unit-tested; the schematic just reads the map + palette.
+ */
+
+export interface DistrictLite {
+  id: string;
+  name: string;
+  sections: { blocks: { moduleRecordNumber: string | null }[] }[];
+}
+
+export interface ModuleDistrict {
+  districtId: string;
+  name: string;
+  /** Index of the district in the layout, used to pick a stable colour. */
+  index: number;
+}
+
+/**
+ * Distinct, readable-on-dark palette for district territories. Indexed by the
+ * district's position in the layout; wraps if there are more districts than
+ * colours.
+ */
+export const DISTRICT_COLORS = [
+  "#38bdf8", // sky
+  "#a78bfa", // violet
+  "#34d399", // emerald
+  "#fb7185", // rose
+  "#fbbf24", // amber
+  "#22d3ee", // cyan
+  "#f472b6", // pink
+  "#a3e635", // lime
+] as const;
+
+export function districtColor(index: number): string {
+  return DISTRICT_COLORS[index % DISTRICT_COLORS.length];
+}
+
+/**
+ * Map each module record number to the district that owns it (via a block
+ * link). A module linked from more than one district takes the first by district
+ * order — an authoring ambiguity the caller can surface separately.
+ */
+export function moduleDistrictMap(
+  districts: DistrictLite[],
+): Map<string, ModuleDistrict> {
+  const map = new Map<string, ModuleDistrict>();
+  districts.forEach((d, index) => {
+    for (const s of d.sections) {
+      for (const b of s.blocks) {
+        const rec = b.moduleRecordNumber?.trim();
+        if (rec && !map.has(rec)) {
+          map.set(rec, { districtId: d.id, name: d.name, index });
+        }
+      }
+    }
+  });
+  return map;
+}
+
+/** Districts that actually own at least one module, with their colour. */
+export function districtLegend(
+  districts: DistrictLite[],
+): { id: string; name: string; color: string }[] {
+  const map = moduleDistrictMap(districts);
+  const usedIds = new Set([...map.values()].map((v) => v.districtId));
+  return districts
+    .map((d, index) => ({ id: d.id, name: d.name, color: districtColor(index) }))
+    .filter((d) => usedIds.has(d.id));
+}


### PR DESCRIPTION
## What

Phase 4 of the WYSIWYG builder (#115): **colour each module in the schematic by
the dispatcher district that owns it**, so a layout's territories read at a
glance.

- **`lib/track/districts.ts`** — pure `moduleDistrictMap()` derives a module's
  district by walking district → section → block and matching
  `blocks.moduleRecordNumber`; `districtLegend()` lists the owning districts with
  a stable colour from a distinct palette. **5 unit tests.**
- The schematic strokes each module in its district colour. Plain (unassigned)
  modules go neutral **slate** so painted ones stand out; staging (indigo) and
  no-length (amber) keep their tints; the endplate-mismatch join dots are
  unchanged. A **district legend** sits under the schematic and each module's
  hover title names its district.

## Verified in the browser
A demo layout coloured **FMN-0001 sky (North)**, **FMN-0003 violet (South)**,
**FMN-0002 slate (unassigned)**, with a matching legend — shown alongside the
endplate-mismatch dots and the track model, all consistent. No console errors.

## Test
76 unit tests (5 new) + typecheck + lint + production build all green.

## Builder status (#115)
✅ reorder · section drag · geometry schematic + flip · drag-place ·
drag-to-insert · endplate connection check · **district paint**. The schematic now
consumes modules, endplates and districts — the foundation the owner-authored
module schematic (#122) imports into.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
