### PR TITLE
feat: straightened Operations schematic — the dispatcher panel (#115)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -13,6 +13,7 @@ import {
   LayoutSchematic,
   MODULE_DRAG_MIME,
 } from "@/components/layout/LayoutSchematic";
+import { OperationsSchematic } from "@/components/layout/OperationsSchematic";
 import type { CatalogModule } from "@/lib/client/types";
 import type { StagingEnd } from "@/lib/db/schema";
 
@@ -759,10 +760,21 @@ export default function AdminLayouts() {
                             )}
                           </div>
 
-                          {/* Schematic (to-scale) */}
+                          {/* Operations schematic (straightened — primary) */}
                           <div>
                             <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
-                              Schematic
+                              Operations schematic
+                            </div>
+                            <OperationsSchematic
+                              modules={tree.modules}
+                              districts={tree.districts}
+                            />
+                          </div>
+
+                          {/* Footprint (to-scale, physical shape) */}
+                          <div>
+                            <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
+                              Footprint (physical layout)
                             </div>
                             <LayoutSchematic
                               modules={tree.modules}

--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -1,0 +1,262 @@
+/**
+ * OperationsSchematic (#115 / #122) — the straightened dispatcher panel.
+ *
+ * The mainline is a horizontal spine (West → East). Main 1 runs unbroken the
+ * whole length; a second main appears as a parallel line that diverges/converges
+ * through turnouts at the control points where single becomes double. Modules are
+ * coloured by district territory. Geometry (curves/corners) is deliberately
+ * ignored here — that's the footprint view's job; a dispatcher needs topology,
+ * track count, and control points, not angles.
+ */
+"use client";
+
+import {
+  buildOperationsSchematic,
+  controlPoints,
+  type OpsModuleInput,
+} from "@/lib/track/operations";
+import { endplateConnections } from "@/lib/track/endplates";
+import {
+  districtColor,
+  districtLegend,
+  moduleDistrictMap,
+  type DistrictLite,
+} from "@/lib/track/districts";
+
+// All coordinates are in inches (the spine's natural unit); the SVG scales.
+const LANE_GAP = 12; // vertical gap between Main 1 and Main 2
+const PAD_X = 12;
+const Y1 = 18; // Main 2 (upper)
+const Y0 = Y1 + LANE_GAP; // Main 1 (lower, continuous)
+const LABEL_Y = Y0 + 14;
+const HEIGHT = LABEL_Y + 8;
+const STROKE = 2.4;
+
+export function OperationsSchematic({
+  modules,
+  districts,
+}: {
+  modules: OpsModuleInput[];
+  districts?: DistrictLite[];
+}) {
+  if (modules.length === 0) {
+    return (
+      <div className="flex h-16 items-center justify-center rounded-md border border-dashed border-slate-700 text-xs text-slate-600">
+        No modules to diagram yet.
+      </div>
+    );
+  }
+
+  const schem = buildOperationsSchematic(modules);
+  const cps = controlPoints(schem);
+  const connections = endplateConnections(modules);
+  const dmap = districts ? moduleDistrictMap(districts) : new Map();
+  const legend = districts ? districtLegend(districts) : [];
+
+  const total = schem.totalInches;
+  const viewBox = `${-PAD_X} 0 ${total + 2 * PAD_X} ${HEIGHT}`;
+  const feet = Math.round((total / 12) * 10) / 10;
+
+  const colorFor = (moduleId?: string | null) =>
+    (moduleId && dmap.get(moduleId)?.index != null
+      ? districtColor(dmap.get(moduleId)!.index)
+      : "#64748b");
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
+        <span>Operations schematic · straightened</span>
+        <span>{feet} ft mainline</span>
+      </div>
+      <svg
+        viewBox={viewBox}
+        width="100%"
+        height="140"
+        preserveAspectRatio="xMidYMid meet"
+        className="rounded-md border border-slate-700 bg-slate-900"
+      >
+        {/* Compass ends */}
+        <text x={-PAD_X + 1} y={Y0 - LANE_GAP / 2} className="fill-slate-500" fontSize="7" dominantBaseline="middle">
+          W
+        </text>
+        <text x={total + PAD_X - 1} y={Y0 - LANE_GAP / 2} textAnchor="end" className="fill-slate-500" fontSize="7" dominantBaseline="middle">
+          E
+        </text>
+
+        {/* Per-module: Main 1 (continuous) + Main 2 (where double) + turnouts */}
+        {schem.cells.map((c) => {
+          const stroke = colorFor(c.input.moduleId);
+          const hasSecond = c.leftTracks >= 2 || c.rightTracks >= 2;
+          const inSwitch = Math.min(c.width * 0.3, 30);
+          const lane1Start = c.leftTracks >= 2 ? c.x : c.x + inSwitch + LANE_GAP;
+          const lane1End =
+            c.rightTracks >= 2 ? c.x + c.width : c.x + c.width - inSwitch - LANE_GAP;
+          return (
+            <g key={c.input.id}>
+              {/* Main 1 — always continuous */}
+              <line
+                x1={c.x}
+                y1={Y0}
+                x2={c.x + c.width}
+                y2={Y0}
+                stroke={stroke}
+                strokeWidth={STROKE}
+                strokeLinecap="round"
+              />
+              {/* Main 2 + diverge/converge turnouts */}
+              {hasSecond && (
+                <>
+                  {lane1End > lane1Start && (
+                    <line
+                      x1={lane1Start}
+                      y1={Y1}
+                      x2={lane1End}
+                      y2={Y1}
+                      stroke={stroke}
+                      strokeWidth={STROKE}
+                      strokeLinecap="round"
+                    />
+                  )}
+                  {c.leftTracks < 2 && (
+                    <line
+                      x1={c.x + inSwitch}
+                      y1={Y0}
+                      x2={lane1Start}
+                      y2={Y1}
+                      stroke={stroke}
+                      strokeWidth={STROKE}
+                      strokeLinecap="round"
+                    />
+                  )}
+                  {c.rightTracks < 2 && (
+                    <line
+                      x1={lane1End}
+                      y1={Y1}
+                      x2={c.x + c.width - inSwitch}
+                      y2={Y0}
+                      stroke={stroke}
+                      strokeWidth={STROKE}
+                      strokeLinecap="round"
+                    />
+                  )}
+                </>
+              )}
+              {/* Module boundary tick */}
+              {c.x > 0 && (
+                <line
+                  x1={c.x}
+                  y1={Y1 - 4}
+                  x2={c.x}
+                  y2={Y0 + 4}
+                  stroke="#334155"
+                  strokeWidth={0.6}
+                />
+              )}
+              {/* Staging yard glyph at the module's staging end */}
+              {c.input.stagingEnd &&
+                [0, 1, 2].map((k) => {
+                  const ex =
+                    c.input.stagingEnd === "A" ? c.x + 2 + k * 3 : c.x + c.width - 2 - k * 3;
+                  return (
+                    <line
+                      key={k}
+                      x1={ex}
+                      y1={Y0 + 3 + k}
+                      x2={ex + 6}
+                      y2={Y0 + 3 + k}
+                      stroke="#818cf8"
+                      strokeWidth={0.8}
+                    />
+                  );
+                })}
+              {/* Hover detail + centred label */}
+              <rect x={c.x} y={0} width={c.width} height={HEIGHT} fill="transparent">
+                <title>
+                  {`${c.input.moduleName ?? c.input.moduleId} · ${
+                    c.leftTracks === c.rightTracks
+                      ? `${c.leftTracks === 2 ? "double" : "single"} main`
+                      : `${c.leftTracks}→${c.rightTracks} track`
+                  }${c.input.moduleId && dmap.get(c.input.moduleId) ? ` · ${dmap.get(c.input.moduleId)!.name}` : ""}${
+                    c.input.stagingEnd ? " · staging" : ""
+                  }`}
+                </title>
+              </rect>
+              {c.width > 28 && (
+                <text
+                  x={c.x + c.width / 2}
+                  y={LABEL_Y}
+                  textAnchor="middle"
+                  className="fill-slate-500"
+                  fontSize="6"
+                >
+                  {c.input.moduleId ?? c.input.moduleName}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Control points — where the main-track count changes (interlockings) */}
+        {cps.map((cp, i) => (
+          <g key={`cp-${i}`}>
+            <circle cx={cp.x} cy={(Y0 + Y1) / 2} r={2.6} fill="#0f172a" stroke="#f59e0b" strokeWidth={1} />
+            <title>
+              {`Control point${cp.label ? ` · ${cp.label}` : ""}: ${cp.fromTracks} → ${cp.toTracks} track`}
+            </title>
+          </g>
+        ))}
+
+        {/* Endplate mismatches — red marker at the offending join */}
+        {connections
+          .filter((cn) => cn.status === "mismatch")
+          .map((cn) => {
+            const cell = schem.cells[cn.toIndex];
+            return (
+              <circle
+                key={`mm-${cn.fromId}-${cn.toId}`}
+                cx={cell.x}
+                cy={Y0}
+                r={3}
+                fill="#7f1d1d"
+                stroke="#ef4444"
+                strokeWidth={1}
+              >
+                <title>{`Endplate mismatch: ${cn.fromConfig} ↔ ${cn.toConfig}`}</title>
+              </circle>
+            );
+          })}
+      </svg>
+
+      {/* Legend */}
+      <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-slate-500">
+        <span className="flex items-center gap-1">
+          <svg width="20" height="10" className="shrink-0">
+            <line x1="1" y1="5" x2="19" y2="5" stroke="#64748b" strokeWidth="1.6" />
+          </svg>
+          single main
+        </span>
+        <span className="flex items-center gap-1">
+          <svg width="20" height="10" className="shrink-0">
+            <line x1="1" y1="3" x2="19" y2="3" stroke="#64748b" strokeWidth="1.6" />
+            <line x1="1" y1="7" x2="19" y2="7" stroke="#64748b" strokeWidth="1.6" />
+          </svg>
+          double main
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-full border border-amber-500" />
+          control point
+        </span>
+        <span className="flex items-center gap-1">
+          <span className="inline-block h-2 w-2 rounded-full border border-red-500 bg-red-900" />
+          endplate mismatch
+        </span>
+        {legend.map((d) => (
+          <span key={d.id} className="flex items-center gap-1">
+            <span className="inline-block h-2 w-2 rounded-sm" style={{ backgroundColor: d.color }} />
+            {d.name}
+          </span>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/track/__tests__/operations.test.ts
+++ b/lib/track/__tests__/operations.test.ts
@@ -1,0 +1,121 @@
+import { describe, it, expect } from "vitest";
+import {
+  buildOperationsSchematic,
+  controlPoints,
+  trackCount,
+  MIN_CELL_INCHES,
+  type OpsModuleInput,
+} from "../operations";
+
+const mod = (
+  id: string,
+  a: string | null,
+  b: string | null,
+  opts: Partial<OpsModuleInput> = {},
+): OpsModuleInput => ({
+  id,
+  moduleName: id,
+  flipped: false,
+  endplates: [
+    { label: "EP-1", track_config: a },
+    { label: "EP-2", track_config: b },
+  ],
+  mainlineLengthInches: 48,
+  ...opts,
+});
+
+describe("trackCount", () => {
+  it("maps single→1, double→2, unknown→null", () => {
+    expect(trackCount("single")).toBe(1);
+    expect(trackCount("double")).toBe(2);
+    expect(trackCount("triple")).toBeNull();
+    expect(trackCount(null)).toBeNull();
+  });
+});
+
+describe("buildOperationsSchematic", () => {
+  it("lays modules West→East with widths ∝ length and cumulative x", () => {
+    const s = buildOperationsSchematic([
+      mod("a", "single", "single", { mainlineLengthInches: 48 }),
+      mod("b", "double", "double", { mainlineLengthInches: 96 }),
+    ]);
+    expect(s.cells[0]).toMatchObject({ x: 0, width: 48 });
+    expect(s.cells[1]).toMatchObject({ x: 48, width: 96 });
+    expect(s.totalInches).toBe(144);
+  });
+
+  it("resolves single vs double from endplate track_config", () => {
+    const s = buildOperationsSchematic([
+      mod("a", "single", "single"),
+      mod("b", "double", "double"),
+    ]);
+    expect(s.cells[0]).toMatchObject({ leftTracks: 1, rightTracks: 1 });
+    expect(s.cells[1]).toMatchObject({ leftTracks: 2, rightTracks: 2 });
+    expect(s.maxTracks).toBe(2);
+  });
+
+  it("models an in-module transition (single on one end, double on the other)", () => {
+    const s = buildOperationsSchematic([mod("a", "single", "double")]);
+    expect(s.cells[0]).toMatchObject({ leftTracks: 1, rightTracks: 2 });
+  });
+
+  it("carries a known count across modules with unknown config", () => {
+    const s = buildOperationsSchematic([
+      mod("a", "double", "double"),
+      mod("b", null, null), // unknown → inherits double from the left
+      mod("c", "double", "double"),
+    ]);
+    expect(s.cells[1]).toMatchObject({ leftTracks: 2, rightTracks: 2 });
+  });
+
+  it("defaults the leading unknown module to a single main", () => {
+    const s = buildOperationsSchematic([mod("a", null, null)]);
+    expect(s.cells[0]).toMatchObject({ leftTracks: 1, rightTracks: 1 });
+  });
+
+  it("enforces a minimum drawn width", () => {
+    const s = buildOperationsSchematic([
+      mod("a", "single", "single", { mainlineLengthInches: 2, lengthTotalInches: 2 }),
+    ]);
+    expect(s.cells[0].width).toBe(MIN_CELL_INCHES);
+  });
+
+  it("respects flip when reading the facing endplates", () => {
+    // flipped: EP order reverses, so left=double(EP-2), right=single(EP-1).
+    const s = buildOperationsSchematic([
+      mod("a", "single", "double", { flipped: true }),
+    ]);
+    expect(s.cells[0]).toMatchObject({ leftTracks: 2, rightTracks: 1 });
+  });
+});
+
+describe("controlPoints", () => {
+  it("flags an in-module single↔double transition at the module centre", () => {
+    const s = buildOperationsSchematic([
+      mod("a", "single", "double", { mainlineLengthInches: 48 }),
+    ]);
+    const cps = controlPoints(s);
+    expect(cps).toHaveLength(1);
+    expect(cps[0]).toMatchObject({ x: 24, fromTracks: 1, toTracks: 2 });
+  });
+
+  it("flags a transition at a module join", () => {
+    const s = buildOperationsSchematic([
+      mod("a", "double", "double", { mainlineLengthInches: 48 }),
+      mod("b", "single", "single", { mainlineLengthInches: 48 }),
+    ]);
+    const cps = controlPoints(s);
+    // double→single occurs at the join (x = 48).
+    expect(cps.some((c) => c.x === 48 && c.fromTracks === 2 && c.toTracks === 1)).toBe(
+      true,
+    );
+  });
+
+  it("reports no control points for a uniform single-track spine", () => {
+    const s = buildOperationsSchematic([
+      mod("a", "single", "single"),
+      mod("b", "single", "single"),
+    ]);
+    expect(controlPoints(s)).toEqual([]);
+  });
+});

--- a/lib/track/operations.ts
+++ b/lib/track/operations.ts
@@ -1,0 +1,134 @@
+/**
+ * Operations schematic (#115 / #122) — the *straightened* dispatcher view.
+ *
+ * Real CTC / dispatching panels throw geography away: the mainline is drawn as a
+ * horizontal spine (West → East), and the diagram only branches where topology
+ * forces it (junctions). Curve/corner geometry is a footprint concern, not an
+ * operations one. What matters here is the sequence of modules, how many main
+ * tracks each carries (single vs double), and where that count changes — the
+ * control points where meets happen.
+ *
+ * This pure builder lays the module sequence out along the spine and resolves
+ * each module's left/right main-track count from its endplate track_config
+ * (single → 1, double → 2), carrying a known count across modules whose config
+ * is unknown so the line stays continuous. The SVG component just draws it.
+ */
+import { inConfig, outConfig, type ModuleEndplates } from "./endplates";
+
+export interface OpsModuleInput extends ModuleEndplates {
+  stagingEnd?: "A" | "B" | null;
+  mainlineLengthInches?: number | null;
+  lengthTotalInches?: number | null;
+}
+
+export interface OpsCell {
+  input: OpsModuleInput;
+  /** Left edge along the spine, in inches from the West end. */
+  x: number;
+  /** Width along the spine, in inches (∝ mainline length). */
+  width: number;
+  /** Main-track count entering (West end) and leaving (East end). */
+  leftTracks: number;
+  rightTracks: number;
+}
+
+export interface OperationsSchematic {
+  cells: OpsCell[];
+  totalInches: number;
+  /** Widest track count anywhere — how many lanes the diagram needs. */
+  maxTracks: number;
+}
+
+/** Minimum drawn width so a short module is still legible. */
+export const MIN_CELL_INCHES = 12;
+/** Fallback length when a module reports none. */
+export const DEFAULT_CELL_INCHES = 24;
+
+/** Main-track count from an endplate track_config; null when unknown. */
+export function trackCount(config: string | null): number | null {
+  if (config === "single") return 1;
+  if (config === "double") return 2;
+  return null;
+}
+
+export function buildOperationsSchematic(
+  modules: OpsModuleInput[],
+): OperationsSchematic {
+  // First pass: raw left/right counts (may be null) and cell widths.
+  let x = 0;
+  const cells: OpsCell[] = modules.map((m) => {
+    const len =
+      (m.mainlineLengthInches && m.mainlineLengthInches > 0
+        ? m.mainlineLengthInches
+        : m.lengthTotalInches && m.lengthTotalInches > 0
+          ? m.lengthTotalInches
+          : DEFAULT_CELL_INCHES) || DEFAULT_CELL_INCHES;
+    const width = Math.max(len, MIN_CELL_INCHES);
+    const cell: OpsCell = {
+      input: m,
+      x,
+      width,
+      leftTracks: trackCount(inConfig(m)) ?? 0,
+      rightTracks: trackCount(outConfig(m)) ?? 0,
+    };
+    x += width;
+    return cell;
+  });
+
+  // Second pass: carry a known count across unknown (0) ends so the spine is
+  // continuous; default the very first unknown to a single main.
+  let carried = 1;
+  for (const cell of cells) {
+    if (cell.leftTracks === 0) cell.leftTracks = carried;
+    if (cell.rightTracks === 0) cell.rightTracks = cell.leftTracks;
+    carried = cell.rightTracks;
+  }
+
+  const maxTracks = cells.reduce(
+    (m, c) => Math.max(m, c.leftTracks, c.rightTracks),
+    1,
+  );
+
+  return { cells, totalInches: x, maxTracks };
+}
+
+/**
+ * Control points: boundaries where the main-track count changes (single↔double)
+ * — inside a module (its two ends differ) or at a join between modules. These
+ * are the interlockings/crossovers a dispatcher cares about.
+ */
+export interface ControlPoint {
+  /** Position along the spine, in inches from the West end. */
+  x: number;
+  fromTracks: number;
+  toTracks: number;
+  /** Human label for the nearest module. */
+  label: string | null;
+}
+
+export function controlPoints(schem: OperationsSchematic): ControlPoint[] {
+  const out: ControlPoint[] = [];
+  const name = (c: OpsCell) => c.input.moduleName ?? c.input.moduleId ?? null;
+  schem.cells.forEach((c, i) => {
+    // Transition inside the module (its ends differ).
+    if (c.leftTracks !== c.rightTracks) {
+      out.push({
+        x: c.x + c.width / 2,
+        fromTracks: c.leftTracks,
+        toTracks: c.rightTracks,
+        label: name(c),
+      });
+    }
+    // Transition at the join to the next module.
+    const next = schem.cells[i + 1];
+    if (next && c.rightTracks !== next.leftTracks) {
+      out.push({
+        x: next.x,
+        fromTracks: c.rightTracks,
+        toTracks: next.leftTracks,
+        label: name(next),
+      });
+    }
+  });
+  return out;
+}


### PR DESCRIPTION
## What

The heart of dispatching is a **straightened track diagram**, not a to-scale
map — exactly how real CTC panels and JMRI's CTC tools draw it. This adds an
**Operations schematic**: the mainline as a horizontal **West → East spine**,
with **single vs double track explicit** and the **control points** between them
marked. Geometry (curves/corners) is deliberately dropped here — that's the
footprint view's job.

## How it reads
- **Main 1** runs unbroken the whole length.
- A **second main** appears as a parallel line that **diverges/converges through
  turnouts** exactly where the track count changes.
- **Control points** (amber) mark every single↔double transition — the
  interlockings where meets happen.
- Modules are **coloured by district** (#127); **endplate mismatches** (#126) and
  **staging** are marked.

## Code
- **`lib/track/operations.ts`** — pure `buildOperationsSchematic()` lays the
  sequence West→East (widths ∝ mainline length), resolves each module's left/right
  main-track count from endplate `track_config` (single→1, double→2), carrying a
  known count across unknown modules so the spine stays continuous.
  `controlPoints()` finds every single↔double transition (in-module or at a join).
  **11 unit tests.**
- **`OperationsSchematic.tsx`** renders the spine, turnouts, control points,
  district colour, staging and mismatch markers. The old geometry-aware drawing
  stays as a secondary **"Footprint (physical layout)"** view.

## Verified in the browser
`single (North) → double-with-turnouts (Cascade) → single (South)` renders W→E
with **2 control points** (1→2 and 2→1) and the mismatch markers, correctly
coloured by district. No console errors.

## Test
87 unit tests (11 new) + typecheck + lint + production build all green.

## Next
Junction branching (multi-spine, the "North–South traffic" case) and overlaying
section/block boundaries and signals onto the spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
