### PR TITLE
feat: overlay section brackets on the Operations schematic (#115)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -20,13 +20,19 @@ import {
   districtColor,
   districtLegend,
   moduleDistrictMap,
-  type DistrictLite,
 } from "@/lib/track/districts";
+import {
+  moduleSectionMap,
+  sectionSpans,
+  type SectionAwareDistrict,
+} from "@/lib/track/sections";
 
 // All coordinates are in inches (the spine's natural unit); the SVG scales.
 const LANE_GAP = 12; // vertical gap between Main 1 and Main 2
 const PAD_X = 12;
-const Y1 = 18; // Main 2 (upper)
+const SECTION_LABEL_Y = 6; // section name (top band)
+const SECTION_BRACKET_Y = 9; // section bracket line
+const Y1 = 22; // Main 2 (upper)
 const Y0 = Y1 + LANE_GAP; // Main 1 (lower, continuous)
 const LABEL_Y = Y0 + 14;
 const HEIGHT = LABEL_Y + 8;
@@ -37,7 +43,7 @@ export function OperationsSchematic({
   districts,
 }: {
   modules: OpsModuleInput[];
-  districts?: DistrictLite[];
+  districts?: SectionAwareDistrict[];
 }) {
   if (modules.length === 0) {
     return (
@@ -52,6 +58,11 @@ export function OperationsSchematic({
   const connections = endplateConnections(modules);
   const dmap = districts ? moduleDistrictMap(districts) : new Map();
   const legend = districts ? districtLegend(districts) : [];
+  const smap = districts ? moduleSectionMap(districts) : new Map();
+  // Contiguous runs of modules that share a section — one bracket each.
+  const spans = sectionSpans(schem.cells, (c) =>
+    c.input.moduleId ? smap.get(c.input.moduleId) : undefined,
+  );
 
   const total = schem.totalInches;
   const viewBox = `${-PAD_X} 0 ${total + 2 * PAD_X} ${HEIGHT}`;
@@ -82,6 +93,30 @@ export function OperationsSchematic({
         <text x={total + PAD_X - 1} y={Y0 - LANE_GAP / 2} textAnchor="end" className="fill-slate-500" fontSize="7" dominantBaseline="middle">
           E
         </text>
+
+        {/* Section brackets — the units a dispatcher allocates */}
+        {spans
+          .filter((s) => s.sectionName)
+          .map((s, i) => {
+            const first = s.items[0];
+            const last = s.items[s.items.length - 1];
+            const startX = first.x;
+            const endX = last.x + last.width;
+            const track = first.input.moduleId
+              ? smap.get(first.input.moduleId)?.track
+              : null;
+            return (
+              <g key={`sec-${i}`}>
+                <line x1={startX} y1={SECTION_BRACKET_Y} x2={endX} y2={SECTION_BRACKET_Y} stroke="#475569" strokeWidth={0.7} />
+                <line x1={startX} y1={SECTION_BRACKET_Y - 2.5} x2={startX} y2={SECTION_BRACKET_Y} stroke="#475569" strokeWidth={0.7} />
+                <line x1={endX} y1={SECTION_BRACKET_Y - 2.5} x2={endX} y2={SECTION_BRACKET_Y} stroke="#475569" strokeWidth={0.7} />
+                <text x={(startX + endX) / 2} y={SECTION_LABEL_Y} textAnchor="middle" className="fill-slate-400" fontSize="6">
+                  {s.sectionName}
+                  {track ? ` · ${track}` : ""}
+                </text>
+              </g>
+            );
+          })}
 
         {/* Per-module: Main 1 (continuous) + Main 2 (where double) + turnouts */}
         {schem.cells.map((c) => {

--- a/lib/track/__tests__/sections.test.ts
+++ b/lib/track/__tests__/sections.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import {
+  moduleSectionMap,
+  sectionSpans,
+  type SectionAwareDistrict,
+} from "../sections";
+
+const district = (
+  id: string,
+  name: string,
+  sections: { id: string; name: string; track?: string | null; mods: (string | null)[] }[],
+): SectionAwareDistrict => ({
+  id,
+  name,
+  sections: sections.map((s) => ({
+    id: s.id,
+    name: s.name,
+    track: s.track ?? null,
+    blocks: s.mods.map((moduleRecordNumber) => ({ moduleRecordNumber })),
+  })),
+});
+
+describe("moduleSectionMap", () => {
+  it("maps a module to the section whose block links it", () => {
+    const map = moduleSectionMap([
+      district("d1", "North", [
+        { id: "s1", name: "Sec A", track: "Main 1", mods: ["FMN-0001"] },
+        { id: "s2", name: "Sec B", mods: ["FMN-0002"] },
+      ]),
+    ]);
+    expect(map.get("FMN-0001")).toMatchObject({
+      sectionId: "s1",
+      sectionName: "Sec A",
+      districtName: "North",
+      track: "Main 1",
+    });
+    expect(map.get("FMN-0002")?.sectionName).toBe("Sec B");
+    expect(map.has("FMN-9999")).toBe(false);
+  });
+
+  it("keeps the first section when a module is linked twice", () => {
+    const map = moduleSectionMap([
+      district("d1", "North", [
+        { id: "s1", name: "Sec A", mods: ["FMN-0001"] },
+        { id: "s2", name: "Sec B", mods: ["FMN-0001"] },
+      ]),
+    ]);
+    expect(map.get("FMN-0001")?.sectionId).toBe("s1");
+  });
+});
+
+describe("sectionSpans", () => {
+  const map = moduleSectionMap([
+    district("d1", "North", [
+      { id: "s1", name: "Sec A", mods: ["a", "b"] },
+      { id: "s2", name: "Sec B", mods: ["d"] },
+    ]),
+  ]);
+  const sectionOf = (rec: string) => map.get(rec);
+
+  it("groups contiguous modules of the same section and breaks on change/gap", () => {
+    const spans = sectionSpans(["a", "b", "c", "d"], sectionOf);
+    expect(spans.map((s) => [s.sectionName, s.items])).toEqual([
+      ["Sec A", ["a", "b"]],
+      [null, ["c"]], // unassigned
+      ["Sec B", ["d"]],
+    ]);
+  });
+
+  it("splits a repeated section that is not contiguous into separate spans", () => {
+    // a(SecA) c(unassigned) b(SecA) → two SecA spans, not merged across the gap.
+    const spans = sectionSpans(["a", "c", "b"], sectionOf);
+    expect(spans.map((s) => s.sectionName)).toEqual(["Sec A", null, "Sec A"]);
+  });
+
+  it("returns an empty list for no items", () => {
+    expect(sectionSpans([], sectionOf)).toEqual([]);
+  });
+});

--- a/lib/track/sections.ts
+++ b/lib/track/sections.ts
@@ -1,0 +1,87 @@
+/**
+ * Module → Section mapping (#115) — the operations schematic colours and groups
+ * by district; this resolves the finer unit a dispatcher actually *allocates*:
+ * the Section. Like district mapping, a module's section is found by walking
+ * district → section → block and matching blocks.moduleRecordNumber.
+ *
+ * Pure so it can be unit-tested; the schematic overlays the result as brackets.
+ */
+
+export interface SectionAwareDistrict {
+  id: string;
+  name: string;
+  sections: {
+    id: string;
+    name: string;
+    track?: string | null;
+    blocks: { moduleRecordNumber: string | null }[];
+  }[];
+}
+
+export interface ModuleSection {
+  sectionId: string;
+  sectionName: string;
+  districtName: string;
+  /** Optional parallel-main label (e.g. "Main 1"). */
+  track: string | null;
+}
+
+/**
+ * Map each module record number to the section that owns it (first by district
+ * then section order when a module is linked more than once).
+ */
+export function moduleSectionMap(
+  districts: SectionAwareDistrict[],
+): Map<string, ModuleSection> {
+  const map = new Map<string, ModuleSection>();
+  for (const d of districts) {
+    for (const s of d.sections) {
+      for (const b of s.blocks) {
+        const rec = b.moduleRecordNumber?.trim();
+        if (rec && !map.has(rec)) {
+          map.set(rec, {
+            sectionId: s.id,
+            sectionName: s.name,
+            districtName: d.name,
+            track: s.track ?? null,
+          });
+        }
+      }
+    }
+  }
+  return map;
+}
+
+export interface SectionSpan<T> {
+  sectionId: string | null;
+  sectionName: string | null;
+  /** Indices of the contiguous run of items this span covers. */
+  items: T[];
+}
+
+/**
+ * Group a module sequence into contiguous runs that share a section, so the
+ * schematic can draw one bracket per section. A run of modules with no section
+ * (unassigned) becomes a span with sectionId null.
+ */
+export function sectionSpans<T>(
+  items: T[],
+  sectionOf: (item: T) => ModuleSection | undefined,
+): SectionSpan<T>[] {
+  const spans: SectionSpan<T>[] = [];
+  for (const item of items) {
+    const sec = sectionOf(item);
+    const id = sec?.sectionId ?? null;
+    const last = spans[spans.length - 1];
+    if (last && last.sectionId === id) {
+      last.items.push(item);
+    } else {
+      spans.push({
+        sectionId: id,
+        sectionName: sec?.sectionName ?? null,
+        items: [item],
+      });
+    }
+  }
+  return spans;
+}


### PR DESCRIPTION
## What

Makes the Operations panel *operable*: the dispatcher allocates **Sections**, so
draw them on the straightened spine. A bracket + label sits above the mainline
spanning the modules that make up each section.

- Contiguous modules in the same section share **one bracket**; unassigned
  modules get none.
- The section's `track` label (e.g. "Main 1") shows alongside the name when set.

## Code
- **`lib/track/sections.ts`** — pure `moduleSectionMap()` (module → section via
  district → section → block → `moduleRecordNumber`) and `sectionSpans()` (group a
  module run into contiguous same-section spans, breaking on change **or gap** so a
  non-contiguous repeat isn't merged). **5 unit tests.**
- `OperationsSchematic` renders a bracket per span above the West→East spine.

## Verified in the browser
The demo layout draws **"Sec N"** over its module and **"Sec S"** over another,
with the unassigned middle module correctly bare. No console errors.

## Test
92 unit tests (5 new) + typecheck + lint + production build all green.

## Next
Signal masts on the spine, and live occupancy/allocation colouring (wiring the
runtime `block_occupancy` / `section_allocations` state into the panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
