### PR TITLE
docs: module schematic format v1 (draft) — MR↔FD contract (#122)

### DIFF
--- a/docs/module-schematic-format.md
+++ b/docs/module-schematic-format.md
@@ -1,0 +1,157 @@
+# Module Schematic Format — v1 (draft)
+
+Status: **draft** · Epic: [#122](https://github.com/willcgage/free-dispatcher/issues/122)
+
+The contract between the **Module Repository** (which authors a module's schematic)
+and **Free-Dispatcher** (which imports and composes modules into a layout). It lets
+an owner depict their module accurately once — track paths, turnouts, signals,
+endplates — so Free-Dispatcher can chain modules into a layout without
+reconstructing each module's internals.
+
+## Division of labor
+
+- **Module Repository** owns *authoring*: one build tool, one canonical schematic
+  per module, versioned.
+- **Free-Dispatcher** owns *composition*: import each module's schematic, chain by
+  endplate, assign sections/districts, and drive dispatching. FD never re-derives a
+  module's internals.
+
+## Design principles
+
+1. **Topological, straightened-first.** The doc describes *what connects to what*,
+   not exact angles. Real CTC/dispatcher panels straighten the railroad; geometry
+   (curves/corners) stays in the existing MR fields for the *footprint* view only.
+2. **Minimal by default.** A plain single-track straight is a few lines of data.
+   Everything past the through-track is optional.
+3. **Composition by endplate.** Modules join only at endplates; each endplate
+   declares the tracks crossing it so FD can wire lanes across the boundary and run
+   the single↔double compatibility check.
+4. **Additive & versioned.** No schematic → FD falls back to deriving single/double
+   from endplate `track_config`. Existing modules keep working.
+
+## Coordinate model — 1-D `pos` + `lane`
+
+- **`pos`** — inches along the module measured from endplate **A** (the canonical
+  West/left end). FD applies the placement `flipped` flag by mirroring
+  `pos → lengthInches − pos` and swapping endplates A/B.
+- **`lane`** — integer track index across the module (0 = primary main, 1 = second
+  main; sidings/spurs get their own indices). Vertical spacing is FD's to render.
+
+There is deliberately **no 2-D geometry** here — that would reintroduce the angles
+the operations view drops, and is harder to author. The footprint view keeps using
+`geometry_type` / `geometry_degrees` / lengths.
+
+## Storage & transport
+
+- **MR storage:** a `schematic jsonb` column plus `schematic_version int` on
+  `freemon_modules`. One document per module.
+- **Transport:** `modules-full` returns the `schematic` object **inline** (it is
+  small). FD syncs it into `repo_modules.schematic` (jsonb), alongside the file
+  `schematics[]` metadata it already stores.
+
+## Entity model
+
+All ids are strings unique within the document. Positions are inches; `config`
+values are `single` | `double`.
+
+| Entity | Purpose | Fields |
+|---|---|---|
+| **endplate** | connection point to the neighbor | `id` (`A`/`B`/…), `label`, `tracks[]` = `{ trackId, lane, config }` |
+| **track** | a running track | `id`, `role` (`main`\|`siding`\|`spur`\|`yard`\|`crossover`), `lane`, `from`, `to` (endplate or node id), `capacityFeet?`, `industryRef?` |
+| **turnout** | a switch diverging off a track | `id`, `pos`, `onTrack`, `divergeTrack`, `kind` (`left`\|`right`\|`wye`), `name`, `address?` |
+| **signal** | a mast/dwarf governing a track | `id`, `pos`, `track`, `facing` (`AtoB`\|`BtoA`), `kind` (`mast`\|`dwarf`), `name`, `aspects[]`, `address?` |
+| **block** | native detection segment | `id`, `name`, `tracks[]`, `from`, `to` (pos range) |
+| **mss** | signal-system interface | `type`, `interfaces[]` (endplate ids) |
+
+Top-level document fields: `version` (int), `module` (record number), `lengthInches`,
+then the arrays above (`endplates` and `tracks` required; the rest optional).
+
+Decisions baked in (revisable):
+- **Blocks** are *native* to the module and optional; FD may subdivide or group them
+  into sections at the layout.
+- **Turnout/signal `address`** is optional and included now (forward-looking for
+  DCC/LCC automation) even though FD is manual today.
+
+## Example — minimal single-track straight
+
+```json
+{
+  "version": 1, "module": "FMN-0001", "lengthInches": 48,
+  "endplates": [
+    { "id": "A", "label": "West", "tracks": [{ "trackId": "main", "lane": 0, "config": "single" }] },
+    { "id": "B", "label": "East", "tracks": [{ "trackId": "main", "lane": 0, "config": "single" }] }
+  ],
+  "tracks": [ { "id": "main", "role": "main", "lane": 0, "from": "A", "to": "B" } ]
+}
+```
+
+## Example — passing siding + industry spur + signal
+
+```json
+{
+  "version": 1, "module": "FMN-0003", "lengthInches": 96,
+  "endplates": [
+    { "id": "A", "label": "West", "tracks": [{ "trackId": "main", "lane": 0, "config": "single" }] },
+    { "id": "B", "label": "East", "tracks": [{ "trackId": "main", "lane": 0, "config": "single" }] }
+  ],
+  "tracks": [
+    { "id": "main", "role": "main",   "lane": 0, "from": "A",   "to": "B" },
+    { "id": "sid",  "role": "siding", "lane": 1, "from": "swW", "to": "swE", "capacityFeet": 8 },
+    { "id": "spur", "role": "spur",   "lane": 2, "from": "swW", "to": "spurEnd", "industryRef": 5 }
+  ],
+  "turnouts": [
+    { "id": "swW", "pos": 18, "onTrack": "main", "divergeTrack": "sid", "kind": "right", "name": "West Siding" },
+    { "id": "swE", "pos": 78, "onTrack": "main", "divergeTrack": "sid", "kind": "left",  "name": "East Siding" }
+  ],
+  "signals": [
+    { "id": "sW", "pos": 10, "track": "main", "facing": "AtoB", "kind": "mast", "name": "CP West", "aspects": ["red","yellow","green"] }
+  ],
+  "blocks": [
+    { "id": "b1", "name": "Main W", "tracks": ["main"], "from": 0,  "to": 48 },
+    { "id": "b2", "name": "Main E", "tracks": ["main"], "from": 48, "to": 96 }
+  ]
+}
+```
+
+## Composition rules (Free-Dispatcher)
+
+1. Chain modules **West → East** in layout sequence order.
+2. At each boundary, module N's endplate **B** meets N+1's endplate **A**; match
+   tracks by **lane**, verify **config** compatibility (the single↔double endplate
+   check), and continue lanes across the boundary.
+3. Apply `flipped` by mirroring `pos` and swapping A/B before chaining.
+4. The layout operations schematic is the **concatenation of module graphs** —
+   turnouts, sidings, signals appear where the owner placed them.
+
+## What stays in Free-Dispatcher
+
+- Grouping module **blocks → sections → districts** and dispatcher assignment
+  (layout/event-specific, not a module property).
+- Runtime **occupancy / allocations** and **signal aspect** derivation — the module
+  supplies the mast; FD computes red/yellow/green from occupancy + authority.
+- The **footprint** view (uses existing geometry fields).
+
+## Fallback (no authored schematic)
+
+FD derives a trivial graph: one `main` track per endplate `track_config`
+(`single`→1 lane, `double`→2 lanes), no turnouts/signals. This is exactly what the
+current operations renderer does, so un-authored modules render unchanged.
+
+## Versioning
+
+- `version` is the format version (start at 1).
+- `schematic_version` (the MR column) increments when an owner edits a module's
+  schematic, so a layout that imported an older revision can detect drift.
+
+## Implementation checklist
+
+**Module Repository**
+- [ ] Migration: `schematic jsonb`, `schematic_version int` on `freemon_modules`.
+- [ ] `modules-full`: return `schematic` inline.
+- [ ] Build tool: the authoring UI in the MR web app (Next.js) that produces this doc.
+
+**Free-Dispatcher**
+- [ ] Sync `repo_modules.schematic` (jsonb).
+- [ ] Import + compose module graphs into the layout operations schematic (replacing
+      the field-derived version, with the fallback above).
+- [ ] Seed layout turnouts/signals/blocks from imported module graphs.


### PR DESCRIPTION
## What

The **contract** for owner-authored module schematics (#122): the Module
Repository builds a module's schematic once; Free-Dispatcher imports and composes
modules into a layout without reconstructing each module's internals.

`docs/module-schematic-format.md` — a topological, straightened-first format.

## Confirmed decisions
- **Coordinate model:** 1-D `pos` (inches from endplate A) + `lane` index.
- **Storage:** `schematic jsonb` + `schematic_version` column on `freemon_modules`,
  returned **inline** by `modules-full`.
- **Entities:** endplates, tracks (main/siding/spur/…), turnouts, signals, blocks,
  MSS — with worked examples (minimal straight; passing siding + spur + signal).
- **Composition:** chain West→East, connect at endplates by lane, single↔double
  check, flip by mirroring `pos`.
- **Additive:** un-authored modules fall back to the field-derived single/double
  the operations renderer already does.

Includes an implementation checklist for both repos. Docs-only — no code change.

Closes the design gate on #122; the MR DB + build tool become well-defined tasks
against this doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
