### PR TITLE
feat: import owner-authored module track-graphs onto the operations schematic (#122)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -59,6 +59,7 @@ interface LayoutModuleNode {
   geometryDegrees: number | null;
   flipped: boolean;
   endplates: { label?: string | null; track_config?: string | null }[] | null;
+  schematic: unknown;
 }
 interface LayoutTree extends LayoutRow {
   modules: LayoutModuleNode[];

--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -26,17 +26,21 @@ import {
   sectionSpans,
   type SectionAwareDistrict,
 } from "@/lib/track/sections";
+import { asModuleSchematic, moduleFeatures } from "@/lib/track/moduleSchematic";
 
 // All coordinates are in inches (the spine's natural unit); the SVG scales.
 const LANE_GAP = 12; // vertical gap between Main 1 and Main 2
 const PAD_X = 12;
 const SECTION_LABEL_Y = 6; // section name (top band)
 const SECTION_BRACKET_Y = 9; // section bracket line
-const Y1 = 22; // Main 2 (upper)
+const Y1 = 32; // Main 2 (upper) — headroom above for siding/spur lanes
 const Y0 = Y1 + LANE_GAP; // Main 1 (lower, continuous)
-const LABEL_Y = Y0 + 14;
-const HEIGHT = LABEL_Y + 8;
+const LABEL_Y = Y0 + 10;
+const HEIGHT = LABEL_Y + 6;
 const STROKE = 2.4;
+
+/** Lane index → y. Lane 0 is Main 1; higher lanes stack upward. */
+const laneY = (lane: number) => Y0 - lane * LANE_GAP;
 
 export function OperationsSchematic({
   modules,
@@ -231,6 +235,68 @@ export function OperationsSchematic({
           );
         })}
 
+        {/* Authored track-graph overlay (#122): sidings/spurs, turnouts, signals
+            for modules whose owner published a schematic. */}
+        {schem.cells.map((c) => {
+          const doc = asModuleSchematic(c.input.schematic);
+          if (!doc) return null;
+          const feat = moduleFeatures(doc);
+          const stroke = colorFor(c.input.moduleId);
+          const px = (frac: number) => c.x + frac * c.width;
+          return (
+            <g key={`${c.input.id}-schem`}>
+              {feat.extraTracks.map((t) => (
+                <line
+                  key={t.id}
+                  x1={px(t.fromFrac)}
+                  y1={laneY(t.lane)}
+                  x2={px(t.toFrac)}
+                  y2={laneY(t.lane)}
+                  stroke={stroke}
+                  strokeWidth={STROKE * 0.8}
+                  strokeLinecap="round"
+                  strokeDasharray={t.role === "spur" ? "2 2" : undefined}
+                >
+                  <title>
+                    {`${t.role}${t.capacityFeet ? ` · ${t.capacityFeet} ft` : ""}`}
+                  </title>
+                </line>
+              ))}
+              {feat.turnouts.map((t) => {
+                const dir = t.posFrac < 0.5 ? 1 : -1;
+                return (
+                  <line
+                    key={t.id}
+                    x1={px(t.posFrac) - dir * 4}
+                    y1={laneY(t.onLane)}
+                    x2={px(t.posFrac)}
+                    y2={laneY(t.divergeLane)}
+                    stroke={stroke}
+                    strokeWidth={STROKE * 0.8}
+                    strokeLinecap="round"
+                  >
+                    <title>{`Turnout${t.name ? ` · ${t.name}` : ""}`}</title>
+                  </line>
+                );
+              })}
+              {feat.signals.map((s) => (
+                <g key={s.id}>
+                  <line
+                    x1={px(s.posFrac)}
+                    y1={laneY(s.lane) - 2}
+                    x2={px(s.posFrac)}
+                    y2={laneY(s.lane) - 7}
+                    stroke="#94a3b8"
+                    strokeWidth={0.8}
+                  />
+                  <circle cx={px(s.posFrac)} cy={laneY(s.lane) - 8} r={1.6} fill="#94a3b8" />
+                  <title>{`Signal${s.name ? ` · ${s.name}` : ""} (${s.facing})`}</title>
+                </g>
+              ))}
+            </g>
+          );
+        })}
+
         {/* Control points — where the main-track count changes (interlockings) */}
         {cps.map((cp, i) => (
           <g key={`cp-${i}`}>
@@ -284,6 +350,20 @@ export function OperationsSchematic({
         <span className="flex items-center gap-1">
           <span className="inline-block h-2 w-2 rounded-full border border-red-500 bg-red-900" />
           endplate mismatch
+        </span>
+        <span className="flex items-center gap-1">
+          <svg width="20" height="10" className="shrink-0">
+            <line x1="1" y1="7" x2="19" y2="7" stroke="#64748b" strokeWidth="1.4" />
+            <line x1="6" y1="7" x2="14" y2="2" stroke="#64748b" strokeWidth="1.4" />
+          </svg>
+          siding / turnout
+        </span>
+        <span className="flex items-center gap-1">
+          <svg width="12" height="10" className="shrink-0">
+            <line x1="6" y1="9" x2="6" y2="4" stroke="#94a3b8" strokeWidth="0.9" />
+            <circle cx="6" cy="3" r="1.8" fill="#94a3b8" />
+          </svg>
+          signal
         </span>
         {legend.map((d) => (
           <span key={d.id} className="flex items-center gap-1">

--- a/docs/module-schematic-format.md
+++ b/docs/module-schematic-format.md
@@ -57,7 +57,7 @@ values are `single` | `double`.
 | Entity | Purpose | Fields |
 |---|---|---|
 | **endplate** | connection point to the neighbor | `id` (`A`/`B`/…), `label`, `tracks[]` = `{ trackId, lane, config }` |
-| **track** | a running track | `id`, `role` (`main`\|`siding`\|`spur`\|`yard`\|`crossover`), `lane`, `from`, `to` (endplate or node id), `capacityFeet?`, `industryRef?` |
+| **track** | a running track | `id`, `role` (`main`\|`siding`\|`spur`\|`yard`\|`crossover`), `lane`, `from`, `to` (endplate or node id), `fromPos?`/`toPos?` (explicit inches, overriding node lookup), `capacityFeet?`, `industryRef?` |
 | **turnout** | a switch diverging off a track | `id`, `pos`, `onTrack`, `divergeTrack`, `kind` (`left`\|`right`\|`wye`), `name`, `address?` |
 | **signal** | a mast/dwarf governing a track | `id`, `pos`, `track`, `facing` (`AtoB`\|`BtoA`), `kind` (`mast`\|`dwarf`), `name`, `aspects[]`, `address?` |
 | **block** | native detection segment | `id`, `name`, `tracks[]`, `from`, `to` (pos range) |
@@ -96,8 +96,8 @@ Decisions baked in (revisable):
   ],
   "tracks": [
     { "id": "main", "role": "main",   "lane": 0, "from": "A",   "to": "B" },
-    { "id": "sid",  "role": "siding", "lane": 1, "from": "swW", "to": "swE", "capacityFeet": 8 },
-    { "id": "spur", "role": "spur",   "lane": 2, "from": "swW", "to": "spurEnd", "industryRef": 5 }
+    { "id": "sid",  "role": "siding", "lane": 1, "from": "swW", "to": "swE", "fromPos": 18, "toPos": 78, "capacityFeet": 8 },
+    { "id": "spur", "role": "spur",   "lane": 2, "from": "swW", "to": "spurEnd", "fromPos": 18, "toPos": 40, "industryRef": 5 }
   ],
   "turnouts": [
     { "id": "swW", "pos": 18, "onTrack": "main", "divergeTrack": "sid", "kind": "right", "name": "West Siding" },
@@ -146,12 +146,12 @@ current operations renderer does, so un-authored modules render unchanged.
 ## Implementation checklist
 
 **Module Repository**
-- [ ] Migration: `schematic jsonb`, `schematic_version int` on `freemon_modules`.
-- [ ] `modules-full`: return `schematic` inline.
+- [x] Migration: `schematic jsonb`, `schematic_version int` on `freemon_modules`.
+- [x] `modules-full`: return `schematic` inline.
 - [ ] Build tool: the authoring UI in the MR web app (Next.js) that produces this doc.
 
 **Free-Dispatcher**
-- [ ] Sync `repo_modules.schematic` (jsonb).
-- [ ] Import + compose module graphs into the layout operations schematic (replacing
-      the field-derived version, with the fallback above).
-- [ ] Seed layout turnouts/signals/blocks from imported module graphs.
+- [x] Sync `repo_modules.schematic` (jsonb).
+- [x] Import + overlay module graphs (sidings/spurs, turnouts, signals) on the
+      operations schematic, with the field-derived fallback above.
+- [ ] Seed layout turnouts/signals/blocks (occupancy/allocation) from imported graphs.

--- a/lib/db/migrations/0013_repo_module_track_graph.sql
+++ b/lib/db/migrations/0013_repo_module_track_graph.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "repo_modules" ADD COLUMN "schematic" jsonb;--> statement-breakpoint
+-- Full re-sync so existing rows backfill their authored track-graph (#122).
+DELETE FROM "app_settings" WHERE "key" = 'module_repo_sync';

--- a/lib/db/migrations/meta/0013_snapshot.json
+++ b/lib/db/migrations/meta/0013_snapshot.json
@@ -1,0 +1,1756 @@
+{
+  "id": "5bf5a11d-cf37-44a6-b568-64fa665a1b5e",
+  "prevId": "9df1bb5c-cb28-488b-b514-76dbecaf6160",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authority_log": {
+      "name": "authority_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_operator": {
+          "name": "by_operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "authority_log_session_idx": {
+          "name": "authority_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authority_log_session_id_sessions_id_fk": {
+          "name": "authority_log_session_id_sessions_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authority_log_train_id_trains_id_fk": {
+          "name": "authority_log_train_id_trains_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_occupancy": {
+      "name": "block_occupancy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occupied": {
+          "name": "occupied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_occupancy_session_block": {
+          "name": "block_occupancy_session_block",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_occupancy_session_idx": {
+          "name": "block_occupancy_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "block_occupancy_session_id_sessions_id_fk": {
+          "name": "block_occupancy_session_id_sessions_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_block_id_blocks_id_fk": {
+          "name": "block_occupancy_block_id_blocks_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_train_id_trains_id_fk": {
+          "name": "block_occupancy_train_id_trains_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "module_record_number": {
+          "name": "module_record_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_section_idx": {
+          "name": "blocks_section_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_section_id_sections_id_fk": {
+          "name": "blocks_section_id_sections_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.districts": {
+      "name": "districts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "districts_layout_idx": {
+          "name": "districts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "districts_layout_id_layouts_id_fk": {
+          "name": "districts_layout_id_layouts_id_fk",
+          "tableFrom": "districts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layouts": {
+      "name": "layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'freemon'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_layouts": {
+      "name": "module_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "staging_end": {
+          "name": "staging_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flipped": {
+          "name": "flipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "module_layouts_layout_idx": {
+          "name": "module_layouts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_layouts_layout_id_layouts_id_fk": {
+          "name": "module_layouts_layout_id_layouts_id_fk",
+          "tableFrom": "module_layouts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "operators_session_idx": {
+          "name": "operators_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operators_device_idx": {
+          "name": "operators_device_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operators_session_id_sessions_id_fk": {
+          "name": "operators_session_id_sessions_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ops_log": {
+      "name": "ops_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ops_log_session_idx": {
+          "name": "ops_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ops_log_session_id_sessions_id_fk": {
+          "name": "ops_log_session_id_sessions_id_fk",
+          "tableFrom": "ops_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_modules": {
+      "name": "repo_modules",
+      "schema": "",
+      "columns": {
+        "record_number": {
+          "name": "record_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_type": {
+          "name": "geometry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_degrees": {
+          "name": "geometry_degrees",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_offset_inches": {
+          "name": "geometry_offset_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "length_total_inches": {
+          "name": "length_total_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mainline_length_inches": {
+          "name": "mainline_length_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplate_count": {
+          "name": "endplate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_mss": {
+          "name": "has_mss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mss_type": {
+          "name": "mss_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplates": {
+          "name": "endplates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industries": {
+          "name": "industries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematics": {
+          "name": "schematics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematic": {
+          "name": "schematic",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_updated_at": {
+          "name": "upstream_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.section_allocations": {
+      "name": "section_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allocated_by": {
+          "name": "allocated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "section_allocations_session_idx": {
+          "name": "section_allocations_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_train_idx": {
+          "name": "section_allocations_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_active_section": {
+          "name": "section_allocations_active_section",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"section_allocations\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_allocations_session_id_sessions_id_fk": {
+          "name": "section_allocations_session_id_sessions_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_section_id_sections_id_fk": {
+          "name": "section_allocations_section_id_sections_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_train_id_trains_id_fk": {
+          "name": "section_allocations_train_id_trains_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sections_district_idx": {
+          "name": "sections_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sections_district_id_districts_id_fk": {
+          "name": "sections_district_id_districts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_config_id": {
+          "name": "layout_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_one_active": {
+          "name": "sessions_one_active",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_layout_id_layouts_id_fk": {
+          "name": "sessions_layout_id_layouts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_tracks": {
+      "name": "staging_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_train_id": {
+          "name": "assigned_train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staging_tracks_layout_idx": {
+          "name": "staging_tracks_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staging_tracks_layout_id_module_layouts_id_fk": {
+          "name": "staging_tracks_layout_id_module_layouts_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "module_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staging_tracks_assigned_train_id_trains_id_fk": {
+          "name": "staging_tracks_assigned_train_id_trains_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "assigned_train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.train_statuses": {
+      "name": "train_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yard'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_authority": {
+          "name": "has_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "train_statuses_train_idx": {
+          "name": "train_statuses_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "train_statuses_session_idx": {
+          "name": "train_statuses_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "train_statuses_train_id_trains_id_fk": {
+          "name": "train_statuses_train_id_trains_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "train_statuses_session_id_sessions_id_fk": {
+          "name": "train_statuses_session_id_sessions_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trains": {
+      "name": "trains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_address": {
+          "name": "dcc_address",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_type": {
+          "name": "dcc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consist_id": {
+          "name": "consist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment_type": {
+          "name": "equipment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_operator_id": {
+          "name": "assigned_operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trains_session_idx": {
+          "name": "trains_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trains_assigned_idx": {
+          "name": "trains_assigned_idx",
+          "columns": [
+            {
+              "expression": "assigned_operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trains_session_id_sessions_id_fk": {
+          "name": "trains_session_id_sessions_id_fk",
+          "tableFrom": "trains",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnout_positions": {
+      "name": "turnout_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turnout_id": {
+          "name": "turnout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnout_positions_session_turnout": {
+          "name": "turnout_positions_session_turnout",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turnout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "turnout_positions_session_idx": {
+          "name": "turnout_positions_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnout_positions_session_id_sessions_id_fk": {
+          "name": "turnout_positions_session_id_sessions_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turnout_positions_turnout_id_turnouts_id_fk": {
+          "name": "turnout_positions_turnout_id_turnouts_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "turnouts",
+          "columnsFrom": [
+            "turnout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnouts": {
+      "name": "turnouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnouts_district_idx": {
+          "name": "turnouts_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnouts_district_id_districts_id_fk": {
+          "name": "turnouts_district_id_districts_id_fk",
+          "tableFrom": "turnouts",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1783182515005,
       "tag": "0012_repo_module_schematics",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "7",
+      "when": 1783191619434,
+      "tag": "0013_repo_module_track_graph",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -248,6 +248,10 @@ export const repoModules = pgTable("repo_modules", {
   // (storage_path, file_name, file_format); the private file is fetched via a
   // signed URL on demand (#122).
   schematics: jsonb("schematics"),
+  // Owner-authored structured track-graph (#122) — the module's schematic doc
+  // (endplates/tracks/turnouts/signals) FD composes into a layout. See
+  // docs/module-schematic-format.md. Null for un-authored modules.
+  schematic: jsonb("schematic"),
   upstreamUpdatedAt: timestamp("upstream_updated_at", { withTimezone: true }),
   syncedAt: timestamp("synced_at", { withTimezone: true }).notNull().defaultNow(),
 });

--- a/lib/server/ModuleRepoSync.ts
+++ b/lib/server/ModuleRepoSync.ts
@@ -61,6 +61,7 @@ interface ModuleFull {
   tracks?: unknown;
   industries?: unknown;
   schematics?: unknown;
+  schematic?: unknown;
 }
 
 export async function syncModules(): Promise<SyncResult | SyncError> {
@@ -146,6 +147,7 @@ export async function syncModules(): Promise<SyncResult | SyncError> {
       tracks: (m.tracks ?? null) as object | null,
       industries: (m.industries ?? null) as object | null,
       schematics: (m.schematics ?? null) as object | null,
+      schematic: (m.schematic ?? null) as object | null,
       upstreamUpdatedAt: m.updated_at ? new Date(m.updated_at) : null,
       syncedAt: new Date(),
     };

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -80,6 +80,7 @@ export interface LayoutModule {
   geometryDegrees: number | null;
   flipped: boolean;
   endplates: unknown;
+  schematic: unknown;
 }
 
 export interface LayoutTree extends LayoutRow {
@@ -254,6 +255,7 @@ class TrackModel {
         geometryType: repoModules.geometryType,
         geometryDegrees: repoModules.geometryDegrees,
         endplates: repoModules.endplates,
+        schematic: repoModules.schematic,
       })
       .from(moduleLayouts)
       .leftJoin(repoModules, eq(moduleLayouts.moduleId, repoModules.recordNumber))

--- a/lib/track/__tests__/moduleSchematic.test.ts
+++ b/lib/track/__tests__/moduleSchematic.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from "vitest";
+import {
+  asModuleSchematic,
+  moduleFeatures,
+  type ModuleSchematicDoc,
+} from "../moduleSchematic";
+
+const doc: ModuleSchematicDoc = {
+  version: 1,
+  module: "FMN-0003",
+  lengthInches: 30,
+  endplates: [
+    { id: "A", tracks: [{ trackId: "main", lane: 0, config: "single" }] },
+    { id: "B", tracks: [{ trackId: "main", lane: 0, config: "single" }] },
+  ],
+  tracks: [
+    { id: "main", role: "main", lane: 0, from: "A", to: "B" },
+    { id: "sid", role: "siding", lane: 1, from: "swW", to: "swE", fromPos: 6, toPos: 24 },
+    { id: "spur", role: "spur", lane: 2, from: "swW", to: "spurEnd", fromPos: 6, toPos: 15 },
+  ],
+  turnouts: [
+    { id: "swW", pos: 6, onTrack: "main", divergeTrack: "sid", kind: "right", name: "West Siding" },
+    { id: "swE", pos: 24, onTrack: "main", divergeTrack: "sid", kind: "left", name: "East Siding" },
+  ],
+  signals: [{ id: "sW", pos: 3, track: "main", facing: "AtoB", name: "CP West" }],
+};
+
+describe("asModuleSchematic", () => {
+  it("accepts a well-formed doc and rejects junk", () => {
+    expect(asModuleSchematic(doc)).not.toBeNull();
+    expect(asModuleSchematic(null)).toBeNull();
+    expect(asModuleSchematic({})).toBeNull();
+    expect(asModuleSchematic({ version: 1 })).toBeNull(); // no endplates/tracks
+    expect(asModuleSchematic({ version: "x", endplates: [], tracks: [] })).toBeNull();
+  });
+});
+
+describe("moduleFeatures", () => {
+  const f = moduleFeatures(doc);
+
+  it("excludes the main track and keeps sidings/spurs as extra tracks", () => {
+    expect(f.extraTracks.map((t) => t.id)).toEqual(["sid", "spur"]);
+  });
+
+  it("normalises positions to fractions of the module length", () => {
+    const sid = f.extraTracks.find((t) => t.id === "sid")!;
+    expect(sid.fromFrac).toBeCloseTo(6 / 30);
+    expect(sid.toFrac).toBeCloseTo(24 / 30);
+    expect(sid.lane).toBe(1);
+  });
+
+  it("places turnouts at their pos with on/diverge lanes resolved", () => {
+    const swW = f.turnouts.find((t) => t.id === "swW")!;
+    expect(swW.posFrac).toBeCloseTo(6 / 30);
+    expect(swW.onLane).toBe(0); // main
+    expect(swW.divergeLane).toBe(1); // siding
+  });
+
+  it("places signals at their pos on the governed track's lane", () => {
+    expect(f.signals[0]).toMatchObject({ posFrac: 0.1, lane: 0, facing: "AtoB" });
+  });
+
+  it("skips a track whose endpoints can't be resolved", () => {
+    const bad: ModuleSchematicDoc = {
+      version: 1,
+      lengthInches: 30,
+      endplates: [{ id: "A" }, { id: "B" }],
+      tracks: [
+        { id: "main", role: "main", lane: 0, from: "A", to: "B" },
+        { id: "orphan", role: "spur", lane: 1, from: "ghost", to: "nowhere" },
+      ],
+    };
+    expect(moduleFeatures(bad).extraTracks).toHaveLength(0);
+  });
+});

--- a/lib/track/moduleSchematic.ts
+++ b/lib/track/moduleSchematic.ts
@@ -1,0 +1,176 @@
+/**
+ * Owner-authored module schematic (#122) — the structured track-graph the Module
+ * Repository builds and Free-Dispatcher imports. See
+ * docs/module-schematic-format.md. This module holds the doc types, a lenient
+ * parser (it arrives as jsonb / unknown), and a pure helper that resolves the
+ * graph into positioned, drawable features for the operations schematic.
+ *
+ * Positions are 1-D inches along the module (from endplate A); this helper
+ * normalises them to fractions [0,1] so the renderer only needs the module's
+ * cell width. Lanes are integer track indices (0 = primary main).
+ */
+
+export interface SchematicEndplateTrack {
+  trackId: string;
+  lane: number;
+  config?: string | null;
+}
+export interface SchematicEndplate {
+  id: string;
+  label?: string | null;
+  tracks?: SchematicEndplateTrack[];
+}
+export interface SchematicTrack {
+  id: string;
+  role: string; // main | siding | spur | yard | crossover
+  lane: number;
+  from?: string;
+  to?: string;
+  fromPos?: number | null;
+  toPos?: number | null;
+  capacityFeet?: number | null;
+  industryRef?: number | null;
+}
+export interface SchematicTurnout {
+  id: string;
+  pos: number;
+  onTrack: string;
+  divergeTrack: string;
+  kind?: string;
+  name?: string | null;
+  address?: string | null;
+}
+export interface SchematicSignal {
+  id: string;
+  pos: number;
+  track?: string;
+  facing?: string; // AtoB | BtoA
+  kind?: string;
+  name?: string | null;
+  aspects?: string[];
+}
+export interface SchematicBlock {
+  id: string;
+  name: string;
+  tracks?: string[];
+  from: number;
+  to: number;
+}
+export interface ModuleSchematicDoc {
+  version: number;
+  module?: string;
+  lengthInches?: number;
+  endplates: SchematicEndplate[];
+  tracks: SchematicTrack[];
+  turnouts?: SchematicTurnout[];
+  signals?: SchematicSignal[];
+  blocks?: SchematicBlock[];
+}
+
+/** Parse a jsonb value into a schematic doc, or null if it isn't one. */
+export function asModuleSchematic(x: unknown): ModuleSchematicDoc | null {
+  if (!x || typeof x !== "object") return null;
+  const d = x as Record<string, unknown>;
+  if (typeof d.version !== "number") return null;
+  if (!Array.isArray(d.endplates) || !Array.isArray(d.tracks)) return null;
+  return d as unknown as ModuleSchematicDoc;
+}
+
+// ---- Drawable features (module-local, fraction 0..1 along the module) ------
+
+export interface DrawTrack {
+  id: string;
+  role: string;
+  lane: number;
+  fromFrac: number;
+  toFrac: number;
+  capacityFeet: number | null;
+}
+export interface DrawTurnout {
+  id: string;
+  name: string | null;
+  posFrac: number;
+  onLane: number;
+  divergeLane: number;
+}
+export interface DrawSignal {
+  id: string;
+  name: string | null;
+  posFrac: number;
+  lane: number;
+  facing: string;
+}
+export interface ModuleFeatures {
+  /** Non-main tracks (sidings/spurs/yard/crossover). */
+  extraTracks: DrawTrack[];
+  turnouts: DrawTurnout[];
+  signals: DrawSignal[];
+}
+
+/**
+ * Resolve a schematic doc into positioned drawables. `pos` (inches) becomes a
+ * fraction of the module length; endplate A = 0, B = length; turnouts sit at
+ * their pos. Tracks may carry explicit fromPos/toPos (overriding node lookup).
+ */
+export function moduleFeatures(doc: ModuleSchematicDoc): ModuleFeatures {
+  const len =
+    doc.lengthInches && doc.lengthInches > 0
+      ? doc.lengthInches
+      : Math.max(
+          1,
+          ...doc.tracks.map((t) => Math.max(t.fromPos ?? 0, t.toPos ?? 0)),
+          ...(doc.turnouts ?? []).map((t) => t.pos),
+        );
+
+  const trackLane = new Map<string, number>();
+  for (const t of doc.tracks) trackLane.set(t.id, t.lane);
+
+  // Endplate positions: first endplate = West (0), the rest = East (len).
+  const endplatePos = new Map<string, number>();
+  doc.endplates.forEach((e, i) => endplatePos.set(e.id, i === 0 ? 0 : len));
+
+  const turnoutPos = new Map<string, number>();
+  for (const t of doc.turnouts ?? []) turnoutPos.set(t.id, t.pos);
+
+  const posOf = (nodeId?: string): number | null => {
+    if (nodeId == null) return null;
+    if (endplatePos.has(nodeId)) return endplatePos.get(nodeId)!;
+    if (turnoutPos.has(nodeId)) return turnoutPos.get(nodeId)!;
+    return null;
+  };
+  const clampFrac = (p: number) => Math.min(1, Math.max(0, p / len));
+
+  const extraTracks: DrawTrack[] = [];
+  for (const t of doc.tracks) {
+    if (t.role === "main") continue; // the spine draws mains
+    const from = t.fromPos ?? posOf(t.from);
+    const to = t.toPos ?? posOf(t.to);
+    if (from == null || to == null) continue; // can't place it
+    extraTracks.push({
+      id: t.id,
+      role: t.role,
+      lane: t.lane,
+      fromFrac: clampFrac(Math.min(from, to)),
+      toFrac: clampFrac(Math.max(from, to)),
+      capacityFeet: t.capacityFeet ?? null,
+    });
+  }
+
+  const turnouts: DrawTurnout[] = (doc.turnouts ?? []).map((t) => ({
+    id: t.id,
+    name: t.name ?? null,
+    posFrac: clampFrac(t.pos),
+    onLane: trackLane.get(t.onTrack) ?? 0,
+    divergeLane: trackLane.get(t.divergeTrack) ?? 1,
+  }));
+
+  const signals: DrawSignal[] = (doc.signals ?? []).map((s) => ({
+    id: s.id,
+    name: s.name ?? null,
+    posFrac: clampFrac(s.pos),
+    lane: s.track ? (trackLane.get(s.track) ?? 0) : 0,
+    facing: s.facing ?? "AtoB",
+  }));
+
+  return { extraTracks, turnouts, signals };
+}

--- a/lib/track/operations.ts
+++ b/lib/track/operations.ts
@@ -19,6 +19,8 @@ export interface OpsModuleInput extends ModuleEndplates {
   stagingEnd?: "A" | "B" | null;
   mainlineLengthInches?: number | null;
   lengthTotalInches?: number | null;
+  /** Owner-authored track-graph (jsonb); overlaid when present (#122). */
+  schematic?: unknown;
 }
 
 export interface OpsCell {


### PR DESCRIPTION
## What

The end-to-end **owner-authored schematic pipeline**, minus the authoring UI. The
Module Repository stores a structured **track-graph** per module and returns it
inline; Free-Dispatcher imports it and **composes it onto the operations panel** —
an owner's turnouts, sidings/spurs and signal masts appear exactly where they
placed them, instead of FD reconstructing them.

## Module Repository (deployed v13, committed in modulerepo)
- Migration: `schematic jsonb` + `schematic_version int` on `freemon_modules`.
- `modules-full` returns `schematic` inline.

## Free-Dispatcher
- `repo_modules.schematic` (jsonb), synced; migration **0013** clears the sync
  cursor; `getLayout` threads it to each module.
- **`lib/track/moduleSchematic.ts`** — doc types, a lenient parser
  (`asModuleSchematic`), and `moduleFeatures()` that resolves the graph into
  positioned drawables (fractions along the module + lane). **6 unit tests.**
- `OperationsSchematic` overlays authored **sidings/spurs** (parallel lanes),
  **turnouts** (diverge/converge), and **signal masts**; un-authored modules keep
  the field-derived single/double fallback.

## Verified end-to-end
A track-graph seeded in the MR (**FMN-0003**: passing siding + spur + signal)
returns from `modules-full` v13 and renders on FD's operations spine — **siding
(6 ft), spur, West/East Siding turnouts, CP West signal** — composed into the
`District Paint Demo` layout. No console errors.

## Test
98 unit tests (6 new) + typecheck + lint + production build all green.

## Contract status ([docs](https://github.com/willcgage/free-dispatcher/blob/main/docs/module-schematic-format.md))
MR storage/transport ✓ · FD sync/import/overlay ✓ · remaining: **MR authoring
build tool** (the web-app editor) and seeding runtime occupancy/allocations from
imported graphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
