### PR TITLE
fix: hold schematic features off the endplates on long modules (#122)

### DIFF
--- a/lib/track/__tests__/moduleSchematic.test.ts
+++ b/lib/track/__tests__/moduleSchematic.test.ts
@@ -60,6 +60,32 @@ describe("moduleFeatures", () => {
     expect(f.signals[0]).toMatchObject({ posFrac: 0.1, lane: 0, facing: "AtoB" });
   });
 
+  it("holds features off the endplates on a very long module (inset clamp)", () => {
+    // One Mile: 432\" module, switch 24\" from the West end would be at ~5.5%.
+    const oneMile: ModuleSchematicDoc = {
+      version: 1,
+      lengthInches: 432,
+      endplates: [
+        { id: "A", tracks: [{ trackId: "main", lane: 0, config: "single" }] },
+        { id: "B", tracks: [{ trackId: "main", lane: 0, config: "single" }] },
+      ],
+      tracks: [
+        { id: "main", role: "main", lane: 0, from: "A", to: "B" },
+        { id: "sid", role: "siding", lane: 1, from: "swW", to: "swE", fromPos: 24, toPos: 408 },
+      ],
+      turnouts: [
+        { id: "swW", pos: 24, onTrack: "main", divergeTrack: "sid", kind: "right" },
+        { id: "swE", pos: 408, onTrack: "main", divergeTrack: "sid", kind: "left" },
+      ],
+    };
+    const feat = moduleFeatures(oneMile);
+    // 24/432 = 0.056 → clamped up to the 0.08 inset (off the endplate).
+    expect(feat.turnouts[0].posFrac).toBeCloseTo(0.08);
+    expect(feat.turnouts[1].posFrac).toBeCloseTo(0.92);
+    expect(feat.extraTracks[0].fromFrac).toBeCloseTo(0.08);
+    expect(feat.extraTracks[0].toFrac).toBeCloseTo(0.92);
+  });
+
   it("skips a track whose endpoints can't be resolved", () => {
     const bad: ModuleSchematicDoc = {
       version: 1,

--- a/lib/track/moduleSchematic.ts
+++ b/lib/track/moduleSchematic.ts
@@ -48,6 +48,8 @@ export interface SchematicSignal {
   kind?: string;
   name?: string | null;
   aspects?: string[];
+  /** Turnout this control point governs; absent = standalone block signal (#122). */
+  turnout?: string;
 }
 export interface SchematicBlock {
   id: string;
@@ -112,6 +114,13 @@ export interface ModuleFeatures {
  * fraction of the module length; endplate A = 0, B = length; turnouts sit at
  * their pos. Tracks may carry explicit fromPos/toPos (overriding node lookup).
  */
+/**
+ * Hold features off the endplates so a switch a few inches from the end of a
+ * very long module (e.g. the 396" "One Mile") still reads clearly — the panel
+ * stays to-scale in the middle but clamps the outer INSET fraction (#122).
+ */
+const INSET = 0.08;
+
 export function moduleFeatures(doc: ModuleSchematicDoc): ModuleFeatures {
   const len =
     doc.lengthInches && doc.lengthInches > 0
@@ -138,7 +147,8 @@ export function moduleFeatures(doc: ModuleSchematicDoc): ModuleFeatures {
     if (turnoutPos.has(nodeId)) return turnoutPos.get(nodeId)!;
     return null;
   };
-  const clampFrac = (p: number) => Math.min(1, Math.max(0, p / len));
+  const clampFrac = (p: number) =>
+    Math.min(1 - INSET, Math.max(INSET, p / len));
 
   const extraTracks: DrawTrack[] = [];
   for (const t of doc.tracks) {


### PR DESCRIPTION
Issue #1 of the schematic-tool feedback: on the 396" One Mile module a switch a few inches from the end rendered *at* the endplate. Keeps the panel to-scale but clamps authored features to an 8% inset so they read clearly. Carries the control-point `turnout` link through the signal type. Unit-tested with the One Mile case. 99 tests + build green.