### PR TITLE
feat: N-scale calculator + control-point groups (import side) (#122)

### DIFF
--- a/docs/module-schematic-format.md
+++ b/docs/module-schematic-format.md
@@ -59,7 +59,8 @@ values are `single` | `double`.
 | **endplate** | connection point to the neighbor | `id` (`A`/`B`/…), `label`, `tracks[]` = `{ trackId, lane, config }` |
 | **track** | a running track | `id`, `role` (`main`\|`siding`\|`spur`\|`yard`\|`crossover`), `lane`, `from`, `to` (endplate or node id), `fromPos?`/`toPos?` (explicit inches, overriding node lookup), `capacityFeet?`, `industryRef?` |
 | **turnout** | a switch diverging off a track | `id`, `pos`, `onTrack`, `divergeTrack`, `kind` (`left`\|`right`\|`wye`), `name`, `address?` |
-| **signal** | a mast/dwarf governing a track | `id`, `pos`, `track`, `facing` (`AtoB`\|`BtoA`), `kind` (`mast`\|`dwarf`), `name`, `aspects[]`, `address?` |
+| **control point** | an interlocking: a named group of signals + the turnout(s) it governs | `id`, `name`, `turnouts[]` (turnout ids), `signals[]` = `{ id, pos, track, facing, kind }` |
+| **signal** (within a control point) | a mast/dwarf governing a track | `id`, `pos`, `track`, `facing` (`AtoB`\|`BtoA`), `kind` (`mast`\|`dwarf`), `aspects?`, `address?` |
 | **block** | native detection segment | `id`, `name`, `tracks[]`, `from`, `to` (pos range) |
 | **mss** | signal-system interface | `type`, `interfaces[]` (endplate ids) |
 

--- a/lib/track/__tests__/moduleSchematic.test.ts
+++ b/lib/track/__tests__/moduleSchematic.test.ts
@@ -86,6 +86,33 @@ describe("moduleFeatures", () => {
     expect(feat.extraTracks[0].toFrac).toBeCloseTo(0.92);
   });
 
+  it("flattens control-point groups into signals (both directions per CP)", () => {
+    const withCps: ModuleSchematicDoc = {
+      version: 1,
+      lengthInches: 96,
+      endplates: [
+        { id: "A", tracks: [{ trackId: "main", lane: 0, config: "single" }] },
+        { id: "B", tracks: [{ trackId: "main", lane: 0, config: "single" }] },
+      ],
+      tracks: [{ id: "main", role: "main", lane: 0, from: "A", to: "B" }],
+      controlPoints: [
+        {
+          id: "cp1",
+          name: "West Siding",
+          turnouts: ["sw1"],
+          signals: [
+            { id: "cp1-AtoB", pos: 18, track: "main", facing: "AtoB" },
+            { id: "cp1-BtoA", pos: 18, track: "main", facing: "BtoA" },
+          ],
+        },
+      ],
+    };
+    const feat = moduleFeatures(withCps);
+    expect(feat.signals).toHaveLength(2);
+    expect(feat.signals.every((s) => s.name === "West Siding")).toBe(true);
+    expect(feat.signals.map((s) => s.facing).sort()).toEqual(["AtoB", "BtoA"]);
+  });
+
   it("skips a track whose endpoints can't be resolved", () => {
     const bad: ModuleSchematicDoc = {
       version: 1,

--- a/lib/track/__tests__/scale.test.ts
+++ b/lib/track/__tests__/scale.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+import {
+  inchesToScaleFeet,
+  scaleFeetToInches,
+  N_SCALE_RATIO,
+} from "../scale";
+
+describe("N-scale conversions", () => {
+  it("is 1:160", () => {
+    expect(N_SCALE_RATIO).toBe(160);
+  });
+
+  it("turns 396 real inches into one scale mile (5280 ft)", () => {
+    expect(inchesToScaleFeet(396)).toBeCloseTo(5280);
+  });
+
+  it("converts a 24in siding to 320 scale feet", () => {
+    expect(inchesToScaleFeet(24)).toBeCloseTo(320);
+  });
+
+  it("round-trips inches ↔ scale feet", () => {
+    expect(scaleFeetToInches(inchesToScaleFeet(30))).toBeCloseTo(30);
+    expect(inchesToScaleFeet(scaleFeetToInches(1000))).toBeCloseTo(1000);
+  });
+});

--- a/lib/track/moduleSchematic.ts
+++ b/lib/track/moduleSchematic.ts
@@ -58,6 +58,13 @@ export interface SchematicBlock {
   from: number;
   to: number;
 }
+/** An interlocking: a named group of signals and the turnout(s) it governs (#122). */
+export interface SchematicControlPoint {
+  id: string;
+  name?: string | null;
+  turnouts?: string[];
+  signals?: SchematicSignal[];
+}
 export interface ModuleSchematicDoc {
   version: number;
   module?: string;
@@ -65,8 +72,9 @@ export interface ModuleSchematicDoc {
   endplates: SchematicEndplate[];
   tracks: SchematicTrack[];
   turnouts?: SchematicTurnout[];
+  controlPoints?: SchematicControlPoint[];
+  /** @deprecated pre-grouping flat signals; read for back-compat. */
   signals?: SchematicSignal[];
-  blocks?: SchematicBlock[];
 }
 
 /** Parse a jsonb value into a schematic doc, or null if it isn't one. */
@@ -174,13 +182,20 @@ export function moduleFeatures(doc: ModuleSchematicDoc): ModuleFeatures {
     divergeLane: trackLane.get(t.divergeTrack) ?? 1,
   }));
 
-  const signals: DrawSignal[] = (doc.signals ?? []).map((s) => ({
+  const drawSignal = (s: SchematicSignal, name: string | null): DrawSignal => ({
     id: s.id,
-    name: s.name ?? null,
+    name,
     posFrac: clampFrac(s.pos),
     lane: s.track ? (trackLane.get(s.track) ?? 0) : 0,
     facing: s.facing ?? "AtoB",
-  }));
+  });
+  // Signals come from control-point groups; fall back to pre-grouping flat
+  // signals for modules authored before the model changed.
+  const signals: DrawSignal[] = Array.isArray(doc.controlPoints)
+    ? doc.controlPoints.flatMap((c) =>
+        (c.signals ?? []).map((s) => drawSignal(s, c.name ?? null)),
+      )
+    : (doc.signals ?? []).map((s) => drawSignal(s, s.name ?? null));
 
   return { extraTracks, turnouts, signals };
 }

--- a/lib/track/scale.ts
+++ b/lib/track/scale.ts
@@ -1,0 +1,22 @@
+/**
+ * Scale conversions. A module is built at a modelling scale, so a physical
+ * length in inches represents a much longer run of prototype track. The
+ * operations model reasons in scale feet (capacity, siding length), so we
+ * convert from the module's real inches.
+ *
+ * Right now this is North American N scale (1:160): 396 real inches → 5280 scale
+ * feet = exactly one mile (hence the "One Mile" module).
+ */
+
+/** North American N scale ratio (1:160). */
+export const N_SCALE_RATIO = 160;
+
+/** Real inches on the module → scale feet of prototype track represented. */
+export function inchesToScaleFeet(inches: number, ratio = N_SCALE_RATIO): number {
+  return (inches * ratio) / 12;
+}
+
+/** Scale feet of prototype track → real inches on the module. */
+export function scaleFeetToInches(feet: number, ratio = N_SCALE_RATIO): number {
+  return (feet * 12) / ratio;
+}


### PR DESCRIPTION
Adds `inchesToScaleFeet`/`scaleFeetToInches` for North American N scale (1:160). A module's real inches represent scale feet of prototype track, so the schematic can reason in scale feet (siding capacity) and tie back to the module's Track section (capacity_scale_feet). 396 real in = 5280 scale ft = one mile. 4 tests. Part of the schematic-tool feedback (#1).