### PR TITLE
fix: size the operations cell to the schematic's own length

### DIFF
--- a/lib/track/__tests__/operations.test.ts
+++ b/lib/track/__tests__/operations.test.ts
@@ -73,6 +73,24 @@ describe("buildOperationsSchematic", () => {
     expect(s.cells[0]).toMatchObject({ leftTracks: 1, rightTracks: 1 });
   });
 
+  it("sizes the cell to the schematic's own length so features line up", () => {
+    // Module record says 396", but the authored schematic uses 432" — the cell
+    // must be 432 or the overlaid siding/turnout/signal positions won't match.
+    const s = buildOperationsSchematic([
+      mod("a", "single", "single", {
+        mainlineLengthInches: 396,
+        lengthTotalInches: 396,
+        schematic: {
+          version: 1,
+          lengthInches: 432,
+          endplates: [],
+          tracks: [{ id: "main", role: "main", lane: 0 }],
+        },
+      }),
+    ]);
+    expect(s.cells[0].width).toBe(432);
+  });
+
   it("enforces a minimum drawn width", () => {
     const s = buildOperationsSchematic([
       mod("a", "single", "single", { mainlineLengthInches: 2, lengthTotalInches: 2 }),

--- a/lib/track/operations.ts
+++ b/lib/track/operations.ts
@@ -14,6 +14,7 @@
  * is unknown so the line stays continuous. The SVG component just draws it.
  */
 import { inConfig, outConfig, type ModuleEndplates } from "./endplates";
+import { asModuleSchematic } from "./moduleSchematic";
 
 export interface OpsModuleInput extends ModuleEndplates {
   stagingEnd?: "A" | "B" | null;
@@ -59,12 +60,18 @@ export function buildOperationsSchematic(
   // First pass: raw left/right counts (may be null) and cell widths.
   let x = 0;
   const cells: OpsCell[] = modules.map((m) => {
+    // When a module has an authored schematic, its features are positioned in
+    // the schematic's own coordinate space (its lengthInches), so the cell must
+    // be that wide or the overlaid sidings/turnouts/signals won't line up.
+    const schematicLen = asModuleSchematic(m.schematic)?.lengthInches;
     const len =
-      (m.mainlineLengthInches && m.mainlineLengthInches > 0
-        ? m.mainlineLengthInches
-        : m.lengthTotalInches && m.lengthTotalInches > 0
-          ? m.lengthTotalInches
-          : DEFAULT_CELL_INCHES) || DEFAULT_CELL_INCHES;
+      (schematicLen && schematicLen > 0
+        ? schematicLen
+        : m.mainlineLengthInches && m.mainlineLengthInches > 0
+          ? m.mainlineLengthInches
+          : m.lengthTotalInches && m.lengthTotalInches > 0
+            ? m.lengthTotalInches
+            : DEFAULT_CELL_INCHES) || DEFAULT_CELL_INCHES;
     const width = Math.max(len, MIN_CELL_INCHES);
     const cell: OpsCell = {
       input: m,


### PR DESCRIPTION
Track endpoints weren't lining up: a module's schematic positions features against its own `lengthInches`, but the panel sized each cell from the module record's length. When they differ (One Mile: record 396", schematic 432") the overlay squished. Now the cell uses the schematic's length. Verified: One Mile siding renders at its true 12→420 endpoints. Regression test added.