### PR TITLE
feat: place layout-level control points within a district (#144)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -17,6 +17,7 @@ import { OperationsSchematic } from "@/components/layout/OperationsSchematic";
 import {
   layoutControlPoints,
   deriveSections,
+  asLayoutCps,
 } from "@/lib/track/layoutControlPoints";
 import type { CatalogModule } from "@/lib/client/types";
 import type { StagingEnd } from "@/lib/db/schema";
@@ -28,6 +29,7 @@ interface LayoutRow {
   description: string | null;
   standard: string;
   controlPointDistricts: Record<string, string> | null;
+  layoutControlPoints: unknown;
   createdAt: string;
 }
 interface BlockNode {
@@ -121,6 +123,10 @@ export default function AdminLayouts() {
   const [catalog, setCatalog] = useState<CatalogModule[]>([]);
   const [modQuery, setModQuery] = useState<Record<string, string>>({});
   const [modChecked, setModChecked] = useState<Record<string, string[]>>({});
+  // Add-form draft for a layout-level control point, keyed by layout id (#144).
+  const [cpDraft, setCpDraft] = useState<
+    Record<string, { name: string; anchor: string; offset: string }>
+  >({});
   const [drag, setDrag] = useState<{ layoutId: string; from: number } | null>(
     null,
   );
@@ -365,6 +371,24 @@ export default function AdminLayouts() {
       await reloadTree(layoutId);
     } catch (e) {
       alert(e instanceof Error ? e.message : "assign failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Add or remove a layout-level control point (#144). */
+  async function saveLayoutControlPoints(
+    layoutId: string,
+    cps: { id: string; name: string; anchor: string; offsetInches: number }[],
+  ) {
+    setBusy(true);
+    try {
+      await apiSend("PATCH", `/api/layouts/${layoutId}`, {
+        layoutControlPoints: cps,
+      });
+      await reloadTree(layoutId);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "save failed");
     } finally {
       setBusy(false);
     }
@@ -818,19 +842,91 @@ export default function AdminLayouts() {
                               Control Points → Districts
                             </div>
                             {(() => {
-                              const cps = layoutControlPoints(tree.modules);
+                              const layoutCps = asLayoutCps(tree.layoutControlPoints);
+                              const cps = layoutControlPoints(tree.modules, layoutCps);
+                              const draft = cpDraft[l.id] ?? {
+                                name: "",
+                                anchor: tree.modules[0]?.id ?? "",
+                                offset: "",
+                              };
+                              const addForm = tree.modules.length > 0 && (
+                                <div className="mt-2 flex items-center gap-1.5">
+                                  <input
+                                    value={draft.name}
+                                    placeholder="New control point"
+                                    onChange={(e) =>
+                                      setCpDraft((p) => ({
+                                        ...p,
+                                        [l.id]: { ...draft, name: e.target.value },
+                                      }))
+                                    }
+                                    className="w-36 rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-xs text-slate-200"
+                                  />
+                                  <select
+                                    value={draft.anchor}
+                                    onChange={(e) =>
+                                      setCpDraft((p) => ({
+                                        ...p,
+                                        [l.id]: { ...draft, anchor: e.target.value },
+                                      }))
+                                    }
+                                    className="rounded border border-slate-700 bg-slate-800 px-1 py-0.5 text-xs text-slate-300"
+                                  >
+                                    {tree.modules.map((m) => (
+                                      <option key={m.id} value={m.id}>
+                                        {m.moduleName ?? m.moduleId}
+                                      </option>
+                                    ))}
+                                  </select>
+                                  <input
+                                    value={draft.offset}
+                                    placeholder="in from A"
+                                    inputMode="decimal"
+                                    onChange={(e) =>
+                                      setCpDraft((p) => ({
+                                        ...p,
+                                        [l.id]: { ...draft, offset: e.target.value },
+                                      }))
+                                    }
+                                    className="w-20 rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-xs text-slate-200"
+                                  />
+                                  <button
+                                    disabled={
+                                      busy ||
+                                      !draft.name.trim() ||
+                                      !draft.anchor ||
+                                      !Number.isFinite(Number(draft.offset)) ||
+                                      draft.offset.trim() === ""
+                                    }
+                                    onClick={() => {
+                                      const cp = {
+                                        id: `lcp-${Date.now().toString(36)}`,
+                                        name: draft.name.trim(),
+                                        anchor: draft.anchor,
+                                        offsetInches: Number(draft.offset),
+                                      };
+                                      setCpDraft((p) => ({
+                                        ...p,
+                                        [l.id]: { ...draft, name: "", offset: "" },
+                                      }));
+                                      saveLayoutControlPoints(l.id, [...layoutCps, cp]);
+                                    }}
+                                    className="rounded border border-slate-600 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+                                  >
+                                    + Add
+                                  </button>
+                                </div>
+                              );
                               if (cps.length === 0)
                                 return (
-                                  <p className="text-xs text-slate-600">
-                                    No control points yet — author them in the
-                                    modules&rsquo; schematics (Module Repository).
-                                  </p>
-                                );
-                              if (tree.districts.length === 0)
-                                return (
-                                  <p className="text-xs text-slate-600">
-                                    Add districts (below) to assign control points.
-                                  </p>
+                                  <>
+                                    <p className="text-xs text-slate-600">
+                                      No control points yet — author them in the
+                                      modules&rsquo; schematics (Module Repository),
+                                      or add one at the layout level below.
+                                    </p>
+                                    {addForm}
+                                  </>
                                 );
                               const assign = tree.controlPointDistricts ?? {};
                               const sections = deriveSections(cps, assign);
@@ -841,33 +937,65 @@ export default function AdminLayouts() {
                                       <li key={cp.key} className="flex items-center gap-2">
                                         <span className="min-w-0 flex-1 truncate text-slate-200">
                                           {cp.name}
+                                          {cp.source === "layout" && (
+                                            <span className="ml-1.5 rounded bg-slate-700 px-1 py-px text-[10px] uppercase text-slate-400">
+                                              layout
+                                            </span>
+                                          )}
                                         </span>
                                         <span className="shrink-0 font-mono text-xs text-slate-500">
                                           {cp.moduleId}
+                                          {cp.source === "layout" &&
+                                            ` @ ${cp.posInches ?? 0}"`}
                                         </span>
-                                        <select
-                                          value={assign[cp.key] ?? ""}
-                                          disabled={busy}
-                                          onChange={(e) =>
-                                            assignControlPoint(
-                                              l.id,
-                                              tree.controlPointDistricts,
-                                              cp.key,
-                                              e.target.value,
-                                            )
-                                          }
-                                          className="shrink-0 rounded border border-slate-700 bg-slate-800 px-1 py-0.5 text-xs text-slate-300"
-                                        >
-                                          <option value="">— district</option>
-                                          {tree.districts.map((d) => (
-                                            <option key={d.id} value={d.id}>
-                                              {d.name}
-                                            </option>
-                                          ))}
-                                        </select>
+                                        {tree.districts.length > 0 && (
+                                          <select
+                                            value={assign[cp.key] ?? ""}
+                                            disabled={busy}
+                                            onChange={(e) =>
+                                              assignControlPoint(
+                                                l.id,
+                                                tree.controlPointDistricts,
+                                                cp.key,
+                                                e.target.value,
+                                              )
+                                            }
+                                            className="shrink-0 rounded border border-slate-700 bg-slate-800 px-1 py-0.5 text-xs text-slate-300"
+                                          >
+                                            <option value="">— district</option>
+                                            {tree.districts.map((d) => (
+                                              <option key={d.id} value={d.id}>
+                                                {d.name}
+                                              </option>
+                                            ))}
+                                          </select>
+                                        )}
+                                        {cp.source === "layout" && (
+                                          <button
+                                            disabled={busy}
+                                            title="Remove layout control point"
+                                            onClick={() =>
+                                              saveLayoutControlPoints(
+                                                l.id,
+                                                layoutCps.filter(
+                                                  (x) => x.id !== cp.cpId,
+                                                ),
+                                              )
+                                            }
+                                            className="shrink-0 rounded px-1 text-xs text-slate-500 hover:text-red-400"
+                                          >
+                                            ✕
+                                          </button>
+                                        )}
                                       </li>
                                     ))}
                                   </ul>
+                                  {tree.districts.length === 0 && (
+                                    <p className="mt-1 text-xs text-slate-600">
+                                      Add districts (below) to assign control points.
+                                    </p>
+                                  )}
+                                  {addForm}
                                   {sections.length > 0 && (
                                     <p className="mt-2 text-xs text-slate-400">
                                       <span className="font-semibold text-slate-300">

--- a/app/api/layouts/[id]/route.ts
+++ b/app/api/layouts/[id]/route.ts
@@ -25,8 +25,10 @@ export async function GET(
 }
 
 /**
- * PATCH /api/layouts/:id — update a layout's control-point → district
- * assignments (Admin). Body: { controlPointDistricts: { [key]: districtId } }.
+ * PATCH /api/layouts/:id — update a layout's control-point configuration
+ * (Admin). Body may carry either or both of:
+ *   controlPointDistricts: { [key]: districtId }              (#138)
+ *   layoutControlPoints: [{id, name, anchor, offsetInches}]   (#144)
  */
 export async function PATCH(
   req: Request,
@@ -36,17 +38,44 @@ export async function PATCH(
   if (!guard.ok) return guard.response;
   const { id } = await params;
 
-  let body: { controlPointDistricts?: Record<string, string> };
+  let body: {
+    controlPointDistricts?: Record<string, string>;
+    layoutControlPoints?: {
+      id: string;
+      name: string;
+      anchor: string;
+      offsetInches: number;
+    }[];
+  };
   try {
     body = await req.json();
   } catch {
     return NextResponse.json({ error: "invalid JSON body" }, { status: 400 });
   }
 
-  // Drop empty assignments so cleared control points don't linger.
-  const map = Object.fromEntries(
-    Object.entries(body.controlPointDistricts ?? {}).filter(([, v]) => v),
-  );
-  await trackModel.setControlPointDistricts(id, map);
+  if (body.controlPointDistricts !== undefined) {
+    // Drop empty assignments so cleared control points don't linger.
+    const map = Object.fromEntries(
+      Object.entries(body.controlPointDistricts ?? {}).filter(([, v]) => v),
+    );
+    await trackModel.setControlPointDistricts(id, map);
+  }
+  if (body.layoutControlPoints !== undefined) {
+    if (!Array.isArray(body.layoutControlPoints)) {
+      return NextResponse.json(
+        { error: "layoutControlPoints must be an array" },
+        { status: 400 },
+      );
+    }
+    const cps = body.layoutControlPoints.filter(
+      (c) =>
+        c &&
+        typeof c.id === "string" &&
+        typeof c.anchor === "string" &&
+        typeof c.name === "string" &&
+        Number.isFinite(c.offsetInches),
+    );
+    await trackModel.setLayoutControlPoints(id, cps);
+  }
   return NextResponse.json({ ok: true });
 }

--- a/lib/db/migrations/0015_layout_level_control_points.sql
+++ b/lib/db/migrations/0015_layout_level_control_points.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "layouts" ADD COLUMN "layout_control_points" jsonb;

--- a/lib/db/migrations/meta/0015_snapshot.json
+++ b/lib/db/migrations/meta/0015_snapshot.json
@@ -1,0 +1,1768 @@
+{
+  "id": "9f7fb340-7ce8-45bd-8a86-b6886ebfe4af",
+  "prevId": "4d0eaa5a-fcf8-465e-b622-5eb8e0640aa5",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authority_log": {
+      "name": "authority_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_operator": {
+          "name": "by_operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "authority_log_session_idx": {
+          "name": "authority_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authority_log_session_id_sessions_id_fk": {
+          "name": "authority_log_session_id_sessions_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authority_log_train_id_trains_id_fk": {
+          "name": "authority_log_train_id_trains_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_occupancy": {
+      "name": "block_occupancy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occupied": {
+          "name": "occupied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_occupancy_session_block": {
+          "name": "block_occupancy_session_block",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_occupancy_session_idx": {
+          "name": "block_occupancy_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "block_occupancy_session_id_sessions_id_fk": {
+          "name": "block_occupancy_session_id_sessions_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_block_id_blocks_id_fk": {
+          "name": "block_occupancy_block_id_blocks_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_train_id_trains_id_fk": {
+          "name": "block_occupancy_train_id_trains_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "module_record_number": {
+          "name": "module_record_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_section_idx": {
+          "name": "blocks_section_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_section_id_sections_id_fk": {
+          "name": "blocks_section_id_sections_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.districts": {
+      "name": "districts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "districts_layout_idx": {
+          "name": "districts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "districts_layout_id_layouts_id_fk": {
+          "name": "districts_layout_id_layouts_id_fk",
+          "tableFrom": "districts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layouts": {
+      "name": "layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'freemon'"
+        },
+        "control_point_districts": {
+          "name": "control_point_districts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "layout_control_points": {
+          "name": "layout_control_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_layouts": {
+      "name": "module_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "staging_end": {
+          "name": "staging_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flipped": {
+          "name": "flipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "module_layouts_layout_idx": {
+          "name": "module_layouts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_layouts_layout_id_layouts_id_fk": {
+          "name": "module_layouts_layout_id_layouts_id_fk",
+          "tableFrom": "module_layouts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "operators_session_idx": {
+          "name": "operators_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operators_device_idx": {
+          "name": "operators_device_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operators_session_id_sessions_id_fk": {
+          "name": "operators_session_id_sessions_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ops_log": {
+      "name": "ops_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ops_log_session_idx": {
+          "name": "ops_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ops_log_session_id_sessions_id_fk": {
+          "name": "ops_log_session_id_sessions_id_fk",
+          "tableFrom": "ops_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_modules": {
+      "name": "repo_modules",
+      "schema": "",
+      "columns": {
+        "record_number": {
+          "name": "record_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_type": {
+          "name": "geometry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_degrees": {
+          "name": "geometry_degrees",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_offset_inches": {
+          "name": "geometry_offset_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "length_total_inches": {
+          "name": "length_total_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mainline_length_inches": {
+          "name": "mainline_length_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplate_count": {
+          "name": "endplate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_mss": {
+          "name": "has_mss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mss_type": {
+          "name": "mss_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplates": {
+          "name": "endplates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industries": {
+          "name": "industries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematics": {
+          "name": "schematics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematic": {
+          "name": "schematic",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_updated_at": {
+          "name": "upstream_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.section_allocations": {
+      "name": "section_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allocated_by": {
+          "name": "allocated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "section_allocations_session_idx": {
+          "name": "section_allocations_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_train_idx": {
+          "name": "section_allocations_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_active_section": {
+          "name": "section_allocations_active_section",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"section_allocations\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_allocations_session_id_sessions_id_fk": {
+          "name": "section_allocations_session_id_sessions_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_section_id_sections_id_fk": {
+          "name": "section_allocations_section_id_sections_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_train_id_trains_id_fk": {
+          "name": "section_allocations_train_id_trains_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sections_district_idx": {
+          "name": "sections_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sections_district_id_districts_id_fk": {
+          "name": "sections_district_id_districts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_config_id": {
+          "name": "layout_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_one_active": {
+          "name": "sessions_one_active",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_layout_id_layouts_id_fk": {
+          "name": "sessions_layout_id_layouts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_tracks": {
+      "name": "staging_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_train_id": {
+          "name": "assigned_train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staging_tracks_layout_idx": {
+          "name": "staging_tracks_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staging_tracks_layout_id_module_layouts_id_fk": {
+          "name": "staging_tracks_layout_id_module_layouts_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "module_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staging_tracks_assigned_train_id_trains_id_fk": {
+          "name": "staging_tracks_assigned_train_id_trains_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "assigned_train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.train_statuses": {
+      "name": "train_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yard'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_authority": {
+          "name": "has_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "train_statuses_train_idx": {
+          "name": "train_statuses_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "train_statuses_session_idx": {
+          "name": "train_statuses_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "train_statuses_train_id_trains_id_fk": {
+          "name": "train_statuses_train_id_trains_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "train_statuses_session_id_sessions_id_fk": {
+          "name": "train_statuses_session_id_sessions_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trains": {
+      "name": "trains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_address": {
+          "name": "dcc_address",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_type": {
+          "name": "dcc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consist_id": {
+          "name": "consist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment_type": {
+          "name": "equipment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_operator_id": {
+          "name": "assigned_operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trains_session_idx": {
+          "name": "trains_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trains_assigned_idx": {
+          "name": "trains_assigned_idx",
+          "columns": [
+            {
+              "expression": "assigned_operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trains_session_id_sessions_id_fk": {
+          "name": "trains_session_id_sessions_id_fk",
+          "tableFrom": "trains",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnout_positions": {
+      "name": "turnout_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turnout_id": {
+          "name": "turnout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnout_positions_session_turnout": {
+          "name": "turnout_positions_session_turnout",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turnout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "turnout_positions_session_idx": {
+          "name": "turnout_positions_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnout_positions_session_id_sessions_id_fk": {
+          "name": "turnout_positions_session_id_sessions_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turnout_positions_turnout_id_turnouts_id_fk": {
+          "name": "turnout_positions_turnout_id_turnouts_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "turnouts",
+          "columnsFrom": [
+            "turnout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnouts": {
+      "name": "turnouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnouts_district_idx": {
+          "name": "turnouts_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnouts_district_id_districts_id_fk": {
+          "name": "turnouts_district_id_districts_id_fk",
+          "tableFrom": "turnouts",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1783219530189,
       "tag": "0014_layout_control_point_districts",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "7",
+      "when": 1783305930189,
+      "tag": "0015_layout_level_control_points",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -60,6 +60,10 @@ export const layouts = pgTable("layouts", {
   // assigning each imported control point to a dispatcher territory (#138).
   // Sections derive as the track between adjacent control points in a district.
   controlPointDistricts: jsonb("control_point_districts"),
+  // Layout-level control points (#144): [{id, name, anchor, offsetInches}],
+  // anchored to a layout_modules row at an offset from its A end. They
+  // interleave with the imported ones and feed the same section derivation.
+  layoutControlPoints: jsonb("layout_control_points"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -228,6 +228,17 @@ class TrackModel {
       .where(eq(layouts.id, layoutId));
   }
 
+  /** Replace the layout-level control points (#144). */
+  async setLayoutControlPoints(
+    layoutId: string,
+    cps: { id: string; name: string; anchor: string; offsetInches: number }[],
+  ): Promise<void> {
+    await db
+      .update(layouts)
+      .set({ layoutControlPoints: cps })
+      .where(eq(layouts.id, layoutId));
+  }
+
   /** Full District→Section→Block tree for a layout, or null if missing. */
   async getLayout(layoutId: string): Promise<LayoutTree | null> {
     const [layout] = await db

--- a/lib/server/__tests__/TrackModel.test.ts
+++ b/lib/server/__tests__/TrackModel.test.ts
@@ -35,6 +35,7 @@ describe("buildLayoutTree (#80)", () => {
     description: null,
     standard: "freemon",
     controlPointDistricts: null,
+    layoutControlPoints: null,
     createdAt: new Date(),
   };
 

--- a/lib/track/__tests__/layoutControlPoints.test.ts
+++ b/lib/track/__tests__/layoutControlPoints.test.ts
@@ -2,14 +2,18 @@ import { describe, it, expect } from "vitest";
 import {
   layoutControlPoints,
   deriveSections,
+  asLayoutCps,
   type CpModuleInput,
+  type LayoutCp,
 } from "../layoutControlPoints";
 
 const mod = (
   moduleId: string,
   positionIndex: number,
-  cps: { id: string; name?: string }[],
+  cps: { id: string; name?: string; pos?: number }[],
+  placementId?: string,
 ): CpModuleInput => ({
+  id: placementId ?? `pl-${moduleId}`,
   moduleId,
   moduleName: moduleId,
   positionIndex,
@@ -18,7 +22,15 @@ const mod = (
     lengthInches: 96,
     endplates: [],
     tracks: [{ id: "main", role: "main", lane: 0 }],
-    controlPoints: cps.map((c) => ({ id: c.id, name: c.name, turnouts: [], signals: [] })),
+    controlPoints: cps.map((c) => ({
+      id: c.id,
+      name: c.name,
+      turnouts: [],
+      signals:
+        c.pos != null
+          ? [{ id: `${c.id}-s`, pos: c.pos, track: "main", facing: "AtoB" }]
+          : [],
+    })),
   },
 });
 
@@ -33,7 +45,23 @@ describe("layoutControlPoints", () => {
       "FMN-0001:cpB",
       "FMN-0002:cpC",
     ]);
-    expect(cps[0]).toMatchObject({ moduleId: "FMN-0001", cpId: "cpA", name: "A" });
+    expect(cps[0]).toMatchObject({
+      moduleId: "FMN-0001",
+      cpId: "cpA",
+      name: "A",
+      source: "module",
+    });
+  });
+
+  it("orders points within a module by schematic position", () => {
+    const cps = layoutControlPoints([
+      mod("FMN-0001", 0, [
+        { id: "east", name: "East", pos: 350 },
+        { id: "west", name: "West", pos: 40 },
+      ]),
+    ]);
+    expect(cps.map((c) => c.cpId)).toEqual(["west", "east"]);
+    expect(cps[0].posInches).toBe(40);
   });
 
   it("skips modules without a schematic and falls back to the cp id for a name", () => {
@@ -44,12 +72,48 @@ describe("layoutControlPoints", () => {
     expect(cps).toHaveLength(1);
     expect(cps[0].name).toBe("cpX");
   });
+
+  it("interleaves layout-level points by anchored offset (#144)", () => {
+    const modules = [
+      mod("FMN-0001", 0, [
+        { id: "west", name: "West", pos: 40 },
+        { id: "east", name: "East", pos: 350 },
+      ]),
+    ];
+    const layoutCps: LayoutCp[] = [
+      { id: "x1", name: "Midway", anchor: "pl-FMN-0001", offsetInches: 200 },
+    ];
+    const cps = layoutControlPoints(modules, layoutCps);
+    expect(cps.map((c) => c.name)).toEqual(["West", "Midway", "East"]);
+    expect(cps[1]).toMatchObject({
+      key: "layout:x1",
+      source: "layout",
+      posInches: 200,
+      moduleId: "FMN-0001",
+    });
+  });
+
+  it("drops layout-level points whose anchor placement is gone", () => {
+    const cps = layoutControlPoints(
+      [mod("FMN-0001", 0, [{ id: "a", name: "A" }])],
+      [{ id: "x1", name: "Orphan", anchor: "pl-REMOVED", offsetInches: 10 }],
+    );
+    expect(cps.map((c) => c.name)).toEqual(["A"]);
+  });
+
+  it("a layout-level point can stand alone on a CP-less module", () => {
+    const cps = layoutControlPoints(
+      [mod("FMN-0001", 0, []), mod("FMN-0002", 1, [{ id: "b", name: "B", pos: 10 }])],
+      [{ id: "x1", name: "Junction", anchor: "pl-FMN-0001", offsetInches: 48 }],
+    );
+    expect(cps.map((c) => c.name)).toEqual(["Junction", "B"]);
+  });
 });
 
 describe("deriveSections", () => {
   const cps = layoutControlPoints([
-    mod("FMN-0001", 0, [{ id: "a", name: "A" }, { id: "b", name: "B" }]),
-    mod("FMN-0002", 1, [{ id: "c", name: "C" }]),
+    mod("FMN-0001", 0, [{ id: "a", name: "A", pos: 10 }, { id: "b", name: "B", pos: 80 }]),
+    mod("FMN-0002", 1, [{ id: "c", name: "C", pos: 10 }]),
   ]);
 
   it("makes a section between adjacent control points sharing a district", () => {
@@ -68,5 +132,36 @@ describe("deriveSections", () => {
     expect(
       deriveSections(cps, { "FMN-0001:a": "d1", "FMN-0001:b": "d2" }),
     ).toEqual([]);
+  });
+
+  it("layout-level points participate in section derivation (#144)", () => {
+    const merged = layoutControlPoints(
+      [mod("FMN-0001", 0, [{ id: "a", name: "A", pos: 10 }, { id: "b", name: "B", pos: 90 }])],
+      [{ id: "x1", name: "Mid", anchor: "pl-FMN-0001", offsetInches: 50 }],
+    );
+    const sections = deriveSections(merged, {
+      "FMN-0001:a": "d1",
+      "layout:x1": "d1",
+      "FMN-0001:b": "d1",
+    });
+    expect(sections.map((s) => s.name)).toEqual(["A – Mid", "Mid – B"]);
+  });
+});
+
+describe("asLayoutCps", () => {
+  it("parses a stored array and tolerates junk", () => {
+    expect(asLayoutCps(null)).toEqual([]);
+    expect(asLayoutCps("nope")).toEqual([]);
+    expect(
+      asLayoutCps([
+        { id: "x1", name: "Mid", anchor: "pl-1", offsetInches: 50 },
+        { id: 5, anchor: "pl-1" }, // bad id → dropped
+        "junk",
+        { id: "x2", anchor: "pl-2" }, // defaults
+      ]),
+    ).toEqual([
+      { id: "x1", name: "Mid", anchor: "pl-1", offsetInches: 50 },
+      { id: "x2", name: "x2", anchor: "pl-2", offsetInches: 0 },
+    ]);
   });
 });

--- a/lib/track/layoutControlPoints.ts
+++ b/lib/track/layoutControlPoints.ts
@@ -6,28 +6,70 @@
  * interlocking. Assigning each to a District makes it a dispatcher's territory;
  * a Section is then the mainline between two adjacent control points that belong
  * to the same district. Pure so it can be unit-tested.
+ *
+ * Beyond the module-authored ones, the Layout Builder can place additional
+ * layout-level control points (#144) — anchored to a module placement at an
+ * offset in inches from its A end — for boundaries the modules don't provide
+ * (a CP-less module, a junction between towns). They interleave positionally
+ * with the imported ones and feed the same Section derivation.
  */
 import { asModuleSchematic } from "./moduleSchematic";
+import type { SchematicControlPoint, ModuleSchematicDoc } from "./moduleSchematic";
 
 export interface CpModuleInput {
+  /** layout_modules row id — the anchor for layout-level control points. */
+  id?: string | null;
   moduleId?: string | null;
   moduleName?: string | null;
   positionIndex?: number;
   schematic?: unknown;
 }
 
+/** A layout-level control point stored on layouts.layout_control_points. */
+export interface LayoutCp {
+  id: string;
+  name: string;
+  /** layout_modules row id the point is anchored to. */
+  anchor: string;
+  /** Inches from the anchored module's A end. */
+  offsetInches: number;
+}
+
 export interface ControlPointRef {
-  /** Stable key within the layout: "<moduleRecordNumber>:<cpId>". */
+  /** Stable key within the layout: "<moduleRecordNumber>:<cpId>" for imported
+   * points, "layout:<id>" for layout-level ones. */
   key: string;
   moduleId: string;
   moduleName: string | null;
   cpId: string;
   name: string;
+  source: "module" | "layout";
+  /** Inches from the module's A end, when the schematic positions it. */
+  posInches: number | null;
 }
 
-/** Control points across the layout's modules, in module (spine) order. */
+/** A module CP's representative position: its westmost signal or turnout. */
+function cpPosInches(
+  cp: SchematicControlPoint,
+  doc: ModuleSchematicDoc,
+): number | null {
+  const positions: number[] = [];
+  for (const s of cp.signals ?? []) positions.push(s.pos);
+  for (const tid of cp.turnouts ?? []) {
+    const t = (doc.turnouts ?? []).find((x) => x.id === tid);
+    if (t) positions.push(t.pos);
+  }
+  return positions.length ? Math.min(...positions) : null;
+}
+
+/**
+ * Control points across the layout, in running order: modules in spine order,
+ * points within a module by position (doc order when unpositioned). Layout-level
+ * points interleave by their anchored offset.
+ */
 export function layoutControlPoints(
   modules: CpModuleInput[],
+  layoutCps: LayoutCp[] = [],
 ): ControlPointRef[] {
   const ordered = [...modules].sort(
     (a, b) => (a.positionIndex ?? 0) - (b.positionIndex ?? 0),
@@ -37,16 +79,35 @@ export function layoutControlPoints(
     const moduleId = m.moduleId;
     if (!moduleId) continue;
     const doc = asModuleSchematic(m.schematic);
+    const refs: ControlPointRef[] = [];
+    let docIndex = 0;
     for (const cp of doc?.controlPoints ?? []) {
       if (!cp.id) continue;
-      out.push({
+      refs.push({
         key: `${moduleId}:${cp.id}`,
         moduleId,
         moduleName: m.moduleName ?? null,
         cpId: cp.id,
         name: cp.name?.trim() || cp.id,
+        source: "module",
+        posInches: cpPosInches(cp, doc!) ?? docIndex,
+      });
+      docIndex += 1;
+    }
+    for (const lc of layoutCps) {
+      if (lc.anchor !== (m.id ?? "")) continue;
+      refs.push({
+        key: `layout:${lc.id}`,
+        moduleId,
+        moduleName: m.moduleName ?? null,
+        cpId: lc.id,
+        name: lc.name?.trim() || lc.id,
+        source: "layout",
+        posInches: lc.offsetInches,
       });
     }
+    refs.sort((a, b) => (a.posInches ?? 0) - (b.posInches ?? 0));
+    out.push(...refs);
   }
   return out;
 }
@@ -81,6 +142,24 @@ export function deriveSections(
         name: `${a.name} – ${b.name}`,
       });
     }
+  }
+  return out;
+}
+
+/** Parse a jsonb value into layout-level control points, tolerating junk. */
+export function asLayoutCps(x: unknown): LayoutCp[] {
+  if (!Array.isArray(x)) return [];
+  const out: LayoutCp[] = [];
+  for (const v of x) {
+    if (!v || typeof v !== "object") continue;
+    const c = v as Record<string, unknown>;
+    if (typeof c.id !== "string" || typeof c.anchor !== "string") continue;
+    out.push({
+      id: c.id,
+      name: typeof c.name === "string" ? c.name : c.id,
+      anchor: c.anchor,
+      offsetInches: typeof c.offsetInches === "number" ? c.offsetInches : 0,
+    });
   }
   return out;
 }


### PR DESCRIPTION
Closes #144. Follow-on to #138: beyond the module-authored control points, the Layout Builder can now place **its own** — anchored to a module placement at an offset (inches from the module's A end) — for boundaries the modules don't provide (a CP-less module, a junction between towns).

- **Interleave positionally**: module CPs now order by their schematic position (westmost signal/turnout) instead of doc order; layout-level ones merge in by anchored offset.
- **Same district assignment + Section derivation** as imported points (keys `layout:<id>` in the same `controlPointDistricts` map).
- **Removable** (imported ones aren't — they belong to the module author). "layout" badge + position shown in the list.
- Stored on `layouts.layout_control_points` (migration 0015, snapshot chain `drizzle-kit check` clean); PATCH `/api/layouts/:id` extended.

**Verified in the browser**: adding *Midway @ 200″* on One Mile interleaves *West → Midway → East* and splits the derived section into *West – Midway* and *Midway – East*; survives reload; removing it restores the single section. 10 unit tests on the lib (115 total), tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)