### PR TITLE
feat: auto-create blocks for derived sections, one per spanned module (#148)

### DIFF
--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -35,6 +35,9 @@ import {
   deriveSections,
   asLayoutCps,
   planSectionSync,
+  planBlockSync,
+  derivedSectionKey,
+  type SpannedModule,
 } from "@/lib/track/layoutControlPoints";
 
 // ---- Authoring input/output shapes ---------------------------------------
@@ -263,7 +266,7 @@ class TrackModel {
       tree.controlPointDistricts && typeof tree.controlPointDistricts === "object"
         ? (tree.controlPointDistricts as Record<string, string>)
         : {};
-    const derived = deriveSections(cps, assignments);
+    const derived = deriveSections(cps, assignments, tree.modules);
     const existing = tree.districts.flatMap((d) =>
       d.sections.map((s) => ({
         id: s.id,
@@ -278,7 +281,6 @@ class TrackModel {
       derived,
       new Set(tree.districts.map((d) => d.id)),
     );
-    if (!plan.insert.length && !plan.update.length && !plan.remove.length) return;
     await db.transaction(async (tx) => {
       if (plan.remove.length) {
         await tx.delete(sections).where(inArray(sections.id, plan.remove));
@@ -289,8 +291,35 @@ class TrackModel {
           .set({ districtId: u.districtId, name: u.name, position: u.position })
           .where(eq(sections.id, u.id));
       }
-      if (plan.insert.length) {
-        await tx.insert(sections).values(plan.insert);
+      const inserted = plan.insert.length
+        ? await tx.insert(sections).values(plan.insert).returning()
+        : [];
+
+      // Blocks under derived sections: one per spanned module (#148).
+      const removedIds = new Set(plan.remove);
+      const derivedRows = [
+        ...existing.filter((s) => s.derivedKey != null && !removedIds.has(s.id)),
+        ...inserted,
+      ];
+      const spanByKey = new Map(
+        derived.map((s) => [derivedSectionKey(s), s.moduleSpan ?? []]),
+      );
+      const desired = new Map<string, SpannedModule[]>(
+        derivedRows.map((s) => [s.id, spanByKey.get(s.derivedKey!) ?? []]),
+      );
+      const sectionIds = derivedRows.map((s) => s.id);
+      const existingBlocks = sectionIds.length
+        ? await tx
+            .select()
+            .from(blocks)
+            .where(inArray(blocks.sectionId, sectionIds))
+        : [];
+      const blockPlan = planBlockSync(existingBlocks, desired);
+      if (blockPlan.remove.length) {
+        await tx.delete(blocks).where(inArray(blocks.id, blockPlan.remove));
+      }
+      if (blockPlan.insert.length) {
+        await tx.insert(blocks).values(blockPlan.insert);
       }
     });
   }

--- a/lib/track/__tests__/layoutControlPoints.test.ts
+++ b/lib/track/__tests__/layoutControlPoints.test.ts
@@ -4,11 +4,14 @@ import {
   deriveSections,
   asLayoutCps,
   planSectionSync,
+  planBlockSync,
   DERIVED_POSITION_BASE,
   type CpModuleInput,
   type LayoutCp,
   type DerivedSection,
   type ExistingSectionRow,
+  type ExistingBlockRow,
+  type SpannedModule,
 } from "../layoutControlPoints";
 
 const mod = (
@@ -149,6 +152,80 @@ describe("deriveSections", () => {
       "FMN-0001:b": "d1",
     });
     expect(sections.map((s) => s.name)).toEqual(["A – Mid", "Mid – B"]);
+  });
+});
+
+describe("deriveSections module span (#148)", () => {
+  it("spans every module between the two control points, including CP-less ones", () => {
+    const modules = [
+      mod("FMN-0001", 0, [{ id: "a", name: "A", pos: 90 }]),
+      mod("FMN-0002", 1, []), // no control points — still part of the span
+      mod("FMN-0003", 2, [{ id: "b", name: "B", pos: 10 }]),
+    ];
+    const cps = layoutControlPoints(modules);
+    const sections = deriveSections(cps, { "FMN-0001:a": "d1", "FMN-0003:b": "d1" }, modules);
+    expect(sections).toHaveLength(1);
+    expect(sections[0].moduleSpan?.map((m) => m.moduleId)).toEqual([
+      "FMN-0001",
+      "FMN-0002",
+      "FMN-0003",
+    ]);
+  });
+
+  it("a section within one module spans just that module; span omitted without modules", () => {
+    const modules = [
+      mod("FMN-0001", 0, [{ id: "a", name: "A", pos: 10 }, { id: "b", name: "B", pos: 90 }]),
+    ];
+    const cps = layoutControlPoints(modules);
+    const assign = { "FMN-0001:a": "d1", "FMN-0001:b": "d1" };
+    expect(deriveSections(cps, assign, modules)[0].moduleSpan?.map((m) => m.moduleId)).toEqual([
+      "FMN-0001",
+    ]);
+    expect(deriveSections(cps, assign)[0].moduleSpan).toBeUndefined();
+  });
+});
+
+describe("planBlockSync (#148)", () => {
+  const span: SpannedModule[] = [
+    { moduleId: "FMN-0001", moduleName: "One Mile" },
+    { moduleId: "FMN-0002", moduleName: null },
+  ];
+  const blk = (
+    id: string,
+    sectionId: string,
+    name: string,
+    position: number,
+    moduleRecordNumber: string,
+  ): ExistingBlockRow => ({ id, sectionId, name, position, moduleRecordNumber });
+
+  it("creates one block per spanned module, named after the module", () => {
+    const plan = planBlockSync([], new Map([["s1", span]]));
+    expect(plan.remove).toEqual([]);
+    expect(plan.insert).toEqual([
+      { sectionId: "s1", name: "One Mile", position: 0, moduleRecordNumber: "FMN-0001" },
+      { sectionId: "s1", name: "FMN-0002", position: 1, moduleRecordNumber: "FMN-0002" },
+    ]);
+  });
+
+  it("is a no-op when blocks already match", () => {
+    const existing = [
+      blk("b1", "s1", "One Mile", 0, "FMN-0001"),
+      blk("b2", "s1", "FMN-0002", 1, "FMN-0002"),
+    ];
+    expect(planBlockSync(existing, new Map([["s1", span]]))).toEqual({
+      insert: [],
+      remove: [],
+    });
+  });
+
+  it("replaces a section's blocks when the span changes, and clears orphans", () => {
+    const existing = [
+      blk("b1", "s1", "One Mile", 0, "FMN-0001"),
+      blk("b9", "sGone", "Old", 0, "FMN-0009"),
+    ];
+    const plan = planBlockSync(existing, new Map([["s1", span]]));
+    expect(plan.remove.sort()).toEqual(["b1", "b9"]);
+    expect(plan.insert).toHaveLength(2);
   });
 });
 

--- a/lib/track/layoutControlPoints.ts
+++ b/lib/track/layoutControlPoints.ts
@@ -112,22 +112,46 @@ export function layoutControlPoints(
   return out;
 }
 
+export interface SpannedModule {
+  moduleId: string;
+  moduleName: string | null;
+}
+
 export interface DerivedSection {
   districtId: string;
   fromKey: string;
   toKey: string;
   name: string;
+  /** Modules the section runs across, in spine order (when modules given). */
+  moduleSpan?: SpannedModule[];
 }
 
 /**
  * Sections between adjacent control points that share a district. The stretch of
  * mainline between two consecutive control points belongs to a district only
- * when both endpoints are assigned to it.
+ * when both endpoints are assigned to it. Pass `modules` to also report each
+ * section's module span (#148) — every placement from the from-point's module
+ * to the to-point's, including CP-less ones in between.
  */
 export function deriveSections(
   controlPoints: ControlPointRef[],
   assignments: Record<string, string | undefined>,
+  modules?: CpModuleInput[],
 ): DerivedSection[] {
+  const spine = modules
+    ? [...modules]
+        .sort((a, b) => (a.positionIndex ?? 0) - (b.positionIndex ?? 0))
+        .filter((m) => m.moduleId)
+    : [];
+  const spanOf = (aModule: string, bModule: string): SpannedModule[] => {
+    const from = spine.findIndex((m) => m.moduleId === aModule);
+    const to = spine.findIndex((m) => m.moduleId === bModule);
+    if (from < 0 || to < 0) return [];
+    return spine
+      .slice(Math.min(from, to), Math.max(from, to) + 1)
+      .map((m) => ({ moduleId: m.moduleId!, moduleName: m.moduleName ?? null }));
+  };
+
   const out: DerivedSection[] = [];
   for (let i = 0; i < controlPoints.length - 1; i++) {
     const a = controlPoints[i];
@@ -140,6 +164,7 @@ export function deriveSections(
         fromKey: a.key,
         toKey: b.key,
         name: `${a.name} – ${b.name}`,
+        ...(modules ? { moduleSpan: spanOf(a.moduleId, b.moduleId) } : {}),
       });
     }
   }
@@ -214,6 +239,69 @@ export function planSectionSync(
   }
   for (const [key, want] of desired) {
     if (!seen.has(key)) plan.insert.push({ ...want, derivedKey: key });
+  }
+  return plan;
+}
+
+export interface ExistingBlockRow {
+  id: string;
+  sectionId: string;
+  name: string;
+  position: number;
+  moduleRecordNumber: string | null;
+}
+
+export interface BlockSyncPlan {
+  insert: {
+    sectionId: string;
+    name: string;
+    position: number;
+    moduleRecordNumber: string;
+  }[];
+  remove: string[]; // block row ids
+}
+
+/**
+ * Blocks under a derived section are fully managed (#148): one block per module
+ * the section spans, in spine order, named after the module. When a section's
+ * blocks no longer match its span, they are replaced wholesale (occupancy is
+ * per-session runtime state; stale rows must not linger under a changed span).
+ * `existing` must contain only blocks of derived sections — hand-authored
+ * sections are never passed in.
+ */
+export function planBlockSync(
+  existing: ExistingBlockRow[],
+  desired: Map<string, SpannedModule[]>, // sectionId → span
+): BlockSyncPlan {
+  const bySection = new Map<string, ExistingBlockRow[]>();
+  for (const b of existing) {
+    const arr = bySection.get(b.sectionId) ?? [];
+    arr.push(b);
+    bySection.set(b.sectionId, arr);
+  }
+  const plan: BlockSyncPlan = { insert: [], remove: [] };
+  const sectionIds = new Set([...desired.keys(), ...bySection.keys()]);
+  for (const sectionId of sectionIds) {
+    const want = (desired.get(sectionId) ?? []).map((m, i) => ({
+      sectionId,
+      name: m.moduleName?.trim() || m.moduleId,
+      position: i,
+      moduleRecordNumber: m.moduleId,
+    }));
+    const have = (bySection.get(sectionId) ?? []).sort(
+      (a, b) => a.position - b.position,
+    );
+    const matches =
+      want.length === have.length &&
+      want.every(
+        (w, i) =>
+          have[i].name === w.name &&
+          have[i].position === w.position &&
+          have[i].moduleRecordNumber === w.moduleRecordNumber,
+      );
+    if (matches) continue;
+    plan.remove.push(...have.map((b) => b.id));
+    plan.insert.push(...want);
   }
   return plan;
 }


### PR DESCRIPTION
Closes #148. Derived sections (#146) materialized with no blocks, so they couldn't take occupancy. Each now gets **one block per module it spans** — in spine order, named after the module, `moduleRecordNumber` set — so the existing block-occupancy runtime works per-module within a section.

- `deriveSections` optionally reports each section's **module span** (every placement from the from-point's module to the to-point's, including CP-less ones in between).
- `planBlockSync` (pure, 5 tests → 124 total): blocks under a derived section are fully managed — replaced wholesale when the span changes, orphans cleared; hand-authored sections are never touched.
- `syncDerivedSections` reconciles blocks in the same transaction as sections.

**Verified in the browser**: the One Mile derived section now lists block *"One Mile"* in the Layout Builder (was *"no blocks"*). tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)