### PR TITLE
feat: live signal aspects on the operations panel (#151)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -45,9 +45,13 @@ const laneY = (lane: number) => Y0 - lane * LANE_GAP;
 export function OperationsSchematic({
   modules,
   districts,
+  signalAspects,
 }: {
   modules: OpsModuleInput[];
   districts?: SectionAwareDistrict[];
+  /** Live CTC aspects keyed "<moduleRecordNumber>:<cpId>" (#151). When given,
+   * control-point signals color green (clear) / red (stop); absent = neutral. */
+  signalAspects?: Record<string, { AtoB: "clear" | "stop"; BtoA: "clear" | "stop" }>;
 }) {
   if (modules.length === 0) {
     return (
@@ -287,11 +291,22 @@ export function OperationsSchematic({
                 const sy = s.side === "below" ? laneY(s.lane) + 3 : laneY(s.lane) - 3;
                 const dir = s.facing === "BtoA" ? -1 : 1;
                 const L = Math.max(4, c.width * 0.02);
+                // Live aspect: join back to the control point (#151).
+                const aspect =
+                  signalAspects && s.cp && c.input.moduleId
+                    ? signalAspects[`${c.input.moduleId}:${s.cp}`]?.[s.facing]
+                    : undefined;
+                const color =
+                  aspect === "clear"
+                    ? "#34d399"
+                    : aspect === "stop"
+                      ? "#ef4444"
+                      : "#94a3b8";
                 return (
                   <g key={s.id}>
-                    <line x1={sx} y1={sy} x2={sx + dir * L} y2={sy} stroke="#94a3b8" strokeWidth={0.9} />
-                    <circle cx={sx + dir * L} cy={sy} r={1.4} fill="#94a3b8" />
-                    <title>{`Signal${s.name ? ` · ${s.name}` : ""} (${s.facing})`}</title>
+                    <line x1={sx} y1={sy} x2={sx + dir * L} y2={sy} stroke={color} strokeWidth={0.9} />
+                    <circle cx={sx + dir * L} cy={sy} r={aspect ? 1.7 : 1.4} fill={color} />
+                    <title>{`Signal${s.name ? ` · ${s.name}` : ""} (${s.facing})${aspect ? ` — ${aspect.toUpperCase()}` : ""}`}</title>
                   </g>
                 );
               })}

--- a/components/track/TrackBoard.tsx
+++ b/components/track/TrackBoard.tsx
@@ -16,9 +16,15 @@ import { apiSend } from "@/lib/client/api";
 import { useTrackBoard } from "@/lib/client/useTrackBoard";
 import {
   deriveSectionAspect,
+  cpSignalAspects,
   ASPECT_META,
   ASPECT_ORDER,
 } from "@/lib/track/signals";
+import {
+  layoutControlPoints,
+  asLayoutCps,
+} from "@/lib/track/layoutControlPoints";
+import { OperationsSchematic } from "@/components/layout/OperationsSchematic";
 import type { TrainRow } from "@/lib/client/types";
 
 type Direction = "AtoB" | "BtoA";
@@ -113,8 +119,35 @@ export function TrackBoard({
       .map((o) => o.blockId),
   );
 
+  // Live CTC panel (#151): control-point signal aspects from allocations.
+  const allSections = layout.districts.flatMap((d) => d.sections);
+  const cps = layout.modules?.length
+    ? layoutControlPoints(layout.modules, asLayoutCps(layout.layoutControlPoints))
+    : [];
+  const sectionsByDerivedKey = new Map(
+    allSections
+      .filter((s) => s.derivedKey != null)
+      .map((s) => [s.derivedKey!, s.id]),
+  );
+  const occupiedSectionIds = new Set(
+    allSections
+      .filter((s) => s.blocks.some((b) => occupiedBlocks.has(b.id)))
+      .map((s) => s.id),
+  );
+  const aspects = cpSignalAspects(
+    cps,
+    sectionsByDerivedKey,
+    allocations,
+    occupiedSectionIds,
+  );
+
   return (
     <div className="space-y-4">
+      {/* Live operations panel — signals show cleared routes (#151). */}
+      {layout.modules && layout.modules.length > 0 && (
+        <OperationsSchematic modules={layout.modules} signalAspects={aspects} />
+      )}
+
       {/* Signal legend */}
       <div className="flex flex-wrap items-center gap-3 text-xs text-slate-400">
         <span className="font-medium text-slate-500">Signals:</span>

--- a/lib/client/useTrackBoard.ts
+++ b/lib/client/useTrackBoard.ts
@@ -19,6 +19,8 @@ export interface SectionNode {
   id: string;
   name: string;
   track: string | null;
+  /** Non-null when materialized from control points (#146). */
+  derivedKey: string | null;
   blocks: BlockNode[];
 }
 export interface TurnoutNode {
@@ -32,10 +34,29 @@ export interface DistrictNode {
   turnouts: TurnoutNode[];
 }
 export type TurnoutPosition = "normal" | "reversed";
+export interface LayoutModuleNode {
+  id: string;
+  moduleId: string;
+  moduleName: string | null;
+  positionIndex: number;
+  stagingEnd: "A" | "B" | null;
+  lengthTotalInches: number | null;
+  mainlineLengthInches: number | null;
+  hasMss: boolean | null;
+  geometryType: string | null;
+  geometryDegrees: number | null;
+  flipped: boolean;
+  endplates: import("@/lib/track/endplates").EndplateInfo[] | null;
+  schematic: unknown;
+}
 export interface LayoutTree {
   id: string;
   name: string;
   districts: DistrictNode[];
+  /** Module placements in spine order — for the live operations panel (#151). */
+  modules?: LayoutModuleNode[];
+  controlPointDistricts?: Record<string, string> | null;
+  layoutControlPoints?: unknown;
 }
 export interface OccupancyRow {
   blockId: string;

--- a/lib/track/__tests__/signals.test.ts
+++ b/lib/track/__tests__/signals.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { deriveSectionAspect } from "../signals";
+import { deriveSectionAspect, cpSignalAspects } from "../signals";
+import type { ControlPointRef } from "../layoutControlPoints";
 
 describe("deriveSectionAspect (#83 virtual signals)", () => {
   it("is occupied when any block is occupied — regardless of allocation", () => {
@@ -20,5 +21,69 @@ describe("deriveSectionAspect (#83 virtual signals)", () => {
   it("treats an empty block list by allocation only", () => {
     expect(deriveSectionAspect([], new Set(), true)).toBe("allocated");
     expect(deriveSectionAspect([], new Set(), false)).toBe("clear");
+  });
+});
+
+describe("cpSignalAspects (#151 live CTC panel)", () => {
+  const cp = (key: string): ControlPointRef => ({
+    key,
+    moduleId: key.split(":")[0],
+    moduleName: null,
+    cpId: key.split(":")[1] ?? key,
+    name: key,
+    source: "module",
+    posInches: null,
+  });
+  // West — Mid — East along the spine; one derived section each side of Mid.
+  const cps = [cp("M:west"), cp("M:mid"), cp("M:east")];
+  const sections = new Map([
+    ["M:west→M:mid", "s1"],
+    ["M:mid→M:east", "s2"],
+  ]);
+
+  it("defaults every signal to stop (absolute signals)", () => {
+    const a = cpSignalAspects(cps, sections, {}, new Set());
+    expect(a["M:west"]).toEqual({ AtoB: "stop", BtoA: "stop" });
+    expect(a["M:mid"]).toEqual({ AtoB: "stop", BtoA: "stop" });
+  });
+
+  it("clears the entrance signal in the allocated direction only", () => {
+    const a = cpSignalAspects(
+      cps,
+      sections,
+      { s1: { direction: "AtoB" } },
+      new Set(),
+    );
+    // Eastward authority into s1: west's A→B clears; nothing else does.
+    expect(a["M:west"].AtoB).toBe("clear");
+    expect(a["M:west"].BtoA).toBe("stop");
+    expect(a["M:mid"]).toEqual({ AtoB: "stop", BtoA: "stop" });
+  });
+
+  it("a westward allocation clears the far-end signal instead", () => {
+    const a = cpSignalAspects(
+      cps,
+      sections,
+      { s2: { direction: "BtoA" } },
+      new Set(),
+    );
+    // Westward authority into s2: east's B→A clears.
+    expect(a["M:east"].BtoA).toBe("clear");
+    expect(a["M:mid"].AtoB).toBe("stop");
+  });
+
+  it("an occupied section holds its signals at stop even when allocated", () => {
+    const a = cpSignalAspects(
+      cps,
+      sections,
+      { s1: { direction: "AtoB" } },
+      new Set(["s1"]),
+    );
+    expect(a["M:west"].AtoB).toBe("stop");
+  });
+
+  it("gaps without a materialized section stay at stop", () => {
+    const a = cpSignalAspects(cps, new Map(), { s1: { direction: "AtoB" } }, new Set());
+    expect(a["M:west"].AtoB).toBe("stop");
   });
 });

--- a/lib/track/signals.ts
+++ b/lib/track/signals.ts
@@ -10,6 +10,8 @@
  *   clear     — free and unallocated → available
  */
 
+import type { ControlPointRef } from "./layoutControlPoints";
+
 export type SignalAspect = "clear" | "allocated" | "occupied";
 
 /** Derive a Section's aspect from its blocks' occupancy and whether it's held. */
@@ -38,3 +40,44 @@ export const ASPECT_META: Record<SignalAspect, AspectMeta> = {
 };
 
 export const ASPECT_ORDER: SignalAspect[] = ["clear", "allocated", "occupied"];
+
+// ---- Control-point signal aspects (#151) -----------------------------------
+
+/** A control-point signal is absolute: red until a route is cleared past it. */
+export type CpSignalAspect = "clear" | "stop";
+
+export interface CpAspects {
+  AtoB: CpSignalAspect;
+  BtoA: CpSignalAspect;
+}
+
+/**
+ * Direction-aware aspects for every control point on the panel (CTC-style):
+ * the signal at a section's entrance clears only when that section is allocated
+ * in the signal's facing direction and nothing occupies it; everything else —
+ * unallocated, opposing movement, occupied — reads stop.
+ *
+ * Keyed by the control point's layout key ("<moduleRecordNumber>:<cpId>" /
+ * "layout:<id>"). Pure so it unit-tests without a database.
+ */
+export function cpSignalAspects(
+  controlPoints: ControlPointRef[],
+  sectionsByDerivedKey: ReadonlyMap<string, string>, // derivedKey → sectionId
+  allocations: Readonly<Record<string, { direction: "AtoB" | "BtoA" }>>,
+  occupiedSectionIds: ReadonlySet<string>,
+): Record<string, CpAspects> {
+  const out: Record<string, CpAspects> = {};
+  for (const cp of controlPoints) out[cp.key] = { AtoB: "stop", BtoA: "stop" };
+  for (let i = 0; i < controlPoints.length - 1; i++) {
+    const a = controlPoints[i];
+    const b = controlPoints[i + 1];
+    const sectionId = sectionsByDerivedKey.get(`${a.key}→${b.key}`);
+    if (!sectionId) continue;
+    const alloc = allocations[sectionId];
+    if (!alloc || occupiedSectionIds.has(sectionId)) continue;
+    // Entering the section eastward past A, or westward past B.
+    if (alloc.direction === "AtoB") out[a.key].AtoB = "clear";
+    else out[b.key].BtoA = "clear";
+  }
+  return out;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.1.0",
+        "@willcgage/module-schematic": "^0.2.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.1.0.tgz",
-      "integrity": "sha512-cNIaD6zSYHxeA1jjM4IQOGJQrETUlOmPGKGE0KA3Ltp9kCMiInJBrLOCroV8VZLbdiBHry2phVHCl4R5k7Ydag==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.2.0.tgz",
+      "integrity": "sha512-L9xyzWUioGVcR362QnXZZ8D298jp0jgRU7NF2+m8ktJX0HMcprfpI8Jd623x3jxzjGCqvtuc17EbgVJVn2AXkg==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.1.0",
+    "@willcgage/module-schematic": "^0.2.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Closes #151. The Track page now opens with the operations schematic as a **live CTC panel**: each control-point signal shows a direction-aware aspect derived from runtime state, updated over the existing SSE subscription.

**Aspect rule** (absolute signals): a signal clears only when the derived section beyond it (#146) is **allocated in the signal's facing direction** and unoccupied — unallocated, opposing movement, or occupancy all read stop.

- `cpSignalAspects` (pure, 5 tests → 129 total): CP key → `{AtoB, BtoA}` from ordered control points, materialized sections, allocations, occupancy.
- Drawn signals join to control points via [`@willcgage/module-schematic@0.2.0`](https://www.npmjs.com/package/@willcgage/module-schematic) (`DrawSignal.cp`) — the package's **first CI publish via npm Trusted Publishing**.
- `OperationsSchematic` gains an optional `signalAspects` prop; clear = green, stop = red, neutral when absent (authoring view unchanged).

**Verified in the browser end-to-end**: all signals stop with no authority → allocating the section A→B clears only the West signal → occupying the block drops it back to stop → release returns all to stop. Live over SSE, no reload. tsc + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)