### PR TITLE
fix: spur off Main 2 no longer renders as a crossover (modulerepo#14)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -35,8 +35,6 @@ const SECTION_LABEL_Y = 6; // section name (top band)
 const SECTION_BRACKET_Y = 9; // section bracket line
 const Y1 = 32; // Main 2 (upper) — headroom above for siding/spur lanes
 const Y0 = Y1 + LANE_GAP; // Main 1 (lower, continuous)
-const LABEL_Y = Y0 + 10;
-const HEIGHT = LABEL_Y + 6;
 const STROKE = 2.4;
 
 /** Lane index → y. Lane 0 is Main 1; higher lanes stack upward. */
@@ -73,6 +71,17 @@ export function OperationsSchematic({
   );
 
   const total = schem.totalInches;
+  // Tracks below Main 1 (negative lanes — e.g. a team track outside a double
+  // main, modulerepo#14) push the label band and canvas bottom down.
+  const minLane = Math.min(
+    0,
+    ...schem.cells.map((c) => {
+      const doc = asModuleSchematic(c.input.schematic);
+      return doc ? moduleFeatures(doc).laneMin : 0;
+    }),
+  );
+  const LABEL_Y = Y0 - minLane * LANE_GAP + 10;
+  const HEIGHT = LABEL_Y + 6;
   const viewBox = `${-PAD_X} 0 ${total + 2 * PAD_X} ${HEIGHT}`;
   const feet = Math.round((total / 12) * 10) / 10;
 
@@ -255,7 +264,9 @@ export function OperationsSchematic({
                 const x1 = px(t.fromFrac);
                 const x2 = px(t.toFrac);
                 const yl = laneY(t.lane);
-                const ym = laneY(0);
+                // Diverge from the main this track's turnout sits on — a team
+                // track off Main 2 starts at lane 1, not a crossover from Main 1.
+                const ym = laneY(t.divergesFromLane);
                 const thr = Math.max(6, c.width * 0.04);
                 const pts =
                   t.role === "spur"

--- a/lib/track/operations.ts
+++ b/lib/track/operations.ts
@@ -63,7 +63,8 @@ export function buildOperationsSchematic(
     // When a module has an authored schematic, its features are positioned in
     // the schematic's own coordinate space (its lengthInches), so the cell must
     // be that wide or the overlaid sidings/turnouts/signals won't line up.
-    const schematicLen = asModuleSchematic(m.schematic)?.lengthInches;
+    const doc = asModuleSchematic(m.schematic);
+    const schematicLen = doc?.lengthInches;
     const len =
       (schematicLen && schematicLen > 0
         ? schematicLen
@@ -73,12 +74,19 @@ export function buildOperationsSchematic(
             ? m.lengthTotalInches
             : DEFAULT_CELL_INCHES) || DEFAULT_CELL_INCHES;
     const width = Math.max(len, MIN_CELL_INCHES);
+    // The authored schematic also declares single/double; trust it when the
+    // physical endplate track_config is missing (modulerepo#14).
+    const schemTracks = doc
+      ? doc.endplates.some((e) => e.tracks?.some((t) => t.config === "double"))
+        ? 2
+        : 1
+      : null;
     const cell: OpsCell = {
       input: m,
       x,
       width,
-      leftTracks: trackCount(inConfig(m)) ?? 0,
-      rightTracks: trackCount(outConfig(m)) ?? 0,
+      leftTracks: trackCount(inConfig(m)) ?? schemTracks ?? 0,
+      rightTracks: trackCount(outConfig(m)) ?? schemTracks ?? 0,
     };
     x += width;
     return cell;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.2.0",
+        "@willcgage/module-schematic": "^0.3.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.2.0.tgz",
-      "integrity": "sha512-L9xyzWUioGVcR362QnXZZ8D298jp0jgRU7NF2+m8ktJX0HMcprfpI8Jd623x3jxzjGCqvtuc17EbgVJVn2AXkg==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.3.0.tgz",
+      "integrity": "sha512-8UbX34yEhpqbcMS10BdXgxU7pG4e9V4T/fIezhWk49ipxsSriH3dZIEeSHvRwnlLTJKIlBEealsa2Pr+D1rxKA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.2.0",
+    "@willcgage/module-schematic": "^0.3.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Fixes the double-track crossover bug reported by the **Harrisonville MoPac Extension** owner (willcgage/modulerepo#14): a team track off Main 2 always drew its diagonal from Main 1 across Main 2 — reading as a crossover — and there was no way to diverge outward.

- [`@willcgage/module-schematic@0.3.0`](https://github.com/willcgage/module-schematic/releases/tag/v0.3.0): **Main 2 is a real track** when an endplate is double (turnouts/signals can attach); **`DrawTrack.divergesFromLane`**; **negative lanes** (outside Main 1) + lane extents.
- `OperationsSchematic`: diverge diagonals start at the correct main; canvas grows downward for negative lanes.
- `buildOperationsSchematic`: trusts the authored schematic's single/double declaration when the physical endplate `track_config` is missing.

**Verified in the browser** with a seeded double-main module: both mains draw; the team track diverges from Main 2 outward (polyline origin y = Main 2's lane). 129 tests + build green. The Module Repository editor/preview side lands separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)