### PR TITLE
feat: repo status drives availability; notify + replace dropped modules (#158)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { apiGet, apiSend } from "@/lib/client/api";
 import { Panel } from "@/components/admin/ui";
 import { moduleMatches } from "@/lib/client/moduleSearch";
@@ -19,6 +19,11 @@ import {
   deriveSections,
   asLayoutCps,
 } from "@/lib/track/layoutControlPoints";
+import {
+  moduleUnavailability,
+  UNAVAILABLE_LABEL,
+  UNAVAILABLE_HINT,
+} from "@/lib/track/moduleAvailability";
 import type { CatalogModule } from "@/lib/client/types";
 import type { StagingEnd } from "@/lib/db/schema";
 
@@ -70,6 +75,8 @@ interface LayoutModuleNode {
   schematic: unknown;
   /** Set when the module was removed from the Module Repository (#155). */
   removedFromRepoAt: string | null;
+  /** Owner's repo status: active | inactive | archived (#158). */
+  status: string | null;
 }
 interface LayoutTree extends LayoutRow {
   modules: LayoutModuleNode[];
@@ -130,6 +137,15 @@ export default function AdminLayouts() {
   const [cpDraft, setCpDraft] = useState<
     Record<string, { name: string; anchor: string; offset: string }>
   >({});
+  // Dropped-module notice + schematic highlight + replace flow (#158).
+  const [unavailNotice, setUnavailNotice] = useState<{ layoutId: string } | null>(null);
+  const unavailNotified = useRef<Set<string>>(new Set());
+  const [highlightMods, setHighlightMods] = useState<Record<string, string[]>>({});
+  const [replacing, setReplacing] = useState<{
+    layoutId: string;
+    placementId: string;
+    value: string;
+  } | null>(null);
   const [drag, setDrag] = useState<{ layoutId: string; from: number } | null>(
     null,
   );
@@ -176,6 +192,7 @@ export default function AdminLayouts() {
   }, []);
 
   async function toggleTree(id: string) {
+    const opening = !expanded.has(id);
     setExpanded((prev) => {
       const next = new Set(prev);
       if (next.has(id)) next.delete(id);
@@ -183,6 +200,46 @@ export default function AdminLayouts() {
       return next;
     });
     if (!trees[id]) await reloadTree(id);
+    // Opening a layout that contains dropped modules pops a notice (#158) —
+    // once per layout per visit.
+    if (opening && !unavailNotified.current.has(id)) {
+      const tree =
+        trees[id] ??
+        (await apiGet<{ layout: LayoutTree }>(`/api/layouts/${id}`).then(
+          (r) => r.layout,
+          () => null,
+        ));
+      const dropped = (tree?.modules ?? []).filter((m) => moduleUnavailability(m));
+      if (dropped.length > 0) {
+        unavailNotified.current.add(id);
+        setUnavailNotice({ layoutId: id });
+      }
+    }
+  }
+
+  /** Highlight a dropped module in the operations schematic and scroll to it. */
+  function showInSchematic(layoutId: string, placementId: string) {
+    setUnavailNotice(null);
+    setHighlightMods((p) => ({ ...p, [layoutId]: [placementId] }));
+    setTimeout(() => {
+      document
+        .getElementById(`ops-schematic-${layoutId}`)
+        ?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }, 50);
+  }
+
+  /** Swap a placement to another catalog module, in place (#158). */
+  async function replaceModule(layoutId: string, placementId: string, rec: string) {
+    setBusy(true);
+    try {
+      await apiSend("PATCH", `/api/modules/${placementId}`, { moduleId: rec });
+      setReplacing(null);
+      await reloadTree(layoutId);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "replace failed");
+    } finally {
+      setBusy(false);
+    }
   }
 
   const qOf = (id: string) => modQuery[id] ?? "";
@@ -463,6 +520,61 @@ export default function AdminLayouts() {
 
   return (
     <div className="max-w-3xl space-y-5">
+      {/* Dropped-modules notice (#158) */}
+      {unavailNotice && trees[unavailNotice.layoutId] && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4"
+          onClick={() => setUnavailNotice(null)}
+        >
+          <div
+            className="w-full max-w-md rounded-lg border border-amber-800/60 bg-slate-900 p-4 shadow-xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <h3 className="mb-1 text-sm font-semibold text-amber-300">
+              This layout uses modules no longer offered by the Module Repository
+            </h3>
+            <p className="mb-3 text-xs text-slate-400">
+              The layout keeps their data, but they were removed, deactivated,
+              or archived upstream. Show one in the schematic, or replace it
+              from the module list.
+            </p>
+            <ul className="space-y-1.5">
+              {trees[unavailNotice.layoutId].modules
+                .filter((m) => moduleUnavailability(m))
+                .map((m) => {
+                  const why = moduleUnavailability(m)!;
+                  return (
+                    <li key={m.id} className="flex items-center gap-2 text-sm">
+                      <span className="min-w-0 flex-1 truncate text-slate-200">
+                        {m.moduleName ?? m.moduleId}
+                      </span>
+                      <span className="rounded bg-amber-900/60 px-1 py-px text-[10px] uppercase text-amber-400">
+                        {UNAVAILABLE_LABEL[why]}
+                      </span>
+                      <button
+                        onClick={() =>
+                          showInSchematic(unavailNotice.layoutId, m.id)
+                        }
+                        className="shrink-0 rounded border border-slate-600 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800"
+                      >
+                        Show in schematic
+                      </button>
+                    </li>
+                  );
+                })}
+            </ul>
+            <div className="mt-3 text-right">
+              <button
+                onClick={() => setUnavailNotice(null)}
+                className="rounded border border-slate-700 px-3 py-1 text-sm text-slate-300 hover:bg-slate-800"
+              >
+                Close
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
       <h1 className="text-2xl font-bold">Layouts</h1>
       <p className="text-sm text-slate-400">
         A layout is the reusable track model — Districts, Sections and Blocks —
@@ -602,18 +714,71 @@ export default function AdminLayouts() {
                                     </span>
                                     <span className="min-w-0 flex-1 truncate text-slate-200">
                                       {m.moduleName ?? m.moduleId}
-                                      {m.removedFromRepoAt && (
-                                        <span
-                                          title="This module was removed from the Module Repository. The layout keeps its data, but it can't be re-added elsewhere."
-                                          className="ml-1.5 rounded bg-amber-900/60 px-1 py-px text-[10px] uppercase text-amber-400"
-                                        >
-                                          removed from repo
-                                        </span>
-                                      )}
+                                      {(() => {
+                                        const why = moduleUnavailability(m);
+                                        return why ? (
+                                          <span
+                                            title={UNAVAILABLE_HINT[why]}
+                                            className="ml-1.5 rounded bg-amber-900/60 px-1 py-px text-[10px] uppercase text-amber-400"
+                                          >
+                                            {UNAVAILABLE_LABEL[why]}
+                                          </span>
+                                        ) : null;
+                                      })()}
                                     </span>
                                     <span className="shrink-0 font-mono text-xs text-slate-500">
                                       {m.moduleId}
                                     </span>
+                                    {replacing?.placementId === m.id ? (
+                                      <span className="flex shrink-0 items-center gap-1">
+                                        <select
+                                          value={replacing.value}
+                                          onChange={(e) =>
+                                            setReplacing({ ...replacing, value: e.target.value })
+                                          }
+                                          className="max-w-44 rounded border border-slate-700 bg-slate-800 px-1 py-0.5 text-xs text-slate-300"
+                                        >
+                                          <option value="">Replace with…</option>
+                                          {catalog
+                                            .filter((c) => c.recordNumber !== m.moduleId)
+                                            .map((c) => (
+                                              <option key={c.recordNumber} value={c.recordNumber}>
+                                                {c.moduleName} · {c.recordNumber}
+                                              </option>
+                                            ))}
+                                        </select>
+                                        <button
+                                          disabled={busy || !replacing.value}
+                                          onClick={() =>
+                                            replaceModule(l.id, m.id, replacing.value)
+                                          }
+                                          className="rounded bg-sky-700 px-1.5 py-0.5 text-xs text-white hover:bg-sky-600 disabled:opacity-40"
+                                        >
+                                          Swap
+                                        </button>
+                                        <button
+                                          onClick={() => setReplacing(null)}
+                                          className="rounded border border-slate-700 px-1 py-0.5 text-xs text-slate-400 hover:bg-slate-800"
+                                        >
+                                          ✕
+                                        </button>
+                                      </span>
+                                    ) : (
+                                      <button
+                                        disabled={busy}
+                                        title="Replace this placement with another catalog module (keeps its position)"
+                                        onClick={() =>
+                                          setReplacing({
+                                            layoutId: l.id,
+                                            placementId: m.id,
+                                            value: "",
+                                          })
+                                        }
+                                        className="shrink-0 rounded border border-slate-700 px-1.5 py-0.5 text-xs text-slate-400 hover:bg-slate-800"
+                                      >
+                                        Replace
+                                      </button>
+                                    )}
                                     <select
                                       value={m.stagingEnd ?? ""}
                                       onChange={(e) =>
@@ -825,13 +990,14 @@ export default function AdminLayouts() {
                           </div>
 
                           {/* Operations schematic (straightened — primary) */}
-                          <div>
+                          <div id={`ops-schematic-${l.id}`}>
                             <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
                               Operations schematic
                             </div>
                             <OperationsSchematic
                               modules={tree.modules}
                               districts={tree.districts}
+                              highlightModuleIds={highlightMods[l.id]}
                             />
                           </div>
 

--- a/app/api/modules/[id]/route.ts
+++ b/app/api/modules/[id]/route.ts
@@ -5,7 +5,7 @@
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { db } from "@/lib/db/client";
-import { moduleLayouts } from "@/lib/db/schema";
+import { moduleLayouts, repoModules } from "@/lib/db/schema";
 import { trackModel } from "@/lib/server/TrackModel";
 import { requireRole } from "@/lib/server/guard";
 import type { StagingEnd } from "@/lib/db/schema";
@@ -25,6 +25,8 @@ export async function PATCH(
     positionIndex?: number;
     stagingEnd?: StagingEnd | null;
     flipped?: boolean;
+    /** Replace the placement with another catalog module (#158). */
+    moduleId?: string;
   };
   try {
     body = await req.json();
@@ -36,6 +38,20 @@ export async function PATCH(
   if (typeof body.positionIndex === "number") set.positionIndex = body.positionIndex;
   if (body.stagingEnd !== undefined) set.stagingEnd = body.stagingEnd;
   if (typeof body.flipped === "boolean") set.flipped = body.flipped;
+  if (typeof body.moduleId === "string" && body.moduleId.trim()) {
+    const rec = body.moduleId.trim();
+    const [target] = await db
+      .select({ recordNumber: repoModules.recordNumber })
+      .from(repoModules)
+      .where(eq(repoModules.recordNumber, rec));
+    if (!target) {
+      return NextResponse.json(
+        { error: `module ${rec} is not in the local catalog` },
+        { status: 400 },
+      );
+    }
+    set.moduleId = rec;
+  }
   if (Object.keys(set).length === 0) {
     return NextResponse.json({ error: "nothing to update" }, { status: 400 });
   }
@@ -46,6 +62,10 @@ export async function PATCH(
     .where(eq(moduleLayouts.id, id))
     .returning();
   if (!row) return NextResponse.json({ error: "not found" }, { status: 404 });
+  if (set.moduleId) {
+    // The spine's control points changed — re-materialize sections (#146).
+    await trackModel.syncDerivedSections(row.layoutId);
+  }
   return NextResponse.json({ module: row });
 }
 

--- a/app/api/modules/catalog/route.ts
+++ b/app/api/modules/catalog/route.ts
@@ -4,7 +4,7 @@
  * Requires a Free Dispatcher session token (any role); no Module Repo token needed.
  */
 import { NextResponse } from "next/server";
-import { asc, isNull } from "drizzle-orm";
+import { and, asc, isNull, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { repoModules } from "@/lib/db/schema";
 import { requireRole } from "@/lib/server/guard";
@@ -31,9 +31,19 @@ export async function GET(req: Request) {
       schematics: repoModules.schematics,
     })
     .from(repoModules)
-    // Tombstoned modules (removed upstream, #155) aren't offered for new
-    // placements; layouts already using them keep their data.
-    .where(isNull(repoModules.removedFromRepoAt))
+    // Unavailable modules aren't offered for new placements: tombstoned
+    // (removed upstream, #155) or marked inactive/archived by the owner
+    // (#158). Missing status counts as active. Layouts already using one
+    // keep their data.
+    .where(
+      and(
+        isNull(repoModules.removedFromRepoAt),
+        or(
+          isNull(repoModules.status),
+          sql`lower(${repoModules.status}) NOT IN ('inactive', 'archived')`,
+        ),
+      ),
+    )
     .orderBy(asc(repoModules.recordNumber));
 
   return NextResponse.json({ modules });

--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -44,12 +44,16 @@ export function OperationsSchematic({
   modules,
   districts,
   signalAspects,
+  highlightModuleIds,
 }: {
   modules: OpsModuleInput[];
   districts?: SectionAwareDistrict[];
   /** Live CTC aspects keyed "<moduleRecordNumber>:<cpId>" (#151). When given,
    * control-point signals color green (clear) / red (stop); absent = neutral. */
   signalAspects?: Record<string, { AtoB: "clear" | "stop"; BtoA: "clear" | "stop" }>;
+  /** Placement ids (layout_modules row ids) to call out — e.g. a module no
+   * longer offered by the repo (#158). Drawn with an amber outline. */
+  highlightModuleIds?: string[];
 }) {
   if (modules.length === 0) {
     return (
@@ -221,6 +225,19 @@ export function OperationsSchematic({
                     />
                   );
                 })}
+              {/* Called-out placement (e.g. dropped from the repo, #158) */}
+              {highlightModuleIds?.includes(c.input.id) && (
+                <rect
+                  x={c.x + 0.5}
+                  y={SECTION_BRACKET_Y + 2}
+                  width={c.width - 1}
+                  height={HEIGHT - SECTION_BRACKET_Y - 4}
+                  fill="#f59e0b22"
+                  stroke="#f59e0b"
+                  strokeWidth={0.8}
+                  rx={2}
+                />
+              )}
               {/* Hover detail + centred label */}
               <rect x={c.x} y={0} width={c.width} height={HEIGHT} fill="transparent">
                 <title>

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -92,6 +92,8 @@ export interface LayoutModule {
   schematic: unknown;
   /** Set when the module was removed from the Module Repository (#155). */
   removedFromRepoAt: Date | null;
+  /** Owner's repo status: active | inactive | archived (#158). */
+  status: string | null;
 }
 
 export interface LayoutTree extends LayoutRow {
@@ -366,6 +368,7 @@ class TrackModel {
         endplates: repoModules.endplates,
         schematic: repoModules.schematic,
         removedFromRepoAt: repoModules.removedFromRepoAt,
+        status: repoModules.status,
       })
       .from(moduleLayouts)
       .leftJoin(repoModules, eq(moduleLayouts.moduleId, repoModules.recordNumber))

--- a/lib/track/__tests__/moduleAvailability.test.ts
+++ b/lib/track/__tests__/moduleAvailability.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from "vitest";
+import { moduleUnavailability } from "../moduleAvailability";
+
+describe("moduleUnavailability (#158)", () => {
+  it("tombstone wins over status", () => {
+    expect(
+      moduleUnavailability({ removedFromRepoAt: "2026-07-05", status: "active" }),
+    ).toBe("removed");
+  });
+
+  it("owner status drives availability, case-insensitively", () => {
+    expect(moduleUnavailability({ status: "inactive" })).toBe("inactive");
+    expect(moduleUnavailability({ status: "Archived" })).toBe("archived");
+    expect(moduleUnavailability({ status: " INACTIVE " })).toBe("inactive");
+  });
+
+  it("active or unknown status is available", () => {
+    expect(moduleUnavailability({ status: "active" })).toBeNull();
+    expect(moduleUnavailability({ status: null })).toBeNull();
+    expect(moduleUnavailability({})).toBeNull();
+    expect(moduleUnavailability({ status: "something-new" })).toBeNull();
+  });
+});

--- a/lib/track/moduleAvailability.ts
+++ b/lib/track/moduleAvailability.ts
@@ -1,0 +1,37 @@
+/**
+ * Module availability (#155/#158) — whether a synced Module Repository record
+ * may be placed in layouts. Two signals combine:
+ *   - the tombstone (removed_from_repo_at): the record vanished from the repo;
+ *   - the owner's status: "active" | "inactive" | "archived" — only active
+ *     modules are offered (missing/unknown status counts as active so older
+ *     data isn't punished).
+ * Pure so it can be unit-tested and shared by API filters and the UI.
+ */
+
+export type UnavailableReason = "removed" | "inactive" | "archived";
+
+export function moduleUnavailability(m: {
+  removedFromRepoAt?: string | Date | null;
+  status?: string | null;
+}): UnavailableReason | null {
+  if (m.removedFromRepoAt) return "removed";
+  const s = (m.status ?? "").trim().toLowerCase();
+  if (s === "inactive") return "inactive";
+  if (s === "archived") return "archived";
+  return null;
+}
+
+export const UNAVAILABLE_LABEL: Record<UnavailableReason, string> = {
+  removed: "removed from repo",
+  inactive: "inactive in repo",
+  archived: "archived in repo",
+};
+
+export const UNAVAILABLE_HINT: Record<UnavailableReason, string> = {
+  removed:
+    "This module was removed from the Module Repository. The layout keeps its data, but it can't be re-added elsewhere.",
+  inactive:
+    "The owner marked this module inactive in the Module Repository — it may not be available for events.",
+  archived:
+    "The owner archived this module in the Module Repository — it's no longer offered for layouts.",
+};


### PR DESCRIPTION
Closes #158. Builds on the tombstone (#155) with the three behaviors requested:

1. **MR status drives availability** — the repo's `active | inactive | archived` (already synced) now gates the catalog: only active (or unknown-status) modules are offered for new placements. Pure `moduleUnavailability()` shared by the API filter and the UI.
2. **Notify on dropped modules** — opening a layout that contains them pops a notice listing each with its reason; **Show in schematic** scrolls to the operations schematic and outlines the module's cell in amber.
3. **Replace in place** — every placement row gets a **Replace** action (pick any catalog module, keeps its spine position). `PATCH /api/modules/:id` accepts `moduleId`, validates it against the local catalog, and re-materializes derived sections after the swap.

**Verified in the browser** with a tombstoned module: modal on expand → Show highlights + scrolls → Replace swaps it for One Mile and the badge clears; catalog excludes unavailable records (16 offered, tombstoned one hidden). 132 tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)