### PR TITLE
feat: surface at-risk modules on the layout list (#160)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -35,6 +35,8 @@ interface LayoutRow {
   standard: string;
   controlPointDistricts: Record<string, string> | null;
   layoutControlPoints: unknown;
+  /** Placements whose module was removed/deactivated/archived upstream (#160). */
+  atRiskModules: number;
   createdAt: string;
 }
 interface BlockNode {
@@ -615,6 +617,22 @@ export default function AdminLayouts() {
                         </span>
                       )}
                     </button>
+                    {l.atRiskModules > 0 && (
+                      <button
+                        title="Modules in this layout were removed, deactivated, or archived in the Module Repository — click to review"
+                        onClick={async () => {
+                          if (!expanded.has(l.id)) {
+                            setExpanded((p) => new Set(p).add(l.id));
+                            if (!trees[l.id]) await reloadTree(l.id);
+                          }
+                          unavailNotified.current.add(l.id);
+                          setUnavailNotice({ layoutId: l.id });
+                        }}
+                        className="shrink-0 rounded bg-amber-900/60 px-1.5 py-0.5 text-xs font-medium text-amber-300 hover:bg-amber-900"
+                      >
+                        ⚠ {l.atRiskModules} at-risk module{l.atRiskModules > 1 ? "s" : ""}
+                      </button>
+                    )}
                     {isCurrent ? (
                       <button
                         disabled={busy}

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -12,7 +12,7 @@
  * is caught at the DB level by a partial unique index (one active allocation per
  * section per session); an allocation route must also stay within one District.
  */
-import { and, asc, eq, inArray } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import {
   layouts,
@@ -225,9 +225,32 @@ class TrackModel {
     return this.getLayout(layoutId) as Promise<LayoutTree>;
   }
 
-  /** All layouts, newest first. */
-  async listLayouts(): Promise<LayoutRow[]> {
-    return db.select().from(layouts);
+  /**
+   * All layouts, each with a count of at-risk placements — modules that were
+   * removed from the repo or marked inactive/archived by their owner (#160).
+   * Surfaced on the layout list so risk is visible without expanding.
+   */
+  async listLayouts(): Promise<(LayoutRow & { atRiskModules: number })[]> {
+    const rows = await db.select().from(layouts);
+    const risky = await db
+      .select({
+        layoutId: moduleLayouts.layoutId,
+        n: sql<number>`count(*)`,
+      })
+      .from(moduleLayouts)
+      .innerJoin(
+        repoModules,
+        eq(moduleLayouts.moduleId, repoModules.recordNumber),
+      )
+      .where(
+        or(
+          isNotNull(repoModules.removedFromRepoAt),
+          sql`lower(coalesce(${repoModules.status}, 'active')) IN ('inactive', 'archived')`,
+        ),
+      )
+      .groupBy(moduleLayouts.layoutId);
+    const byLayout = new Map(risky.map((r) => [r.layoutId, Number(r.n)]));
+    return rows.map((l) => ({ ...l, atRiskModules: byLayout.get(l.id) ?? 0 }));
   }
 
   /** Assign the layout's imported control points to districts (#138). */


### PR DESCRIPTION
Closes #160. Inactive/archived modules pose a risk to a layout — now you see it **without expanding each layout**.

- `GET /api/layouts` returns `atRiskModules` per layout (removed from repo, or owner-marked inactive/archived — same `moduleUnavailability` rules as #158)
- The layout row shows an amber **⚠ N at-risk module(s)** chip; clicking it expands the layout and opens the dropped-modules notice with its Show-in-schematic and Replace actions

**Verified in the browser**: archived a module locally → its layout shows the chip on the collapsed row → click opens the notice reading *"Blairstown — archived in repo"*. Catalog also excludes it. 132 tests + build green.

(Alongside, in the Module Repository: **"Loop"** added to the `module_categories` lookup — DB-driven, live immediately, no deploy.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)