### PR TITLE
fix: incremental sync no longer tombstones unmodified Active modules (#163)

### DIFF
--- a/app/admin/modules/page.tsx
+++ b/app/admin/modules/page.tsx
@@ -42,7 +42,7 @@ export default function AdminModules() {
     setSyncMsg(null);
     try {
       const result = await apiSend<
-        | { synced: number; removed?: number; lastSyncedAt: string }
+        | { synced: number; removed?: number; restored?: number; lastSyncedAt: string }
         | { error: string; message: string }
       >("POST", "/api/modules/sync", undefined);
 
@@ -61,7 +61,7 @@ export default function AdminModules() {
           ok: true,
           text: `Synced ${result.synced} module(s)${
             result.removed ? ` · ${result.removed} removed from the repo` : ""
-          }`,
+          }${result.restored ? ` · ${result.restored} restored` : ""}`,
         });
       }
     } catch (err) {

--- a/lib/server/ModuleRepoSync.ts
+++ b/lib/server/ModuleRepoSync.ts
@@ -1,4 +1,4 @@
-import { and, eq, isNull, notInArray } from "drizzle-orm";
+import { and, eq, inArray, isNotNull, isNull, notInArray } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import { appSettings, repoModules } from "@/lib/db/schema";
 import { config } from "@/lib/config";
@@ -33,6 +33,8 @@ export interface SyncResult {
   synced: number;
   /** Modules newly tombstoned this sync — gone from the repo (#155). */
   removed: number;
+  /** Tombstones cleared this sync — the record is back in the repo (#163). */
+  restored: number;
   lastSyncedAt: string;
 }
 
@@ -82,6 +84,9 @@ export async function syncModules(): Promise<SyncResult | SyncError> {
   // endpoint is the function's own slug. (The earlier `/api/v1/modules/full`
   // path resolved to a non-existent `api` function and 404'd — issue #70.)
   const url = new URL(`${config.moduleRepo.url}/functions/v1/modules-full`);
+  // All statuses: FD mirrors inactive/archived so layouts can flag them
+  // (#158); the endpoint's default of active-only would hide those flips.
+  url.searchParams.set("status", "any");
   if (meta?.last_synced_at) {
     url.searchParams.set("updated_since", meta.last_synced_at);
   }
@@ -162,22 +167,81 @@ export async function syncModules(): Promise<SyncResult | SyncError> {
       .onConflictDoUpdate({ target: repoModules.recordNumber, set: values });
   }
 
-  // Tombstone local records the repo no longer returns (#155). Guarded: an
-  // empty catalog is treated as an upstream problem, not a mass removal.
+  // Reconcile against the repo's COMPLETE id list (#163). The main fetch may
+  // be incremental (updated_since) — diffing tombstones against that partial
+  // set wrongly retired every unmodified module (the #156 bug). The id list is
+  // cheap ({record_number, status} only), always full, and also mirrors
+  // status flips that predate this sync's window. Best-effort: if the listing
+  // fails or comes back empty, skip — never mass-tombstone on bad data.
   let removed = 0;
-  if (modules.length > 0) {
-    const fetched = modules.map((m) => m.record_number);
-    const retired = await db
-      .update(repoModules)
-      .set({ removedFromRepoAt: new Date() })
-      .where(
-        and(
-          isNull(repoModules.removedFromRepoAt),
-          notInArray(repoModules.recordNumber, fetched),
-        ),
-      )
-      .returning({ recordNumber: repoModules.recordNumber });
-    removed = retired.length;
+  let restored = 0;
+  try {
+    const idsUrl = new URL(`${config.moduleRepo.url}/functions/v1/modules-full`);
+    idsUrl.searchParams.set("fields", "ids");
+    idsUrl.searchParams.set("status", "any");
+    const idsRes = await fetch(idsUrl.toString(), {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        apikey: config.moduleRepo.anonKey,
+      },
+    });
+    if (idsRes.ok) {
+      const ids = (await idsRes.json()) as {
+        record_number: string;
+        status?: string | null;
+      }[];
+      if (Array.isArray(ids) && ids.length > 0) {
+        const present = ids.map((i) => i.record_number);
+
+        // Records the repo still lists: clear any tombstone (this also
+        // repairs rows wrongly retired by the pre-#163 logic)…
+        const back = await db
+          .update(repoModules)
+          .set({ removedFromRepoAt: null })
+          .where(
+            and(
+              isNotNull(repoModules.removedFromRepoAt),
+              inArray(repoModules.recordNumber, present),
+            ),
+          )
+          .returning({ recordNumber: repoModules.recordNumber });
+        restored = back.length;
+
+        // …and mirror status flips the incremental window missed.
+        const local = await db
+          .select({
+            recordNumber: repoModules.recordNumber,
+            status: repoModules.status,
+          })
+          .from(repoModules)
+          .where(inArray(repoModules.recordNumber, present));
+        const localStatus = new Map(local.map((r) => [r.recordNumber, r.status]));
+        for (const i of ids) {
+          if (!i.status) continue;
+          if ((localStatus.get(i.record_number) ?? null) === i.status) continue;
+          if (!localStatus.has(i.record_number)) continue; // never synced
+          await db
+            .update(repoModules)
+            .set({ status: i.status })
+            .where(eq(repoModules.recordNumber, i.record_number));
+        }
+
+        // Records the repo no longer lists at all: tombstone (#155).
+        const retired = await db
+          .update(repoModules)
+          .set({ removedFromRepoAt: new Date() })
+          .where(
+            and(
+              isNull(repoModules.removedFromRepoAt),
+              notInArray(repoModules.recordNumber, present),
+            ),
+          )
+          .returning({ recordNumber: repoModules.recordNumber });
+        removed = retired.length;
+      }
+    }
+  } catch {
+    // best-effort — the upserted catalog is still valid without the diff
   }
 
   const [{ count }] = await db
@@ -187,7 +251,7 @@ export async function syncModules(): Promise<SyncResult | SyncError> {
   const now = new Date().toISOString();
   await writeSyncMeta({ last_synced_at: now, module_count: Number(count) });
 
-  return { synced: modules.length, removed, lastSyncedAt: now };
+  return { synced: modules.length, removed, restored, lastSyncedAt: now };
 }
 
 export async function getSyncMeta(): Promise<SyncMeta | null> {

--- a/lib/server/__tests__/ModuleRepoSync.test.ts
+++ b/lib/server/__tests__/ModuleRepoSync.test.ts
@@ -167,6 +167,48 @@ describe("syncModules — happy path", () => {
     expect(mockOnConflict).toHaveBeenCalledTimes(3); // 2 modules + 1 sync meta write
   });
 
+  it("requests all statuses and reconciles against the full id list (#163)", async () => {
+    // The reconcile adds a local-status select between the meta read and the
+    // final count query — give the order-sensitive from() mock a third result.
+    mockFrom.mockReturnValueOnce(makeFromResult([{ count: 2 }]));
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([makeModule(1)]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify([
+            { record_number: "FMN-0001", status: "active" },
+            { record_number: "FMN-0002", status: "inactive" },
+          ]),
+          { status: 200 },
+        ),
+      );
+
+    await syncModules();
+
+    // Main fetch mirrors every status (not just active)…
+    const mainUrl = vi.mocked(fetch).mock.calls[0][0] as string;
+    expect(mainUrl).toContain("status=any");
+    // …and the tombstone diff uses a SECOND, complete id listing — never the
+    // (possibly incremental) main fetch (the #156 mass-tombstone bug).
+    const idsUrl = vi.mocked(fetch).mock.calls[1][0] as string;
+    expect(idsUrl).toContain("fields=ids");
+    expect(idsUrl).toContain("status=any");
+  });
+
+  it("skips the tombstone diff when the id listing fails", async () => {
+    vi.mocked(fetch)
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify([makeModule(1)]), { status: 200 }),
+      )
+      .mockResolvedValueOnce(new Response("oops", { status: 500 }));
+
+    const result = await syncModules();
+
+    expect(result).toMatchObject({ synced: 1, removed: 0, restored: 0 });
+  });
+
   it("appends updated_since param when a previous sync exists", async () => {
     // Override: first from() returns existing sync meta
     mockFrom.mockReset();


### PR DESCRIPTION
Closes #163 — the bug you hit: a sync **dropped modules that are marked Active**.

**Root cause** (regression from #156): after the first sync, `updated_since` makes the modules-full fetch *partial* (only recently-edited records) — and the tombstone pass retired everything not in that partial set, i.e. every unmodified Active module.

**Fix (both sides):**
- Removals diff against a second, **always-complete id listing** (`modules-full?fields=ids&status=any` — cheap `{record_number, status}` rows; new mode deployed to the edge function, source in modulerepo)
- Records still listed get their tombstone **cleared** — your wrongly-dropped modules **auto-repair on the next sync**
- Status flips the incremental window missed are mirrored from the id list; the main fetch now uses `status=any` so inactive/archived arrive with real statuses
- Guarded: id listing failed/empty → skip the diff entirely; sync reports `restored` alongside `removed`
- Bonus hardening: the edge function's auth guard accepted the public anon key as a "JWT" — non-active visibility now requires a real user token (verified 403 live)

134 tests green, including a regression pin: the tombstone diff must use the complete listing, never the incremental fetch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)