### PR TITLE
feat: render loop modules as terminal bulbs on the operations panel (#165)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -140,25 +140,47 @@ export function OperationsSchematic({
           })}
 
         {/* Per-module: Main 1 (continuous) + Main 2 (where double) + turnouts */}
-        {schem.cells.map((c) => {
+        {schem.cells.map((c, ci) => {
           const stroke = colorFor(c.input.moduleId);
-          const hasSecond = c.leftTracks >= 2 || c.rightTracks >= 2;
+          // A loop module (single-endplate turnback, #165): the main ends in a
+          // terminal bulb on the outward side — first cell opens west, any
+          // other placement opens east.
+          const cellDoc = asModuleSchematic(c.input.schematic);
+          const isLoop = !!cellDoc && moduleFeatures(cellDoc).loop;
+          const bulbWest = isLoop && ci === 0;
+          const bulbR = Math.min(6, c.width * 0.06);
+          const mainX1 = isLoop && bulbWest ? c.x + bulbR * 2 : c.x;
+          const mainX2 =
+            isLoop && !bulbWest ? c.x + c.width - bulbR * 2 : c.x + c.width;
+          const hasSecond = !isLoop && (c.leftTracks >= 2 || c.rightTracks >= 2);
           const inSwitch = Math.min(c.width * 0.3, 30);
           const lane1Start = c.leftTracks >= 2 ? c.x : c.x + inSwitch + LANE_GAP;
           const lane1End =
             c.rightTracks >= 2 ? c.x + c.width : c.x + c.width - inSwitch - LANE_GAP;
           return (
             <g key={c.input.id}>
-              {/* Main 1 — always continuous */}
+              {/* Main 1 — continuous; loops turn back at the bulb */}
               <line
-                x1={c.x}
+                x1={mainX1}
                 y1={Y0}
-                x2={c.x + c.width}
+                x2={mainX2}
                 y2={Y0}
                 stroke={stroke}
                 strokeWidth={STROKE}
                 strokeLinecap="round"
               />
+              {isLoop && (
+                <circle
+                  cx={bulbWest ? c.x + bulbR : c.x + c.width - bulbR}
+                  cy={Y0}
+                  r={bulbR}
+                  fill="none"
+                  stroke={stroke}
+                  strokeWidth={STROKE * 0.7}
+                >
+                  <title>Balloon loop — trains turn back</title>
+                </circle>
+              )}
               {/* Main 2 + diverge/converge turnouts */}
               {hasSecond && (
                 <>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.3.0",
+        "@willcgage/module-schematic": "^0.4.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.3.0.tgz",
-      "integrity": "sha512-8UbX34yEhpqbcMS10BdXgxU7pG4e9V4T/fIezhWk49ipxsSriH3dZIEeSHvRwnlLTJKIlBEealsa2Pr+D1rxKA==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.4.0.tgz",
+      "integrity": "sha512-6LkEqi4U143haF76KIKlp+Px0iW+dUSf6qFZa63CzaxjKTX+DX7Zj3ni619iXc2f4nWNo9h1fDo2TklW9LOMQw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.3.0",
+    "@willcgage/module-schematic": "^0.4.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
First slice of #165 (Seaford). A **loop module** (single-endplate turnback) draws its main to a **terminal bulb** on the outward side — first placement opens west, any other opens east — instead of running through to a second endplate.

- Interior tracks (the industries inside the balloon) render as ordinary spurs
- The throat's control point enumerates last in spine order — district assignment + derived sections work unchanged up to the throat
- [`@willcgage/module-schematic@0.4.0`](https://github.com/willcgage/module-schematic/releases/tag/v0.4.0): `ModuleSchematicDoc.loop` / `isLoopDoc()` / `ModuleFeatures.loop`; a loop never emits `main2` (the parallel lead legs are ONE main — the key insight from the Seaford track plan)
- MR's schematic builder gains a "Loop module" toggle (single endplate, Entry label) — lands on modulerepo main separately

**Verified in the browser**: One Mile + a Seaford-style loop at the east end — main runs 0→396→504 with the bulb at the spine end; *Seaford Throat* lists as the final control point. 134 tests + build green.

Still open on #165: end-of-spine placement validation, turnback dispatch semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)