### PR TITLE
fix: loops keep endplate B — a standard endplate on the balloon is an interchange (#165)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -146,7 +146,8 @@ export function OperationsSchematic({
           // terminal bulb on the outward side — first cell opens west, any
           // other placement opens east.
           const cellDoc = asModuleSchematic(c.input.schematic);
-          const isLoop = !!cellDoc && moduleFeatures(cellDoc).loop;
+          const cellFeat = cellDoc ? moduleFeatures(cellDoc) : null;
+          const isLoop = !!cellFeat?.loop;
           const bulbWest = isLoop && ci === 0;
           const bulbR = Math.min(6, c.width * 0.06);
           const mainX1 = isLoop && bulbWest ? c.x + bulbR * 2 : c.x;
@@ -170,16 +171,45 @@ export function OperationsSchematic({
                 strokeLinecap="round"
               />
               {isLoop && (
-                <circle
-                  cx={bulbWest ? c.x + bulbR : c.x + c.width - bulbR}
-                  cy={Y0}
-                  r={bulbR}
-                  fill="none"
-                  stroke={stroke}
-                  strokeWidth={STROKE * 0.7}
-                >
-                  <title>Balloon loop — trains turn back</title>
-                </circle>
+                <>
+                  <circle
+                    cx={bulbWest ? c.x + bulbR : c.x + c.width - bulbR}
+                    cy={Y0}
+                    r={bulbR}
+                    fill="none"
+                    stroke={stroke}
+                    strokeWidth={STROKE * 0.7}
+                  >
+                    <title>
+                      {cellFeat?.loopInterchange
+                        ? "Balloon loop with interchange — a second route connects here"
+                        : "Balloon loop — trains turn back"}
+                    </title>
+                  </circle>
+                  {/* Standard endplate B on the balloon = interchange branch */}
+                  {cellFeat?.loopInterchange && (
+                    <>
+                      <line
+                        x1={bulbWest ? c.x + bulbR : c.x + c.width - bulbR}
+                        y1={Y0 - bulbR}
+                        x2={bulbWest ? c.x + bulbR : c.x + c.width - bulbR}
+                        y2={Y0 - bulbR - 8}
+                        stroke={stroke}
+                        strokeWidth={STROKE * 0.7}
+                      />
+                      <line
+                        x1={(bulbWest ? c.x + bulbR : c.x + c.width - bulbR) - 4}
+                        y1={Y0 - bulbR - 8}
+                        x2={(bulbWest ? c.x + bulbR : c.x + c.width - bulbR) + 4}
+                        y2={Y0 - bulbR - 8}
+                        stroke="#94a3b8"
+                        strokeWidth={1.2}
+                      >
+                        <title>Interchange endplate (B)</title>
+                      </line>
+                    </>
+                  )}
+                </>
               )}
               {/* Main 2 + diverge/converge turnouts */}
               {hasSecond && (

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.4.0",
+        "@willcgage/module-schematic": "^0.5.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.4.0.tgz",
-      "integrity": "sha512-6LkEqi4U143haF76KIKlp+Px0iW+dUSf6qFZa63CzaxjKTX+DX7Zj3ni619iXc2f4nWNo9h1fDo2TklW9LOMQw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.5.0.tgz",
+      "integrity": "sha512-wUBMdpgMQdvK5Jucep8+b+mzc0h8deeZDG8QoQle9V3Yo9k+Rfksf8eNVfImw9e1sx6K+8i5cp6yofXHA4+wVQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.4.0",
+    "@willcgage/module-schematic": "^0.5.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Correction on #166 from the Seaford track plan: the stub on the balloon section is a **standard endplate** — a loop with a second endplate is an **interchange** (a second route connects at the loop), not a pure turnback. Endplate B must not disappear on loop modules.

- [`@willcgage/module-schematic@0.5.0`](https://github.com/willcgage/module-schematic/releases/tag/v0.5.0): `EndplateBConfig = single | double | none` — on a loop, B present = interchange (label *Interchange*), `none` = pure turnback; non-loop modules always keep a real B. `ModuleFeatures.loopInterchange`.
- Operations panel: interchange loops draw an **endplate branch off the bulb** (stub + endplate tick, hover says which).
- MR editor keeps the B select on loops with a *"None — pure turnback"* option; toggling loop defaults to turnback so an interchange is an explicit choice.

**Verified in the browser**: Seaford-style seed with a standard B renders bulb + interchange branch. 134 tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)