### PR TITLE
feat: Main 2 directional returns — the balloon as a U joining the mains (#165)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -148,11 +148,18 @@ export function OperationsSchematic({
           const cellDoc = asModuleSchematic(c.input.schematic);
           const cellFeat = cellDoc ? moduleFeatures(cellDoc) : null;
           const isLoop = !!cellFeat?.loop;
+          // Main 2 directional return (#165): the balloon is a U joining the
+          // two main lanes at the outward side — no bulb.
+          const isUReturn = isLoop && cellFeat?.loopReturn === "main2";
           const bulbWest = isLoop && ci === 0;
           const bulbR = Math.min(6, c.width * 0.06);
-          const mainX1 = isLoop && bulbWest ? c.x + bulbR * 2 : c.x;
+          const uR = (Y0 - Y1) / 2; // U-bend radius spans the two main lanes
+          const mainX1 =
+            isLoop && bulbWest ? c.x + (isUReturn ? uR : bulbR * 2) : c.x;
           const mainX2 =
-            isLoop && !bulbWest ? c.x + c.width - bulbR * 2 : c.x + c.width;
+            isLoop && !bulbWest
+              ? c.x + c.width - (isUReturn ? uR : bulbR * 2)
+              : c.x + c.width;
           const hasSecond = !isLoop && (c.leftTracks >= 2 || c.rightTracks >= 2);
           const inSwitch = Math.min(c.width * 0.3, 30);
           const lane1Start = c.leftTracks >= 2 ? c.x : c.x + inSwitch + LANE_GAP;
@@ -170,7 +177,34 @@ export function OperationsSchematic({
                 strokeWidth={STROKE}
                 strokeLinecap="round"
               />
-              {isLoop && (
+              {isUReturn && (
+                <>
+                  {/* Main 2 runs the lead; the balloon is the U between the mains */}
+                  <line
+                    x1={bulbWest ? mainX1 : c.x}
+                    y1={Y1}
+                    x2={bulbWest ? c.x + c.width : mainX2}
+                    y2={Y1}
+                    stroke={stroke}
+                    strokeWidth={STROKE}
+                    strokeLinecap="round"
+                  />
+                  <path
+                    d={
+                      bulbWest
+                        ? `M ${mainX1} ${Y0} A ${uR} ${uR} 0 0 1 ${mainX1} ${Y1}`
+                        : `M ${mainX2} ${Y0} A ${uR} ${uR} 0 0 0 ${mainX2} ${Y1}`
+                    }
+                    fill="none"
+                    stroke={stroke}
+                    strokeWidth={STROKE}
+                    strokeLinecap="round"
+                  >
+                    <title>Directional return — out on Main 1, back on Main 2</title>
+                  </path>
+                </>
+              )}
+              {isLoop && !isUReturn && (
                 <>
                   <circle
                     cx={bulbWest ? c.x + bulbR : c.x + c.width - bulbR}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.5.0",
+        "@willcgage/module-schematic": "^0.6.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.5.0.tgz",
-      "integrity": "sha512-wUBMdpgMQdvK5Jucep8+b+mzc0h8deeZDG8QoQle9V3Yo9k+Rfksf8eNVfImw9e1sx6K+8i5cp6yofXHA4+wVQ==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.6.0.tgz",
+      "integrity": "sha512-4sjIH/0BnjEDdPaYSHiCmqAjRLUY5uFNpIXfA+ebAxk9dPe/jCBlAaGt3tt/7L+SjaBLYenXTZY0IwA4cXgG7g==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.5.0",
+    "@willcgage/module-schematic": "^0.6.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Core slice from the loop-rendering research on #165 (topology-driven defaults; transit terminal-loop idiom for the double-track case).

- [`@willcgage/module-schematic@0.6.0`](https://github.com/willcgage/module-schematic/releases/tag/v0.6.0): **`loopReturn: "same" | "main2"`** (main2 emits `main2` as a positioned track on the lead), **`tracks[].inLoop`** (balloon-interior tracks — one pos+lane record drives both the fan and a future geometric render), `loopRender` override (geometric reserved). All absent fields = existing bulb; fully back-compatible.
- **Operations panel**: `loopReturn: "main2"` draws both mains across the cell and a **U-bend joining lanes 0/1** on the outward side — out on Main 1, back on Main 2.
- **MR editor** (separate commit to modulerepo main): "Loop returns onto" select (loop + double), per-track "In loop" checkbox, U + direction arrow in the preview, circulation arrow on plain bulbs.

**Verified in the browser**: double-main module + return-loop module — both mains run the spine, the U closes them at the east end. 134 tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)