### PR TITLE
feat: crossings (diamonds) + branch connector arrows (#170 slices 1–2)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -81,7 +81,10 @@ export function OperationsSchematic({
     0,
     ...schem.cells.map((c) => {
       const doc = asModuleSchematic(c.input.schematic);
-      return doc ? moduleFeatures(doc).laneMin : 0;
+      if (!doc) return 0;
+      const f = moduleFeatures(doc);
+      // A down-side branch connector (#170) hangs a lane below the lowest track.
+      return f.laneMin - (f.branchConnectors.some((b) => b.side === "down") ? 1 : 0);
     }),
   );
   const LABEL_Y = Y0 - minLane * LANE_GAP + 10;
@@ -397,6 +400,49 @@ export function OperationsSchematic({
                   <title>{`Turnout${t.name ? ` · ${t.name}` : ""}`}</title>
                 </circle>
               ))}
+              {/* Crossings (diamonds) — an X spanning the two lanes (#170) */}
+              {feat.crossings.map((x) => {
+                const cx = px(x.posFrac);
+                const yA = laneY(x.laneA);
+                const yB = laneY(x.laneB);
+                const cy = (yA + yB) / 2;
+                const h = Math.max(Math.abs(yA - yB) / 2, 3);
+                return (
+                  <g key={x.id} stroke="#f87171" strokeWidth={1.4} strokeLinecap="round">
+                    <line x1={cx - 3} y1={cy - h} x2={cx + 3} y2={cy + h} />
+                    <line x1={cx - 3} y1={cy + h} x2={cx + 3} y2={cy - h} />
+                    <title>{`Crossing${x.name ? ` · ${x.name}` : ""}`}</title>
+                  </g>
+                );
+              })}
+              {/* Branch endplates — named connector arrows (#170) */}
+              {feat.branchConnectors.map((b) => {
+                const bx = px(b.posFrac);
+                const dir = b.side === "down" ? 1 : -1;
+                const y0g = laneY(0);
+                const yTip = y0g + dir * (LANE_GAP - 1);
+                return (
+                  <g key={b.id}>
+                    <line x1={bx} y1={y0g} x2={bx + 4} y2={yTip} stroke="#94a3b8" strokeWidth={1.4} strokeLinecap="round" />
+                    <polygon
+                      points={`${bx + 4 - 2.4},${yTip} ${bx + 4 + 2.4},${yTip} ${bx + 4},${yTip + dir * 3.2}`}
+                      fill="#94a3b8"
+                    />
+                    {c.width > 30 && (
+                      <text
+                        x={bx + 7}
+                        y={yTip + dir * 4}
+                        fontSize="5.5"
+                        className="fill-slate-500"
+                        dominantBaseline={b.side === "down" ? "hanging" : "auto"}
+                      >
+                        {`to ${b.label}`}
+                      </text>
+                    )}
+                    <title>{`Branch endplate — to ${b.label}`}</title>
+                  </g>
+                );
+              })}
               {feat.signals.map((s) => {
                 // Draw the signal parallel to the track, pointing in its facing
                 // direction, so two signals at the same spot (opposite ways)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.6.0",
+        "@willcgage/module-schematic": "^0.7.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.6.0.tgz",
-      "integrity": "sha512-4sjIH/0BnjEDdPaYSHiCmqAjRLUY5uFNpIXfA+ebAxk9dPe/jCBlAaGt3tt/7L+SjaBLYenXTZY0IwA4cXgG7g==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.7.0.tgz",
+      "integrity": "sha512-o+U2OCLpu+GE/qDngmQi1YXEVQ1expiNlmOCHUYrFlYebfvEf90zQo58qfauJ98tB5Q7bg+/Qs2bb8Si68QYPw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.6.0",
+    "@willcgage/module-schematic": "^0.7.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
First two slices of #170 (junction & multi-route modules) — the ones needing **no composition change**, per the research plan.

- **Crossings/diamonds**: `crossings[]` in the doc — a no-choice conflict node, drawn as an **X** spanning the two tracks' lanes; control points may protect crossings alongside turnouts. Unlocks the GSP-Waste-style plans.
- **Branch endplates**: an endplate beyond A/B with `at: {pos, side}` renders as a **named connector arrow** ("to Bowl Idaho") off the main — the CATS/US&S off-band idiom — so wye/T/corner junction modules read correctly before branch spines (slice 3) exist.
- [`@willcgage/module-schematic@0.7.0`](https://github.com/willcgage/module-schematic/releases/tag/v0.7.0) (24 tests); MR builder gains a *Crossings & branch* section (separate modulerepo commit).

**Verified in the browser** with a Bowl-Idaho-style seed: red X at the *KW&N Diamond*, *to Bowl Idaho* arrow dropping off the main, junction CP enumerating. 134 tests + build green.

Next slices on #170: `branches[]` spine graph (3), route identity (4), wye reversal (5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)