### PR TITLE
feat: branch spines — the layout as a graph of module chains (#170 slice 3)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -80,8 +80,16 @@ interface LayoutModuleNode {
   /** Owner's repo status: active | inactive | archived (#158). */
   status: string | null;
 }
+interface BranchSpine {
+  id: string;
+  name: string;
+  origin: { placementId: string; endplateId: string };
+  modules: LayoutModuleNode[];
+}
 interface LayoutTree extends LayoutRow {
   modules: LayoutModuleNode[];
+  /** Branch spines (#170) — defs + their placements. */
+  branchSpines: BranchSpine[];
   districts: DistrictNode[];
 }
 
@@ -138,6 +146,11 @@ export default function AdminLayouts() {
   // Add-form draft for a layout-level control point, keyed by layout id (#144).
   const [cpDraft, setCpDraft] = useState<
     Record<string, { name: string; anchor: string; offset: string }>
+  >({});
+  // Branch spines (#170): picker target + new-branch draft, keyed by layout id.
+  const [addTarget, setAddTarget] = useState<Record<string, string>>({});
+  const [branchDraft, setBranchDraft] = useState<
+    Record<string, { name: string; placementId: string }>
   >({});
   // Dropped-module notice + schematic highlight + replace flow (#158).
   const [unavailNotice, setUnavailNotice] = useState<{ layoutId: string } | null>(null);
@@ -262,11 +275,29 @@ export default function AdminLayouts() {
     if (ids.length === 0) return;
     setBusy(true);
     try {
-      await apiSend("POST", "/api/modules", { layoutId, moduleIds: ids });
+      // Target spine (#170): the picker's "Add to" select — main or a branch.
+      const branchId = addTarget[layoutId] || undefined;
+      await apiSend("POST", "/api/modules", { layoutId, moduleIds: ids, branchId });
       setModChecked((p) => ({ ...p, [layoutId]: [] }));
       await Promise.all([reloadTree(layoutId), load()]);
     } catch (e) {
       alert(e instanceof Error ? e.message : "add failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Create / delete branch spines (#170). */
+  async function saveBranches(
+    layoutId: string,
+    branches: { id: string; name: string; origin: { placementId: string; endplateId: string } }[],
+  ) {
+    setBusy(true);
+    try {
+      await apiSend("PATCH", `/api/layouts/${layoutId}`, { branches });
+      await reloadTree(layoutId);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "save failed");
     } finally {
       setBusy(false);
     }
@@ -886,6 +917,126 @@ export default function AdminLayouts() {
                               </p>
                             )}
 
+                            {/* Branch spines (#170) */}
+                            {tree.branchSpines.map((b) => (
+                              <div key={b.id} className="mb-2 rounded border border-slate-800 bg-slate-900/40 p-1.5">
+                                <div className="mb-1 flex items-center gap-2 text-xs">
+                                  <span className="text-slate-400">⤷</span>
+                                  <span className="font-medium text-slate-200">{b.name}</span>
+                                  <span className="text-slate-500">
+                                    from{" "}
+                                    {tree.modules.find((m) => m.id === b.origin.placementId)
+                                      ?.moduleName ?? "?"}{" "}
+                                    ({b.origin.endplateId})
+                                  </span>
+                                  <button
+                                    disabled={busy}
+                                    title="Delete branch — its modules return to the main line"
+                                    onClick={() =>
+                                      saveBranches(
+                                        l.id,
+                                        tree.branchSpines
+                                          .filter((x) => x.id !== b.id)
+                                          .map(({ id, name, origin }) => ({ id, name, origin })),
+                                      )
+                                    }
+                                    className="ml-auto rounded px-1 text-xs text-slate-500 hover:text-red-400"
+                                  >
+                                    ✕
+                                  </button>
+                                </div>
+                                {b.modules.length === 0 ? (
+                                  <p className="text-[11px] text-slate-600">
+                                    No modules — pick “→ {b.name}” in the catalog’s Add-to select.
+                                  </p>
+                                ) : (
+                                  <ul className="space-y-0.5">
+                                    {b.modules.map((m, bi) => (
+                                      <li key={m.id} className="flex items-center gap-2 text-sm">
+                                        <span className="w-5 shrink-0 text-right text-xs text-slate-500">
+                                          {bi + 1}
+                                        </span>
+                                        <span className="min-w-0 flex-1 truncate text-slate-200">
+                                          {m.moduleName ?? m.moduleId}
+                                        </span>
+                                        <span className="shrink-0 font-mono text-xs text-slate-500">
+                                          {m.moduleId}
+                                        </span>
+                                        <button
+                                          disabled={busy}
+                                          onClick={() => removeModule(l.id, m.id)}
+                                          className="shrink-0 rounded px-1 text-xs text-slate-500 hover:text-red-400"
+                                        >
+                                          ✕
+                                        </button>
+                                      </li>
+                                    ))}
+                                  </ul>
+                                )}
+                              </div>
+                            ))}
+                            {/* New branch: anchored at a main-spine module */}
+                            {tree.modules.length > 0 && (
+                              <div className="mb-2 flex items-center gap-1.5">
+                                <input
+                                  value={branchDraft[l.id]?.name ?? ""}
+                                  placeholder="New branch (e.g. Bowl Idaho)"
+                                  onChange={(e) =>
+                                    setBranchDraft((p) => ({
+                                      ...p,
+                                      [l.id]: {
+                                        name: e.target.value,
+                                        placementId:
+                                          p[l.id]?.placementId ?? tree.modules[0].id,
+                                      },
+                                    }))
+                                  }
+                                  className="w-44 rounded border border-slate-700 bg-slate-800 px-1.5 py-0.5 text-xs text-slate-200"
+                                />
+                                <span className="text-xs text-slate-500">from</span>
+                                <select
+                                  value={branchDraft[l.id]?.placementId ?? tree.modules[0].id}
+                                  onChange={(e) =>
+                                    setBranchDraft((p) => ({
+                                      ...p,
+                                      [l.id]: {
+                                        name: p[l.id]?.name ?? "",
+                                        placementId: e.target.value,
+                                      },
+                                    }))
+                                  }
+                                  className="rounded border border-slate-700 bg-slate-800 px-1 py-0.5 text-xs text-slate-300"
+                                >
+                                  {tree.modules.map((m) => (
+                                    <option key={m.id} value={m.id}>
+                                      {m.moduleName ?? m.moduleId}
+                                    </option>
+                                  ))}
+                                </select>
+                                <button
+                                  disabled={busy || !(branchDraft[l.id]?.name ?? "").trim()}
+                                  onClick={() => {
+                                    const d = branchDraft[l.id]!;
+                                    setBranchDraft((p) => ({
+                                      ...p,
+                                      [l.id]: { name: "", placementId: d.placementId },
+                                    }));
+                                    saveBranches(l.id, [
+                                      ...tree.branchSpines.map(({ id, name, origin }) => ({ id, name, origin })),
+                                      {
+                                        id: `br-${Date.now().toString(36)}`,
+                                        name: d.name.trim(),
+                                        origin: { placementId: d.placementId, endplateId: "C" },
+                                      },
+                                    ]);
+                                  }}
+                                  className="rounded border border-slate-600 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+                                >
+                                  + Branch
+                                </button>
+                              </div>
+                            )}
+
                             {/* Add from the catalog (multi-select) */}
                             {catalog.length === 0 ? (
                               <p className="text-xs text-slate-600">
@@ -912,6 +1063,23 @@ export default function AdminLayouts() {
                                       }))
                                     }
                                   />
+                                  {tree.branchSpines.length > 0 && (
+                                    <select
+                                      value={addTarget[l.id] ?? ""}
+                                      onChange={(e) =>
+                                        setAddTarget((p) => ({ ...p, [l.id]: e.target.value }))
+                                      }
+                                      title="Which spine new modules join (#170)"
+                                      className="shrink-0 rounded border border-slate-700 bg-slate-800 px-1 py-1 text-xs text-slate-300"
+                                    >
+                                      <option value="">→ Main line</option>
+                                      {tree.branchSpines.map((b) => (
+                                        <option key={b.id} value={b.id}>
+                                          → {b.name}
+                                        </option>
+                                      ))}
+                                    </select>
+                                  )}
                                   <button
                                     disabled={busy || checkedOf(l.id).length === 0}
                                     onClick={() => addModules(l.id)}
@@ -1007,7 +1175,9 @@ export default function AdminLayouts() {
                             )}
                           </div>
 
-                          {/* Operations schematic (straightened — primary) */}
+                          {/* Operations schematic (straightened — primary).
+                              Branch spines stack as their own bands below the
+                              main line, the CATS/US&S multi-band idiom (#170). */}
                           <div id={`ops-schematic-${l.id}`}>
                             <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
                               Operations schematic
@@ -1017,6 +1187,26 @@ export default function AdminLayouts() {
                               districts={tree.districts}
                               highlightModuleIds={highlightMods[l.id]}
                             />
+                            {tree.branchSpines
+                              .filter((b) => b.modules.length > 0)
+                              .map((b) => (
+                                <div key={b.id} className="mt-2">
+                                  <div className="mb-0.5 text-[11px] text-slate-500">
+                                    ⤷ <span className="text-slate-300">{b.name}</span>{" "}
+                                    — from{" "}
+                                    {tree.modules.find(
+                                      (m) => m.id === b.origin.placementId,
+                                    )?.moduleName ?? "the main line"}{" "}
+                                    ({b.origin.endplateId})
+                                  </div>
+                                  <OperationsSchematic
+                                    modules={b.modules}
+                                    districts={tree.districts}
+                                    highlightModuleIds={highlightMods[l.id]}
+                                  branchBand
+                                  />
+                                </div>
+                              ))}
                           </div>
 
                           {/* Footprint (to-scale, physical shape) */}
@@ -1038,7 +1228,14 @@ export default function AdminLayouts() {
                             </div>
                             {(() => {
                               const layoutCps = asLayoutCps(tree.layoutControlPoints);
-                              const cps = layoutControlPoints(tree.modules, layoutCps);
+                              // Main spine first, then each branch (#170) —
+                              // sections never derive across the junction.
+                              const cps = [
+                                ...layoutControlPoints(tree.modules, layoutCps),
+                                ...tree.branchSpines.flatMap((b) =>
+                                  layoutControlPoints(b.modules, layoutCps, b.id),
+                                ),
+                              ];
                               const draft = cpDraft[l.id] ?? {
                                 name: "",
                                 anchor: tree.modules[0]?.id ?? "",

--- a/app/api/layouts/[id]/route.ts
+++ b/app/api/layouts/[id]/route.ts
@@ -4,6 +4,7 @@
  */
 import { NextResponse } from "next/server";
 import { trackModel } from "@/lib/server/TrackModel";
+import { asBranches } from "@/lib/track/layoutControlPoints";
 import { requireRole } from "@/lib/server/guard";
 
 export const dynamic = "force-dynamic";
@@ -46,6 +47,8 @@ export async function PATCH(
       anchor: string;
       offsetInches: number;
     }[];
+    /** Branch-spine definitions (#170). */
+    branches?: unknown;
   };
   try {
     body = await req.json();
@@ -76,6 +79,10 @@ export async function PATCH(
         Number.isFinite(c.offsetInches),
     );
     await trackModel.setLayoutControlPoints(id, cps);
+  }
+  if (body.branches !== undefined) {
+    // Branch-spine definitions (#170); junk entries are dropped by the parser.
+    await trackModel.setBranches(id, asBranches(body.branches));
   }
   // Re-materialize the sections the control points derive (#146).
   await trackModel.syncDerivedSections(id);

--- a/app/api/modules/route.ts
+++ b/app/api/modules/route.ts
@@ -51,6 +51,8 @@ export async function POST(req: Request) {
     moduleId?: string;
     moduleIds?: string[];
     stagingEnd?: StagingEnd;
+    /** Target spine (#170): a branch id from layouts.branches; absent = main. */
+    branchId?: string;
   };
   try {
     body = await req.json();
@@ -73,11 +75,16 @@ export async function POST(req: Request) {
   }
 
   const layoutId = body.layoutId.trim();
+  const branchId = body.branchId?.trim() || null;
   const existing = await db
     .select()
     .from(moduleLayouts)
     .where(eq(moduleLayouts.layoutId, layoutId));
-  let pos = existing.reduce((m, r) => Math.max(m, r.positionIndex), -1) + 1;
+  // Position within the target spine (#170) — each spine orders independently.
+  let pos =
+    existing
+      .filter((r) => (r.branchId ?? null) === branchId)
+      .reduce((m, r) => Math.max(m, r.positionIndex), -1) + 1;
 
   const rows = await db
     .insert(moduleLayouts)
@@ -87,6 +94,7 @@ export async function POST(req: Request) {
         moduleId,
         positionIndex: pos++,
         stagingEnd: body.stagingEnd ?? null,
+        branchId,
       })),
     )
     .returning();

--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -45,6 +45,7 @@ export function OperationsSchematic({
   districts,
   signalAspects,
   highlightModuleIds,
+  branchBand,
 }: {
   modules: OpsModuleInput[];
   districts?: SectionAwareDistrict[];
@@ -54,6 +55,9 @@ export function OperationsSchematic({
   /** Placement ids (layout_modules row ids) to call out — e.g. a module no
    * longer offered by the repo (#158). Drawn with an amber outline. */
   highlightModuleIds?: string[];
+  /** This band is a branch spine (#170): its west end is the junction, so a
+   * loop in the first cell still opens outward (east), never west. */
+  branchBand?: boolean;
 }) {
   if (modules.length === 0) {
     return (
@@ -154,7 +158,7 @@ export function OperationsSchematic({
           // Main 2 directional return (#165): the balloon is a U joining the
           // two main lanes at the outward side — no bulb.
           const isUReturn = isLoop && cellFeat?.loopReturn === "main2";
-          const bulbWest = isLoop && ci === 0;
+          const bulbWest = isLoop && ci === 0 && !branchBand;
           const bulbR = Math.min(6, c.width * 0.06);
           const uR = (Y0 - Y1) / 2; // U-bend radius spans the two main lanes
           const mainX1 =

--- a/components/track/TrackBoard.tsx
+++ b/components/track/TrackBoard.tsx
@@ -121,9 +121,17 @@ export function TrackBoard({
 
   // Live CTC panel (#151): control-point signal aspects from allocations.
   const allSections = layout.districts.flatMap((d) => d.sections);
-  const cps = layout.modules?.length
-    ? layoutControlPoints(layout.modules, asLayoutCps(layout.layoutControlPoints))
-    : [];
+  const layoutCps = asLayoutCps(layout.layoutControlPoints);
+  const branchSpines = layout.branchSpines ?? [];
+  // Main spine, then each branch (#170) — adjacency never crosses the junction.
+  const cps = [
+    ...(layout.modules?.length
+      ? layoutControlPoints(layout.modules, layoutCps)
+      : []),
+    ...branchSpines.flatMap((b) =>
+      layoutControlPoints(b.modules, layoutCps, b.id),
+    ),
+  ];
   const sectionsByDerivedKey = new Map(
     allSections
       .filter((s) => s.derivedKey != null)
@@ -143,9 +151,23 @@ export function TrackBoard({
 
   return (
     <div className="space-y-4">
-      {/* Live operations panel — signals show cleared routes (#151). */}
+      {/* Live operations panel — signals show cleared routes (#151); branch
+          spines stack as their own bands (#170). */}
       {layout.modules && layout.modules.length > 0 && (
-        <OperationsSchematic modules={layout.modules} signalAspects={aspects} />
+        <>
+          <OperationsSchematic modules={layout.modules} signalAspects={aspects} />
+          {branchSpines
+            .filter((b) => b.modules.length > 0)
+            .map((b) => (
+              <div key={b.id}>
+                <div className="mb-0.5 text-[11px] text-slate-500">
+                  ⤷ <span className="text-slate-300">{b.name}</span>
+                </div>
+                <OperationsSchematic modules={b.modules} signalAspects={aspects} branchBand
+                                  />
+              </div>
+            ))}
+        </>
       )}
 
       {/* Signal legend */}

--- a/lib/client/useTrackBoard.ts
+++ b/lib/client/useTrackBoard.ts
@@ -55,6 +55,13 @@ export interface LayoutTree {
   districts: DistrictNode[];
   /** Module placements in spine order — for the live operations panel (#151). */
   modules?: LayoutModuleNode[];
+  /** Branch spines (#170) — defs + their placements. */
+  branchSpines?: {
+    id: string;
+    name: string;
+    origin: { placementId: string; endplateId: string };
+    modules: LayoutModuleNode[];
+  }[];
   controlPointDistricts?: Record<string, string> | null;
   layoutControlPoints?: unknown;
 }

--- a/lib/db/migrations/0018_branch_spines.sql
+++ b/lib/db/migrations/0018_branch_spines.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "layouts" ADD COLUMN "branches" jsonb;
+--> statement-breakpoint
+ALTER TABLE "module_layouts" ADD COLUMN "branch_id" text;

--- a/lib/db/migrations/meta/0018_snapshot.json
+++ b/lib/db/migrations/meta/0018_snapshot.json
@@ -1,0 +1,1792 @@
+{
+  "id": "a2d2f3a4-aac1-4cbf-9c5b-2b5d6ae6e564",
+  "prevId": "bf8ff7e5-2d80-475b-b8fd-7bbd65c09874",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authority_log": {
+      "name": "authority_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_operator": {
+          "name": "by_operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "authority_log_session_idx": {
+          "name": "authority_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authority_log_session_id_sessions_id_fk": {
+          "name": "authority_log_session_id_sessions_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authority_log_train_id_trains_id_fk": {
+          "name": "authority_log_train_id_trains_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_occupancy": {
+      "name": "block_occupancy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occupied": {
+          "name": "occupied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_occupancy_session_block": {
+          "name": "block_occupancy_session_block",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_occupancy_session_idx": {
+          "name": "block_occupancy_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "block_occupancy_session_id_sessions_id_fk": {
+          "name": "block_occupancy_session_id_sessions_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_block_id_blocks_id_fk": {
+          "name": "block_occupancy_block_id_blocks_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_train_id_trains_id_fk": {
+          "name": "block_occupancy_train_id_trains_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "module_record_number": {
+          "name": "module_record_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_section_idx": {
+          "name": "blocks_section_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_section_id_sections_id_fk": {
+          "name": "blocks_section_id_sections_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.districts": {
+      "name": "districts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "districts_layout_idx": {
+          "name": "districts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "districts_layout_id_layouts_id_fk": {
+          "name": "districts_layout_id_layouts_id_fk",
+          "tableFrom": "districts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layouts": {
+      "name": "layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'freemon'"
+        },
+        "control_point_districts": {
+          "name": "control_point_districts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "layout_control_points": {
+          "name": "layout_control_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branches": {
+          "name": "branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_layouts": {
+      "name": "module_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "staging_end": {
+          "name": "staging_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flipped": {
+          "name": "flipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "module_layouts_layout_idx": {
+          "name": "module_layouts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_layouts_layout_id_layouts_id_fk": {
+          "name": "module_layouts_layout_id_layouts_id_fk",
+          "tableFrom": "module_layouts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "operators_session_idx": {
+          "name": "operators_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operators_device_idx": {
+          "name": "operators_device_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operators_session_id_sessions_id_fk": {
+          "name": "operators_session_id_sessions_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ops_log": {
+      "name": "ops_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ops_log_session_idx": {
+          "name": "ops_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ops_log_session_id_sessions_id_fk": {
+          "name": "ops_log_session_id_sessions_id_fk",
+          "tableFrom": "ops_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_modules": {
+      "name": "repo_modules",
+      "schema": "",
+      "columns": {
+        "record_number": {
+          "name": "record_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_type": {
+          "name": "geometry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_degrees": {
+          "name": "geometry_degrees",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_offset_inches": {
+          "name": "geometry_offset_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "length_total_inches": {
+          "name": "length_total_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mainline_length_inches": {
+          "name": "mainline_length_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplate_count": {
+          "name": "endplate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_mss": {
+          "name": "has_mss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mss_type": {
+          "name": "mss_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplates": {
+          "name": "endplates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industries": {
+          "name": "industries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematics": {
+          "name": "schematics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematic": {
+          "name": "schematic",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_updated_at": {
+          "name": "upstream_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_from_repo_at": {
+          "name": "removed_from_repo_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.section_allocations": {
+      "name": "section_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allocated_by": {
+          "name": "allocated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "section_allocations_session_idx": {
+          "name": "section_allocations_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_train_idx": {
+          "name": "section_allocations_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_active_section": {
+          "name": "section_allocations_active_section",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"section_allocations\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_allocations_session_id_sessions_id_fk": {
+          "name": "section_allocations_session_id_sessions_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_section_id_sections_id_fk": {
+          "name": "section_allocations_section_id_sections_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_train_id_trains_id_fk": {
+          "name": "section_allocations_train_id_trains_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "derived_key": {
+          "name": "derived_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sections_district_idx": {
+          "name": "sections_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sections_district_id_districts_id_fk": {
+          "name": "sections_district_id_districts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_config_id": {
+          "name": "layout_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_one_active": {
+          "name": "sessions_one_active",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_layout_id_layouts_id_fk": {
+          "name": "sessions_layout_id_layouts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_tracks": {
+      "name": "staging_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_train_id": {
+          "name": "assigned_train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staging_tracks_layout_idx": {
+          "name": "staging_tracks_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staging_tracks_layout_id_module_layouts_id_fk": {
+          "name": "staging_tracks_layout_id_module_layouts_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "module_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staging_tracks_assigned_train_id_trains_id_fk": {
+          "name": "staging_tracks_assigned_train_id_trains_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "assigned_train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.train_statuses": {
+      "name": "train_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yard'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_authority": {
+          "name": "has_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "train_statuses_train_idx": {
+          "name": "train_statuses_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "train_statuses_session_idx": {
+          "name": "train_statuses_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "train_statuses_train_id_trains_id_fk": {
+          "name": "train_statuses_train_id_trains_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "train_statuses_session_id_sessions_id_fk": {
+          "name": "train_statuses_session_id_sessions_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trains": {
+      "name": "trains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_address": {
+          "name": "dcc_address",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_type": {
+          "name": "dcc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consist_id": {
+          "name": "consist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment_type": {
+          "name": "equipment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_operator_id": {
+          "name": "assigned_operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trains_session_idx": {
+          "name": "trains_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trains_assigned_idx": {
+          "name": "trains_assigned_idx",
+          "columns": [
+            {
+              "expression": "assigned_operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trains_session_id_sessions_id_fk": {
+          "name": "trains_session_id_sessions_id_fk",
+          "tableFrom": "trains",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnout_positions": {
+      "name": "turnout_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turnout_id": {
+          "name": "turnout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnout_positions_session_turnout": {
+          "name": "turnout_positions_session_turnout",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turnout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "turnout_positions_session_idx": {
+          "name": "turnout_positions_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnout_positions_session_id_sessions_id_fk": {
+          "name": "turnout_positions_session_id_sessions_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turnout_positions_turnout_id_turnouts_id_fk": {
+          "name": "turnout_positions_turnout_id_turnouts_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "turnouts",
+          "columnsFrom": [
+            "turnout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnouts": {
+      "name": "turnouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnouts_district_idx": {
+          "name": "turnouts_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnouts_district_id_districts_id_fk": {
+          "name": "turnouts_district_id_districts_id_fk",
+          "tableFrom": "turnouts",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -127,6 +127,13 @@
       "when": 1783478730189,
       "tag": "0017_repo_module_tombstones",
       "breakpoints": true
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1783565130189,
+      "tag": "0018_branch_spines",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -64,6 +64,10 @@ export const layouts = pgTable("layouts", {
   // anchored to a layout_modules row at an offset from its A end. They
   // interleave with the imported ones and feed the same section derivation.
   layoutControlPoints: jsonb("layout_control_points"),
+  // Spine graph (#170): [{id, name, origin: {placementId, endplateId}}] —
+  // branch spines attached at a junction endplate of a placed module. The
+  // ordered module_layouts rows with branch_id null remain the main spine.
+  branches: jsonb("branches"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -223,6 +227,10 @@ export const moduleLayouts = pgTable(
     stagingEnd: text("staging_end").$type<StagingEnd>(),
     // Mirror this placement so curves bend the other way (#115 orientation).
     flipped: boolean("flipped").notNull().default(false),
+    // Spine graph (#170): null = the main spine; otherwise the id of a branch
+    // in layouts.branches this placement belongs to. positionIndex orders
+    // within its own spine.
+    branchId: text("branch_id"),
   },
   (t) => [index("module_layouts_layout_idx").on(t.layoutId)],
 );

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -12,7 +12,7 @@
  * is caught at the DB level by a partial unique index (one active allocation per
  * section per session); an allocation route must also stay within one District.
  */
-import { and, asc, eq, inArray, isNotNull, or, sql } from "drizzle-orm";
+import { and, asc, eq, inArray, isNotNull, notInArray, or, sql } from "drizzle-orm";
 import { db } from "@/lib/db/client";
 import {
   layouts,
@@ -34,9 +34,11 @@ import {
   layoutControlPoints,
   deriveSections,
   asLayoutCps,
+  asBranches,
   planSectionSync,
   planBlockSync,
   derivedSectionKey,
+  type BranchDef,
   type SpannedModule,
 } from "@/lib/track/layoutControlPoints";
 
@@ -94,10 +96,15 @@ export interface LayoutModule {
   removedFromRepoAt: Date | null;
   /** Owner's repo status: active | inactive | archived (#158). */
   status: string | null;
+  /** Spine this placement sits on (#170): null = main spine. */
+  branchId: string | null;
 }
 
 export interface LayoutTree extends LayoutRow {
+  /** Main-spine placements (branchId null), in spine order. */
   modules: LayoutModule[];
+  /** Branch spines (#170): defs from layouts.branches with their placements. */
+  branchSpines: (BranchDef & { modules: LayoutModule[] })[];
   districts: (DistrictRow & {
     sections: (SectionRow & { blocks: BlockRow[] })[];
     turnouts: TurnoutRow[];
@@ -153,9 +160,16 @@ export function buildLayoutTree(
     arr.push(t);
     turnoutsByDistrict.set(t.districtId, arr);
   }
+  const sorted = [...moduleRows].sort((a, b) => a.positionIndex - b.positionIndex);
+  const branchDefs = asBranches((layout as { branches?: unknown }).branches);
   return {
     ...layout,
-    modules: [...moduleRows].sort((a, b) => a.positionIndex - b.positionIndex),
+    // Main spine = placements without a branchId (#170).
+    modules: sorted.filter((m) => m.branchId == null),
+    branchSpines: branchDefs.map((b) => ({
+      ...b,
+      modules: sorted.filter((m) => m.branchId === b.id),
+    })),
     districts: [...districtRows].sort(byPos).map((d) => ({
       ...d,
       sections: (sectionsByDistrict.get(d.id) ?? []).sort(byPos).map((s) => ({
@@ -264,6 +278,25 @@ class TrackModel {
       .where(eq(layouts.id, layoutId));
   }
 
+  /** Replace the layout's branch-spine definitions (#170). Placements on a
+   * deleted branch fall back to the main spine (branchId cleared). */
+  async setBranches(layoutId: string, branches: BranchDef[]): Promise<void> {
+    await db.transaction(async (tx) => {
+      await tx.update(layouts).set({ branches }).where(eq(layouts.id, layoutId));
+      const keep = branches.map((b) => b.id);
+      await tx
+        .update(moduleLayouts)
+        .set({ branchId: null })
+        .where(
+          and(
+            eq(moduleLayouts.layoutId, layoutId),
+            isNotNull(moduleLayouts.branchId),
+            ...(keep.length ? [notInArray(moduleLayouts.branchId, keep)] : []),
+          ),
+        );
+    });
+  }
+
   /** Replace the layout-level control points (#144). */
   async setLayoutControlPoints(
     layoutId: string,
@@ -285,15 +318,23 @@ class TrackModel {
   async syncDerivedSections(layoutId: string): Promise<void> {
     const tree = await this.getLayout(layoutId);
     if (!tree) return;
-    const cps = layoutControlPoints(
-      tree.modules,
-      asLayoutCps(tree.layoutControlPoints),
-    );
+    const layoutCps = asLayoutCps(tree.layoutControlPoints);
     const assignments =
       tree.controlPointDistricts && typeof tree.controlPointDistricts === "object"
         ? (tree.controlPointDistricts as Record<string, string>)
         : {};
-    const derived = deriveSections(cps, assignments, tree.modules);
+    // Each spine derives independently (#170): main first, then branches.
+    const spines: { id: string | null; modules: typeof tree.modules }[] = [
+      { id: null, modules: tree.modules },
+      ...tree.branchSpines.map((b) => ({ id: b.id, modules: b.modules })),
+    ];
+    const derived = spines.flatMap((s) =>
+      deriveSections(
+        layoutControlPoints(s.modules, layoutCps, s.id),
+        assignments,
+        s.modules,
+      ),
+    );
     const existing = tree.districts.flatMap((d) =>
       d.sections.map((s) => ({
         id: s.id,
@@ -392,6 +433,7 @@ class TrackModel {
         schematic: repoModules.schematic,
         removedFromRepoAt: repoModules.removedFromRepoAt,
         status: repoModules.status,
+        branchId: moduleLayouts.branchId,
       })
       .from(moduleLayouts)
       .leftJoin(repoModules, eq(moduleLayouts.moduleId, repoModules.recordNumber))

--- a/lib/server/__tests__/TrackModel.test.ts
+++ b/lib/server/__tests__/TrackModel.test.ts
@@ -36,6 +36,7 @@ describe("buildLayoutTree (#80)", () => {
     standard: "freemon",
     controlPointDistricts: null,
     layoutControlPoints: null,
+    branches: null,
     createdAt: new Date(),
   };
 

--- a/lib/track/__tests__/layoutControlPoints.test.ts
+++ b/lib/track/__tests__/layoutControlPoints.test.ts
@@ -3,6 +3,7 @@ import {
   layoutControlPoints,
   deriveSections,
   asLayoutCps,
+  asBranches,
   planSectionSync,
   planBlockSync,
   DERIVED_POSITION_BASE,
@@ -284,6 +285,56 @@ describe("planSectionSync (#146)", () => {
   it("skips sections for districts that no longer exist", () => {
     const plan = planSectionSync([], derived, new Set<string>());
     expect(plan.insert).toEqual([]);
+  });
+});
+
+describe("branch spines (#170)", () => {
+  const main = [
+    mod("FMN-0001", 0, [{ id: "a", name: "A", pos: 10 }, { id: "b", name: "B", pos: 90 }]),
+  ];
+  const branch = [mod("FMN-0002", 0, [{ id: "c", name: "C", pos: 10 }])];
+
+  it("tags refs with their spine and keeps keys spine-agnostic", () => {
+    const cps = [
+      ...layoutControlPoints(main, []),
+      ...layoutControlPoints(branch, [], "br-1"),
+    ];
+    expect(cps.map((c) => `${c.key}@${c.spineId ?? "main"}`)).toEqual([
+      "FMN-0001:a@main",
+      "FMN-0001:b@main",
+      "FMN-0002:c@br-1",
+    ]);
+  });
+
+  it("sections never derive across the junction (spine boundary)", () => {
+    const cps = [
+      ...layoutControlPoints(main, []),
+      ...layoutControlPoints(branch, [], "br-1"),
+    ];
+    // Everything in one district — but B (main) → C (branch) must NOT pair.
+    const sections = deriveSections(cps, {
+      "FMN-0001:a": "d1",
+      "FMN-0001:b": "d1",
+      "FMN-0002:c": "d1",
+    });
+    expect(sections.map((s) => s.name)).toEqual(["A – B"]);
+  });
+});
+
+describe("asBranches", () => {
+  it("parses stored defs and tolerates junk", () => {
+    expect(asBranches(null)).toEqual([]);
+    expect(
+      asBranches([
+        { id: "br-1", name: "Bowl Idaho", origin: { placementId: "pl-1", endplateId: "C" } },
+        { id: "br-2", origin: { placementId: "pl-2" } }, // name + endplate default
+        { id: 5, origin: {} }, // dropped
+        "junk",
+      ]),
+    ).toEqual([
+      { id: "br-1", name: "Bowl Idaho", origin: { placementId: "pl-1", endplateId: "C" } },
+      { id: "br-2", name: "br-2", origin: { placementId: "pl-2", endplateId: "C" } },
+    ]);
   });
 });
 

--- a/lib/track/__tests__/signals.test.ts
+++ b/lib/track/__tests__/signals.test.ts
@@ -33,6 +33,7 @@ describe("cpSignalAspects (#151 live CTC panel)", () => {
     name: key,
     source: "module",
     posInches: null,
+    spineId: null,
   });
   // West — Mid — East along the spine; one derived section each side of Mid.
   const cps = [cp("M:west"), cp("M:mid"), cp("M:east")];

--- a/lib/track/layoutControlPoints.ts
+++ b/lib/track/layoutControlPoints.ts
@@ -46,6 +46,10 @@ export interface ControlPointRef {
   source: "module" | "layout";
   /** Inches from the module's A end, when the schematic positions it. */
   posInches: number | null;
+  /** Spine this point sits on (#170): null = the main spine, otherwise a
+   * branch id. Sections never derive across spines — a junction endplate
+   * terminates the section chain. */
+  spineId: string | null;
 }
 
 /** A module CP's representative position: its westmost signal or turnout. */
@@ -70,6 +74,7 @@ function cpPosInches(
 export function layoutControlPoints(
   modules: CpModuleInput[],
   layoutCps: LayoutCp[] = [],
+  spineId: string | null = null,
 ): ControlPointRef[] {
   const ordered = [...modules].sort(
     (a, b) => (a.positionIndex ?? 0) - (b.positionIndex ?? 0),
@@ -91,6 +96,7 @@ export function layoutControlPoints(
         name: cp.name?.trim() || cp.id,
         source: "module",
         posInches: cpPosInches(cp, doc!) ?? docIndex,
+        spineId,
       });
       docIndex += 1;
     }
@@ -104,6 +110,7 @@ export function layoutControlPoints(
         name: lc.name?.trim() || lc.id,
         source: "layout",
         posInches: lc.offsetInches,
+        spineId,
       });
     }
     refs.sort((a, b) => (a.posInches ?? 0) - (b.posInches ?? 0));
@@ -156,6 +163,9 @@ export function deriveSections(
   for (let i = 0; i < controlPoints.length - 1; i++) {
     const a = controlPoints[i];
     const b = controlPoints[i + 1];
+    // Adjacency is per-spine (#170): a junction terminates the chain — no
+    // section spans from a main-spine point onto a branch (or vice versa).
+    if ((a.spineId ?? null) !== (b.spineId ?? null)) continue;
     const da = assignments[a.key];
     const db = assignments[b.key];
     if (da && da === db) {
@@ -304,6 +314,41 @@ export function planBlockSync(
     plan.insert.push(...want);
   }
   return plan;
+}
+
+// ---- Branch spines (#170) --------------------------------------------------
+
+/** A branch spine attached at a junction endplate of a placed module. */
+export interface BranchDef {
+  id: string;
+  name: string;
+  origin: {
+    /** layout_modules row id of the junction module (on the main spine). */
+    placementId: string;
+    /** The junction endplate on that module (e.g. "C"). */
+    endplateId: string;
+  };
+}
+
+/** Parse a jsonb value into branch definitions, tolerating junk. */
+export function asBranches(x: unknown): BranchDef[] {
+  if (!Array.isArray(x)) return [];
+  const out: BranchDef[] = [];
+  for (const v of x) {
+    if (!v || typeof v !== "object") continue;
+    const b = v as Record<string, unknown>;
+    const origin = (b.origin ?? {}) as Record<string, unknown>;
+    if (typeof b.id !== "string" || typeof origin.placementId !== "string") continue;
+    out.push({
+      id: b.id,
+      name: typeof b.name === "string" && b.name ? b.name : b.id,
+      origin: {
+        placementId: origin.placementId,
+        endplateId: typeof origin.endplateId === "string" ? origin.endplateId : "C",
+      },
+    });
+  }
+  return out;
 }
 
 /** Parse a jsonb value into layout-level control points, tolerating junk. */

--- a/lib/track/signals.ts
+++ b/lib/track/signals.ts
@@ -71,6 +71,8 @@ export function cpSignalAspects(
   for (let i = 0; i < controlPoints.length - 1; i++) {
     const a = controlPoints[i];
     const b = controlPoints[i + 1];
+    // Per-spine adjacency (#170): no section spans a junction.
+    if ((a.spineId ?? null) !== (b.spineId ?? null)) continue;
     const sectionId = sectionsByDerivedKey.get(`${a.key}→${b.key}`);
     if (!sectionId) continue;
     const alloc = allocations[sectionId];


### PR DESCRIPTION
Slice 3 of #170 — the composition lift. The layout grows from a single linear spine to a **spine graph**: branch spines attach at a junction module's branch endplate and render as their own stacked bands (the CATS/US&S multi-band idiom), paired with the junction's connector arrow from slice 2.

- `layouts.branches` + `module_layouts.branch_id` (migration 0018); per-spine ordering; deleting a branch returns its placements to the main line
- `POST /api/modules` gains `branchId`; `PATCH /api/layouts/:id` gains `branches`
- **`ControlPointRef.spineId`**: sections and live signal aspects derive **per spine** — a junction terminates the chain (guards in `deriveSections` + `cpSignalAspects`; 137 tests)
- Layout Builder: **+ Branch**, per-branch module lists, picker **Add-to** spine select; ops schematic + live Track panel stack one band per branch
- `branchBand` prop: a branch band's west end is the junction, so a first-cell loop opens outward

**Verified in the browser**: One Mile + Bowl Junction (diamond + branch arrow) on the main, Seaford loop on the *Bowl Idaho* branch — two bands; with all four CPs in one district, sections derive *West–East* and *East–Bowl Jct* (correct two-module block span) and **no section crosses the junction**. tsc + build green.

Remaining on #170: route identity (slice 4), wye reversal (slice 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)