### PR TITLE
feat: single↔double transition modules render at the authored turnout (FMN-0038)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -169,9 +169,19 @@ export function OperationsSchematic({
               : c.x + c.width;
           const hasSecond = !isLoop && (c.leftTracks >= 2 || c.rightTracks >= 2);
           const inSwitch = Math.min(c.width * 0.3, 30);
-          const lane1Start = c.leftTracks >= 2 ? c.x : c.x + inSwitch + LANE_GAP;
-          const lane1End =
-            c.rightTracks >= 2 ? c.x + c.width : c.x + c.width - inSwitch - LANE_GAP;
+          // Authored transition (FMN-0038): Main 2's extent comes from the
+          // schematic's mainline turnout, not the default inset.
+          const m2 = cellFeat?.main2Extent ?? null;
+          const lane1Start = m2
+            ? c.x + m2.fromFrac * c.width + (c.leftTracks < 2 ? LANE_GAP : 0)
+            : c.leftTracks >= 2
+              ? c.x
+              : c.x + inSwitch + LANE_GAP;
+          const lane1End = m2
+            ? c.x + m2.toFrac * c.width - (c.rightTracks < 2 ? LANE_GAP : 0)
+            : c.rightTracks >= 2
+              ? c.x + c.width
+              : c.x + c.width - inSwitch - LANE_GAP;
           return (
             <g key={c.input.id}>
               {/* Main 1 — continuous; loops turn back at the bulb */}
@@ -268,7 +278,7 @@ export function OperationsSchematic({
                   )}
                   {c.leftTracks < 2 && (
                     <line
-                      x1={c.x + inSwitch}
+                      x1={lane1Start - LANE_GAP}
                       y1={Y0}
                       x2={lane1Start}
                       y2={Y1}
@@ -281,7 +291,7 @@ export function OperationsSchematic({
                     <line
                       x1={lane1End}
                       y1={Y1}
-                      x2={c.x + c.width - inSwitch}
+                      x2={lane1End + LANE_GAP}
                       y2={Y0}
                       stroke={stroke}
                       strokeWidth={STROKE}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.7.0",
+        "@willcgage/module-schematic": "^0.8.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.7.0.tgz",
-      "integrity": "sha512-o+U2OCLpu+GE/qDngmQi1YXEVQ1expiNlmOCHUYrFlYebfvEf90zQo58qfauJ98tB5Q7bg+/Qs2bb8Si68QYPw==",
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.8.0.tgz",
+      "integrity": "sha512-egc/YMXMXzeWJ1s4JdlXiybyxwua/pC5QCICL35+3iAxABqzN1rJjNAhcHuvIxDMF9DdY5ypnUD232d3ordKig==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.7.0",
+    "@willcgage/module-schematic": "^0.8.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
From authoring FMN-0038 (one single endplate, one double): the mainline needs a turnout where Main 2 begins, and nothing asked for it — Main 2 rendered full-length.

- [`@willcgage/module-schematic@0.8.0`](https://github.com/willcgage/module-schematic/releases/tag/v0.8.0): **the turnout diverging to `main2` is the single source of truth** — Main 2 emits as a positioned track between it and the double end; `buildTransition()` one-click (turnout + *End of Double Track* CP + both-direction signals); `ModuleFeatures.main2Extent`.
- **Operations panel**: the lane-1 diverge sits at the **authored** transition position instead of the fixed inset.
- **MR builder** (separate modulerepo commit): detects mismatched endplates → amber prompt with **+ Add transition**.

**Verified in the browser**: seeded FMN-0038 (turnout @ 18″) after One Mile — diverge starts exactly at cell+18, Main 2 runs to the double end, EODT turnout + signals render. 137 tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)