### PR TITLE
feat: endplate joins as data + mirrored placements (#175 phase 2)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -79,6 +79,8 @@ interface LayoutModuleNode {
   removedFromRepoAt: string | null;
   /** Owner's repo status: active | inactive | archived (#158). */
   status: string | null;
+  /** Mirrored/flipped placement for the footprint solver (#175). */
+  mirrored: boolean;
 }
 interface BranchSpine {
   id: string;
@@ -86,10 +88,23 @@ interface BranchSpine {
   origin: { placementId: string; endplateId: string };
   modules: LayoutModuleNode[];
 }
+interface EndplateRefNode {
+  placementId: string;
+  endplateId: string;
+}
+interface JoinNode {
+  id: string;
+  a: EndplateRefNode;
+  b: EndplateRefNode;
+  implicit?: boolean;
+  status: "ok" | "mismatch" | "unknown" | "dangling";
+}
 interface LayoutTree extends LayoutRow {
   modules: LayoutModuleNode[];
   /** Branch spines (#170) — defs + their placements. */
   branchSpines: BranchSpine[];
+  /** Endplate joins (#175) — implicit + explicit, with compatibility. */
+  joins: JoinNode[];
   districts: DistrictNode[];
 }
 
@@ -152,6 +167,8 @@ export default function AdminLayouts() {
   const [branchDraft, setBranchDraft] = useState<
     Record<string, { name: string; placementId: string }>
   >({});
+  // Explicit-join draft (#175), keyed by layout id: "<placementId>:<endplateId>".
+  const [joinDraft, setJoinDraft] = useState<Record<string, { a: string; b: string }>>({});
   // Dropped-module notice + schematic highlight + replace flow (#158).
   const [unavailNotice, setUnavailNotice] = useState<{ layoutId: string } | null>(null);
   const unavailNotified = useRef<Set<string>>(new Set());
@@ -282,6 +299,35 @@ export default function AdminLayouts() {
       await Promise.all([reloadTree(layoutId), load()]);
     } catch (e) {
       alert(e instanceof Error ? e.message : "add failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Replace the explicit endplate joins (#175). */
+  async function saveJoins(
+    layoutId: string,
+    joins: { id: string; a: EndplateRefNode; b: EndplateRefNode }[],
+  ) {
+    setBusy(true);
+    try {
+      await apiSend("PATCH", `/api/layouts/${layoutId}`, { joins });
+      await reloadTree(layoutId);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "save failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  /** Toggle a placement's mirrored flag (#175). */
+  async function toggleMirror(layoutId: string, placementId: string, mirrored: boolean) {
+    setBusy(true);
+    try {
+      await apiSend("PATCH", `/api/modules/${placementId}`, { mirrored: !mirrored });
+      await reloadTree(layoutId);
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "update failed");
     } finally {
       setBusy(false);
     }
@@ -828,6 +874,18 @@ export default function AdminLayouts() {
                                         Replace
                                       </button>
                                     )}
+                                    <button
+                                      disabled={busy}
+                                      title="Mirror this placement (flip it for the footprint — Free-mo modules are two-sided)"
+                                      onClick={() => toggleMirror(l.id, m.id, m.mirrored)}
+                                      className={`shrink-0 rounded border px-1.5 py-0.5 text-xs ${
+                                        m.mirrored
+                                          ? "border-sky-700 bg-sky-900/40 text-sky-300"
+                                          : "border-slate-700 text-slate-400 hover:bg-slate-800"
+                                      }`}
+                                    >
+                                      ⇋
+                                    </button>
                                     <select
                                       value={m.stagingEnd ?? ""}
                                       onChange={(e) =>
@@ -1219,6 +1277,148 @@ export default function AdminLayouts() {
                               districts={tree.districts}
                               onDropModule={(rec) => dropAddModule(l.id, rec)}
                             />
+                          </div>
+
+                          {/* Endplate joins (#175) */}
+                          <div>
+                            <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
+                              Endplate joins
+                            </div>
+                            {(() => {
+                              const allMods = [
+                                ...tree.modules,
+                                ...tree.branchSpines.flatMap((b) => b.modules),
+                              ];
+                              const modById = new Map(allMods.map((m) => [m.id, m]));
+                              const epsOf = (m?: LayoutModuleNode): string[] => {
+                                const doc = m?.schematic as
+                                  | { endplates?: { id?: string }[] }
+                                  | null
+                                  | undefined;
+                                const ids = (doc?.endplates ?? [])
+                                  .map((e) => e?.id)
+                                  .filter((x): x is string => !!x);
+                                return ids.length ? ids : ["A", "B"];
+                              };
+                              const label = (r: EndplateRefNode) => {
+                                const m = modById.get(r.placementId);
+                                return `${m?.moduleName ?? m?.moduleId ?? "?"} · ${r.endplateId}`;
+                              };
+                              const statusColor: Record<string, string> = {
+                                ok: "text-emerald-400",
+                                mismatch: "text-amber-400",
+                                unknown: "text-slate-500",
+                                dangling: "text-red-400",
+                              };
+                              const draft = joinDraft[l.id] ?? { a: "", b: "" };
+                              const epOptions = allMods.flatMap((m) =>
+                                epsOf(m).map((ep) => ({
+                                  value: `${m.id}:${ep}`,
+                                  text: `${m.moduleName ?? m.moduleId} · ${ep}`,
+                                })),
+                              );
+                              if (allMods.length === 0)
+                                return (
+                                  <p className="text-xs text-slate-600">
+                                    Add modules to see how their endplates connect.
+                                  </p>
+                                );
+                              return (
+                                <>
+                                  <ul className="space-y-0.5">
+                                    {tree.joins.map((j) => (
+                                      <li key={j.id} className="flex items-center gap-2 text-xs">
+                                        <span className={statusColor[j.status]} title={j.status}>
+                                          {j.status === "ok"
+                                            ? "●"
+                                            : j.status === "mismatch"
+                                              ? "▲"
+                                              : j.status === "dangling"
+                                                ? "✕"
+                                                : "○"}
+                                        </span>
+                                        <span className="min-w-0 flex-1 truncate text-slate-300">
+                                          {label(j.a)} ↔ {label(j.b)}
+                                        </span>
+                                        {j.implicit ? (
+                                          <span className="shrink-0 rounded bg-slate-800 px-1 py-px text-[10px] uppercase text-slate-500">
+                                            spine
+                                          </span>
+                                        ) : (
+                                          <button
+                                            disabled={busy}
+                                            title="Remove this join"
+                                            onClick={() =>
+                                              saveJoins(
+                                                l.id,
+                                                tree.joins
+                                                  .filter((x) => !x.implicit && x.id !== j.id)
+                                                  .map(({ id, a, b }) => ({ id, a, b })),
+                                              )
+                                            }
+                                            className="shrink-0 rounded px-1 text-slate-500 hover:text-red-400"
+                                          >
+                                            ✕
+                                          </button>
+                                        )}
+                                      </li>
+                                    ))}
+                                  </ul>
+                                  {/* Add an explicit join — close a circuit, connect any two endplates */}
+                                  <div className="mt-2 flex flex-wrap items-center gap-1.5">
+                                    <select
+                                      value={draft.a}
+                                      onChange={(e) =>
+                                        setJoinDraft((p) => ({ ...p, [l.id]: { ...draft, a: e.target.value } }))
+                                      }
+                                      className="max-w-40 rounded border border-slate-700 bg-slate-800 px-1 py-0.5 text-xs text-slate-300"
+                                    >
+                                      <option value="">endplate…</option>
+                                      {epOptions.map((o) => (
+                                        <option key={o.value} value={o.value}>{o.text}</option>
+                                      ))}
+                                    </select>
+                                    <span className="text-xs text-slate-500">↔</span>
+                                    <select
+                                      value={draft.b}
+                                      onChange={(e) =>
+                                        setJoinDraft((p) => ({ ...p, [l.id]: { ...draft, b: e.target.value } }))
+                                      }
+                                      className="max-w-40 rounded border border-slate-700 bg-slate-800 px-1 py-0.5 text-xs text-slate-300"
+                                    >
+                                      <option value="">endplate…</option>
+                                      {epOptions.map((o) => (
+                                        <option key={o.value} value={o.value}>{o.text}</option>
+                                      ))}
+                                    </select>
+                                    <button
+                                      disabled={busy || !draft.a || !draft.b || draft.a === draft.b}
+                                      onClick={() => {
+                                        const [pa, ea] = draft.a.split(":");
+                                        const [pb, eb] = draft.b.split(":");
+                                        setJoinDraft((p) => ({ ...p, [l.id]: { a: "", b: "" } }));
+                                        saveJoins(l.id, [
+                                          ...tree.joins
+                                            .filter((x) => !x.implicit)
+                                            .map(({ id, a, b }) => ({ id, a, b })),
+                                          {
+                                            id: `join-${Date.now().toString(36)}`,
+                                            a: { placementId: pa, endplateId: ea },
+                                            b: { placementId: pb, endplateId: eb },
+                                          },
+                                        ]);
+                                      }}
+                                      className="rounded border border-slate-600 px-2 py-0.5 text-xs text-slate-300 hover:bg-slate-800 disabled:opacity-40"
+                                    >
+                                      + Join
+                                    </button>
+                                    <span className="text-[11px] text-slate-600">
+                                      spine joins are automatic — add one to close a loop or link any two ends
+                                    </span>
+                                  </div>
+                                </>
+                              );
+                            })()}
                           </div>
 
                           {/* Control Points → Districts (#138) */}

--- a/app/api/layouts/[id]/route.ts
+++ b/app/api/layouts/[id]/route.ts
@@ -5,6 +5,7 @@
 import { NextResponse } from "next/server";
 import { trackModel } from "@/lib/server/TrackModel";
 import { asBranches } from "@/lib/track/layoutControlPoints";
+import { asJoins } from "@/lib/track/layoutJoins";
 import { requireRole } from "@/lib/server/guard";
 
 export const dynamic = "force-dynamic";
@@ -49,6 +50,8 @@ export async function PATCH(
     }[];
     /** Branch-spine definitions (#170). */
     branches?: unknown;
+    /** Explicit endplate joins (#175). */
+    joins?: unknown;
   };
   try {
     body = await req.json();
@@ -83,6 +86,10 @@ export async function PATCH(
   if (body.branches !== undefined) {
     // Branch-spine definitions (#170); junk entries are dropped by the parser.
     await trackModel.setBranches(id, asBranches(body.branches));
+  }
+  if (body.joins !== undefined) {
+    // Explicit endplate joins (#175); junk entries dropped by the parser.
+    await trackModel.setJoins(id, asJoins(body.joins));
   }
   // Re-materialize the sections the control points derive (#146).
   await trackModel.syncDerivedSections(id);

--- a/app/api/modules/[id]/route.ts
+++ b/app/api/modules/[id]/route.ts
@@ -25,6 +25,8 @@ export async function PATCH(
     positionIndex?: number;
     stagingEnd?: StagingEnd | null;
     flipped?: boolean;
+    /** Mirrored/flipped placement for the footprint solver (#175). */
+    mirrored?: boolean;
     /** Replace the placement with another catalog module (#158). */
     moduleId?: string;
   };
@@ -38,6 +40,7 @@ export async function PATCH(
   if (typeof body.positionIndex === "number") set.positionIndex = body.positionIndex;
   if (body.stagingEnd !== undefined) set.stagingEnd = body.stagingEnd;
   if (typeof body.flipped === "boolean") set.flipped = body.flipped;
+  if (typeof body.mirrored === "boolean") set.mirrored = body.mirrored;
   if (typeof body.moduleId === "string" && body.moduleId.trim()) {
     const rec = body.moduleId.trim();
     const [target] = await db

--- a/lib/db/migrations/0019_layout_joins.sql
+++ b/lib/db/migrations/0019_layout_joins.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "layouts" ADD COLUMN "joins" jsonb;
+--> statement-breakpoint
+ALTER TABLE "module_layouts" ADD COLUMN "mirrored" boolean DEFAULT false NOT NULL;

--- a/lib/db/migrations/meta/0019_snapshot.json
+++ b/lib/db/migrations/meta/0019_snapshot.json
@@ -1,0 +1,1805 @@
+{
+  "id": "1595de0c-b4e0-4de2-8524-9bf427701e7e",
+  "prevId": "a2d2f3a4-aac1-4cbf-9c5b-2b5d6ae6e564",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.app_settings": {
+      "name": "app_settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.authority_log": {
+      "name": "authority_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "segment": {
+          "name": "segment",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "by_operator": {
+          "name": "by_operator",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "at": {
+          "name": "at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "authority_log_session_idx": {
+          "name": "authority_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "authority_log_session_id_sessions_id_fk": {
+          "name": "authority_log_session_id_sessions_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "authority_log_train_id_trains_id_fk": {
+          "name": "authority_log_train_id_trains_id_fk",
+          "tableFrom": "authority_log",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.block_occupancy": {
+      "name": "block_occupancy",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "block_id": {
+          "name": "block_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occupied": {
+          "name": "occupied",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "block_occupancy_session_block": {
+          "name": "block_occupancy_session_block",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "block_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "block_occupancy_session_idx": {
+          "name": "block_occupancy_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "block_occupancy_session_id_sessions_id_fk": {
+          "name": "block_occupancy_session_id_sessions_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_block_id_blocks_id_fk": {
+          "name": "block_occupancy_block_id_blocks_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "blocks",
+          "columnsFrom": [
+            "block_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "block_occupancy_train_id_trains_id_fk": {
+          "name": "block_occupancy_train_id_trains_id_fk",
+          "tableFrom": "block_occupancy",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.blocks": {
+      "name": "blocks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "module_record_number": {
+          "name": "module_record_number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "blocks_section_idx": {
+          "name": "blocks_section_idx",
+          "columns": [
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "blocks_section_id_sections_id_fk": {
+          "name": "blocks_section_id_sections_id_fk",
+          "tableFrom": "blocks",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.districts": {
+      "name": "districts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "districts_layout_idx": {
+          "name": "districts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "districts_layout_id_layouts_id_fk": {
+          "name": "districts_layout_id_layouts_id_fk",
+          "tableFrom": "districts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.layouts": {
+      "name": "layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'freemon'"
+        },
+        "control_point_districts": {
+          "name": "control_point_districts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "layout_control_points": {
+          "name": "layout_control_points",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "branches": {
+          "name": "branches",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joins": {
+          "name": "joins",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.module_layouts": {
+      "name": "module_layouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "module_id": {
+          "name": "module_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position_index": {
+          "name": "position_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "staging_end": {
+          "name": "staging_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "flipped": {
+          "name": "flipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "branch_id": {
+          "name": "branch_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mirrored": {
+          "name": "mirrored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "module_layouts_layout_idx": {
+          "name": "module_layouts_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "module_layouts_layout_id_layouts_id_fk": {
+          "name": "module_layouts_layout_id_layouts_id_fk",
+          "tableFrom": "module_layouts",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.operators": {
+      "name": "operators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_id": {
+          "name": "device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "joined_at": {
+          "name": "joined_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "left_at": {
+          "name": "left_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "operators_session_idx": {
+          "name": "operators_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "operators_device_idx": {
+          "name": "operators_device_idx",
+          "columns": [
+            {
+              "expression": "device_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "operators_session_id_sessions_id_fk": {
+          "name": "operators_session_id_sessions_id_fk",
+          "tableFrom": "operators",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.ops_log": {
+      "name": "ops_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payload": {
+          "name": "payload",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "ops_log_session_idx": {
+          "name": "ops_log_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "ops_log_session_id_sessions_id_fk": {
+          "name": "ops_log_session_id_sessions_id_fk",
+          "tableFrom": "ops_log",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_modules": {
+      "name": "repo_modules",
+      "schema": "",
+      "columns": {
+        "record_number": {
+          "name": "record_number",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "module_name": {
+          "name": "module_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "standard": {
+          "name": "standard",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "category": {
+          "name": "category",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_type": {
+          "name": "geometry_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_degrees": {
+          "name": "geometry_degrees",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "geometry_offset_inches": {
+          "name": "geometry_offset_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "length_total_inches": {
+          "name": "length_total_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mainline_length_inches": {
+          "name": "mainline_length_inches",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplate_count": {
+          "name": "endplate_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_mss": {
+          "name": "has_mss",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mss_type": {
+          "name": "mss_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "endplates": {
+          "name": "endplates",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tracks": {
+          "name": "tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "industries": {
+          "name": "industries",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematics": {
+          "name": "schematics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "schematic": {
+          "name": "schematic",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "upstream_updated_at": {
+          "name": "upstream_updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "removed_from_repo_at": {
+          "name": "removed_from_repo_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.section_allocations": {
+      "name": "section_allocations",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "section_id": {
+          "name": "section_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active": {
+          "name": "active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "allocated_by": {
+          "name": "allocated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allocated_at": {
+          "name": "allocated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "released_at": {
+          "name": "released_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "section_allocations_session_idx": {
+          "name": "section_allocations_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_train_idx": {
+          "name": "section_allocations_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "section_allocations_active_section": {
+          "name": "section_allocations_active_section",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "section_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"section_allocations\".\"active\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "section_allocations_session_id_sessions_id_fk": {
+          "name": "section_allocations_session_id_sessions_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_section_id_sections_id_fk": {
+          "name": "section_allocations_section_id_sections_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "sections",
+          "columnsFrom": [
+            "section_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "section_allocations_train_id_trains_id_fk": {
+          "name": "section_allocations_train_id_trains_id_fk",
+          "tableFrom": "section_allocations",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sections": {
+      "name": "sections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track": {
+          "name": "track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "derived_key": {
+          "name": "derived_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "sections_district_idx": {
+          "name": "sections_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sections_district_id_districts_id_fk": {
+          "name": "sections_district_id_districts_id_fk",
+          "tableFrom": "sections",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sessions": {
+      "name": "sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "venue": {
+          "name": "venue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "layout_config_id": {
+          "name": "layout_config_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_one_active": {
+          "name": "sessions_one_active",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"sessions\".\"status\" = 'active'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "sessions_layout_id_layouts_id_fk": {
+          "name": "sessions_layout_id_layouts_id_fk",
+          "tableFrom": "sessions",
+          "tableTo": "layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.staging_tracks": {
+      "name": "staging_tracks",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "layout_id": {
+          "name": "layout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "end": {
+          "name": "end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "assigned_train_id": {
+          "name": "assigned_train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "staging_tracks_layout_idx": {
+          "name": "staging_tracks_layout_idx",
+          "columns": [
+            {
+              "expression": "layout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "staging_tracks_layout_id_module_layouts_id_fk": {
+          "name": "staging_tracks_layout_id_module_layouts_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "module_layouts",
+          "columnsFrom": [
+            "layout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "staging_tracks_assigned_train_id_trains_id_fk": {
+          "name": "staging_tracks_assigned_train_id_trains_id_fk",
+          "tableFrom": "staging_tracks",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "assigned_train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.train_statuses": {
+      "name": "train_statuses",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "train_id": {
+          "name": "train_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'yard'"
+        },
+        "location_name": {
+          "name": "location_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "has_authority": {
+          "name": "has_authority",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "train_statuses_train_idx": {
+          "name": "train_statuses_train_idx",
+          "columns": [
+            {
+              "expression": "train_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "train_statuses_session_idx": {
+          "name": "train_statuses_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "train_statuses_train_id_trains_id_fk": {
+          "name": "train_statuses_train_id_trains_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "trains",
+          "columnsFrom": [
+            "train_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "train_statuses_session_id_sessions_id_fk": {
+          "name": "train_statuses_session_id_sessions_id_fk",
+          "tableFrom": "train_statuses",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.trains": {
+      "name": "trains",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "number": {
+          "name": "number",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_address": {
+          "name": "dcc_address",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dcc_type": {
+          "name": "dcc_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "owner": {
+          "name": "owner",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "consist_id": {
+          "name": "consist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "equipment_type": {
+          "name": "equipment_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "assigned_operator_id": {
+          "name": "assigned_operator_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "trains_session_idx": {
+          "name": "trains_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "trains_assigned_idx": {
+          "name": "trains_assigned_idx",
+          "columns": [
+            {
+              "expression": "assigned_operator_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "trains_session_id_sessions_id_fk": {
+          "name": "trains_session_id_sessions_id_fk",
+          "tableFrom": "trains",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnout_positions": {
+      "name": "turnout_positions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "turnout_id": {
+          "name": "turnout_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'normal'"
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnout_positions_session_turnout": {
+          "name": "turnout_positions_session_turnout",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "turnout_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "turnout_positions_session_idx": {
+          "name": "turnout_positions_session_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnout_positions_session_id_sessions_id_fk": {
+          "name": "turnout_positions_session_id_sessions_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "turnout_positions_turnout_id_turnouts_id_fk": {
+          "name": "turnout_positions_turnout_id_turnouts_id_fk",
+          "tableFrom": "turnout_positions",
+          "tableTo": "turnouts",
+          "columnsFrom": [
+            "turnout_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.turnouts": {
+      "name": "turnouts",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "district_id": {
+          "name": "district_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "turnouts_district_idx": {
+          "name": "turnouts_district_idx",
+          "columns": [
+            {
+              "expression": "district_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "turnouts_district_id_districts_id_fk": {
+          "name": "turnouts_district_id_districts_id_fk",
+          "tableFrom": "turnouts",
+          "tableTo": "districts",
+          "columnsFrom": [
+            "district_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/lib/db/migrations/meta/_journal.json
+++ b/lib/db/migrations/meta/_journal.json
@@ -134,6 +134,13 @@
       "when": 1783565130189,
       "tag": "0018_branch_spines",
       "breakpoints": true
+    },
+    {
+      "idx": 19,
+      "version": "7",
+      "when": 1783651530189,
+      "tag": "0019_layout_joins",
+      "breakpoints": true
     }
   ]
 }

--- a/lib/db/schema.ts
+++ b/lib/db/schema.ts
@@ -68,6 +68,10 @@ export const layouts = pgTable("layouts", {
   // branch spines attached at a junction endplate of a placed module. The
   // ordered module_layouts rows with branch_id null remain the main spine.
   branches: jsonb("branches"),
+  // Explicit endplate joins (#175): [{id, a:{placementId,endplateId},
+  // b:{...}}] beyond the spine's implicit B→A chaining — closing a circuit,
+  // connecting a loop's second endplate, any endplate-to-any-endplate.
+  joins: jsonb("joins"),
   createdAt: timestamp("created_at", { withTimezone: true })
     .notNull()
     .defaultNow(),
@@ -231,6 +235,10 @@ export const moduleLayouts = pgTable(
     // in layouts.branches this placement belongs to. positionIndex orders
     // within its own spine.
     branchId: text("branch_id"),
+    // Mirrored/flipped placement (#175): the footprint solver reflects the
+    // module's poses (Free-mo modules are two-sided). Distinct from `flipped`
+    // (the older curve-direction hint).
+    mirrored: boolean("mirrored").notNull().default(false),
   },
   (t) => [index("module_layouts_layout_idx").on(t.layoutId)],
 );

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -41,6 +41,13 @@ import {
   type BranchDef,
   type SpannedModule,
 } from "@/lib/track/layoutControlPoints";
+import {
+  layoutJoins,
+  asJoins,
+  joinStatus,
+  type LayoutJoin,
+  type JoinStatus,
+} from "@/lib/track/layoutJoins";
 
 // ---- Authoring input/output shapes ---------------------------------------
 
@@ -98,6 +105,8 @@ export interface LayoutModule {
   status: string | null;
   /** Spine this placement sits on (#170): null = main spine. */
   branchId: string | null;
+  /** Mirrored/flipped placement (#175). */
+  mirrored: boolean;
 }
 
 export interface LayoutTree extends LayoutRow {
@@ -105,6 +114,9 @@ export interface LayoutTree extends LayoutRow {
   modules: LayoutModule[];
   /** Branch spines (#170): defs from layouts.branches with their placements. */
   branchSpines: (BranchDef & { modules: LayoutModule[] })[];
+  /** Endplate joins (#175): implicit spine joins + stored explicit ones, each
+   * tagged with its compatibility status. */
+  joins: (LayoutJoin & { status: JoinStatus })[];
   districts: (DistrictRow & {
     sections: (SectionRow & { blocks: BlockRow[] })[];
     turnouts: TurnoutRow[];
@@ -162,14 +174,31 @@ export function buildLayoutTree(
   }
   const sorted = [...moduleRows].sort((a, b) => a.positionIndex - b.positionIndex);
   const branchDefs = asBranches((layout as { branches?: unknown }).branches);
+  const mainSpine = sorted.filter((m) => m.branchId == null);
+  const branchSpines = branchDefs.map((b) => ({
+    ...b,
+    modules: sorted.filter((m) => m.branchId === b.id),
+  }));
+  // Endplate joins (#175): implicit spine chaining + stored explicit joins,
+  // each tagged with per-join compatibility.
+  const byId = new Map(sorted.map((m) => [m.id, m]));
+  const joins = layoutJoins(
+    [
+      { branchId: null, modules: mainSpine },
+      ...branchSpines.map((b) => ({
+        branchId: b.id,
+        origin: b.origin,
+        modules: b.modules,
+      })),
+    ],
+    asJoins((layout as { joins?: unknown }).joins),
+  ).map((j) => ({ ...j, status: joinStatus(j, byId) }));
   return {
     ...layout,
     // Main spine = placements without a branchId (#170).
-    modules: sorted.filter((m) => m.branchId == null),
-    branchSpines: branchDefs.map((b) => ({
-      ...b,
-      modules: sorted.filter((m) => m.branchId === b.id),
-    })),
+    modules: mainSpine,
+    branchSpines,
+    joins,
     districts: [...districtRows].sort(byPos).map((d) => ({
       ...d,
       sections: (sectionsByDistrict.get(d.id) ?? []).sort(byPos).map((s) => ({
@@ -276,6 +305,11 @@ class TrackModel {
       .update(layouts)
       .set({ controlPointDistricts: map })
       .where(eq(layouts.id, layoutId));
+  }
+
+  /** Replace the layout's explicit endplate joins (#175). */
+  async setJoins(layoutId: string, joins: LayoutJoin[]): Promise<void> {
+    await db.update(layouts).set({ joins }).where(eq(layouts.id, layoutId));
   }
 
   /** Replace the layout's branch-spine definitions (#170). Placements on a
@@ -434,6 +468,7 @@ class TrackModel {
         removedFromRepoAt: repoModules.removedFromRepoAt,
         status: repoModules.status,
         branchId: moduleLayouts.branchId,
+        mirrored: moduleLayouts.mirrored,
       })
       .from(moduleLayouts)
       .leftJoin(repoModules, eq(moduleLayouts.moduleId, repoModules.recordNumber))

--- a/lib/server/__tests__/TrackModel.test.ts
+++ b/lib/server/__tests__/TrackModel.test.ts
@@ -37,6 +37,7 @@ describe("buildLayoutTree (#80)", () => {
     controlPointDistricts: null,
     layoutControlPoints: null,
     branches: null,
+    joins: null,
     createdAt: new Date(),
   };
 

--- a/lib/track/__tests__/layoutJoins.test.ts
+++ b/lib/track/__tests__/layoutJoins.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from "vitest";
+import {
+  moduleEndplates,
+  implicitJoins,
+  layoutJoins,
+  joinStatus,
+  joinKey,
+  asJoins,
+  type JoinSpine,
+  type JoinPlacement,
+} from "../layoutJoins";
+
+const mod = (
+  id: string,
+  positionIndex: number,
+  endplates: { id: string; config?: "single" | "double" }[] = [
+    { id: "A" },
+    { id: "B" },
+  ],
+): JoinPlacement => ({
+  id,
+  positionIndex,
+  moduleId: id,
+  schematic: {
+    version: 1,
+    endplates: endplates.map((e) => ({
+      id: e.id,
+      tracks: [{ trackId: "main", lane: 0, config: e.config ?? "single" }],
+    })),
+    tracks: [{ id: "main", role: "main", lane: 0 }],
+  },
+});
+
+describe("moduleEndplates", () => {
+  it("reads endplate ids from the doc, defaulting to A/B", () => {
+    expect(moduleEndplates(mod("p1", 0, [{ id: "A" }, { id: "B" }, { id: "C" }]))).toEqual(["A", "B", "C"]);
+    expect(moduleEndplates({ id: "p9", schematic: null })).toEqual(["A", "B"]);
+  });
+});
+
+describe("implicitJoins", () => {
+  it("chains consecutive main-spine modules B→A", () => {
+    const joins = implicitJoins([
+      { branchId: null, modules: [mod("p1", 0), mod("p2", 1), mod("p3", 2)] },
+    ]);
+    expect(joins.map((j) => `${j.a.placementId}:${j.a.endplateId}-${j.b.placementId}:${j.b.endplateId}`)).toEqual([
+      "p1:B-p2:A",
+      "p2:B-p3:A",
+    ]);
+    expect(joins.every((j) => j.implicit)).toBe(true);
+  });
+
+  it("attaches a branch at its origin endplate ↔ the branch's first A", () => {
+    const spines: JoinSpine[] = [
+      { branchId: null, modules: [mod("p1", 0), mod("jct", 1, [{ id: "A" }, { id: "B" }, { id: "C" }])] },
+      { branchId: "br", origin: { placementId: "jct", endplateId: "C" }, modules: [mod("b1", 0)] },
+    ];
+    const joins = implicitJoins(spines);
+    expect(joins.some((j) => joinKey(j) === joinKey({ a: { placementId: "jct", endplateId: "C" }, b: { placementId: "b1", endplateId: "A" } }))).toBe(true);
+  });
+});
+
+describe("layoutJoins", () => {
+  const spines: JoinSpine[] = [
+    { branchId: null, modules: [mod("p1", 0), mod("p2", 1)] },
+  ];
+
+  it("merges stored explicit joins and drops ones restating an implicit join", () => {
+    const stored = [
+      // circuit closure: p2's B back to p1's A — genuinely new
+      { id: "x1", a: { placementId: "p2", endplateId: "B" }, b: { placementId: "p1", endplateId: "A" } },
+      // restates the implicit p1:B-p2:A — dropped
+      { id: "x2", a: { placementId: "p2", endplateId: "A" }, b: { placementId: "p1", endplateId: "B" } },
+    ];
+    const joins = layoutJoins(spines, stored);
+    expect(joins).toHaveLength(2); // 1 implicit + 1 new explicit
+    const explicit = joins.find((j) => !j.implicit)!;
+    expect(joinKey(explicit)).toBe(joinKey({ a: { placementId: "p2", endplateId: "B" }, b: { placementId: "p1", endplateId: "A" } }));
+  });
+});
+
+describe("joinStatus", () => {
+  const byId = new Map(
+    [
+      mod("p1", 0, [{ id: "A" }, { id: "B", config: "double" }]),
+      mod("p2", 1, [{ id: "A", config: "double" }, { id: "B" }]),
+      mod("p3", 2, [{ id: "A" }, { id: "B" }]),
+    ].map((m) => [m.id, m]),
+  );
+
+  it("ok when both endplates share a track config", () => {
+    expect(joinStatus({ a: { placementId: "p1", endplateId: "B" }, b: { placementId: "p2", endplateId: "A" } }, byId)).toBe("ok"); // double-double
+    expect(joinStatus({ a: { placementId: "p2", endplateId: "B" }, b: { placementId: "p3", endplateId: "A" } }, byId)).toBe("ok"); // single-single
+  });
+
+  it("mismatch across single↔double", () => {
+    expect(joinStatus({ a: { placementId: "p1", endplateId: "B" }, b: { placementId: "p3", endplateId: "A" } }, byId)).toBe("mismatch"); // double-single
+  });
+
+  it("dangling when a placement or endplate is missing", () => {
+    expect(joinStatus({ a: { placementId: "gone", endplateId: "B" }, b: { placementId: "p3", endplateId: "A" } }, byId)).toBe("dangling");
+    expect(joinStatus({ a: { placementId: "p3", endplateId: "Z" }, b: { placementId: "p1", endplateId: "A" } }, byId)).toBe("dangling");
+  });
+});
+
+describe("asJoins", () => {
+  it("parses stored joins and tolerates junk", () => {
+    expect(asJoins(null)).toEqual([]);
+    expect(
+      asJoins([
+        { id: "j1", a: { placementId: "p1", endplateId: "B" }, b: { placementId: "p2", endplateId: "A" } },
+        { a: { placementId: "p3", endplateId: "A" } }, // missing b → dropped
+        "junk",
+      ]),
+    ).toEqual([
+      { id: "j1", a: { placementId: "p1", endplateId: "B" }, b: { placementId: "p2", endplateId: "A" } },
+    ]);
+  });
+});

--- a/lib/track/layoutJoins.ts
+++ b/lib/track/layoutJoins.ts
@@ -1,0 +1,172 @@
+/**
+ * Layout joins (#175 phase 2) — endplate-to-endplate connections between module
+ * placements. Every endplate is the same standard Free-moN interface, so a join
+ * is just a pair of endplate refs; the footprint solver (phase 3) walks them.
+ *
+ * The chain + branch spines GENERATE joins implicitly (consecutive modules mate
+ * B→A; a branch's first module mates the junction endplate). Those are derived,
+ * never stored. Explicit joins — stored on layouts.branches' sibling
+ * layouts.joins — add what the spine can't imply: closing a circuit (last
+ * module's endplate back to the first), connecting a loop module's second
+ * endplate, or any endplate-to-any-endplate cross-connection.
+ *
+ * Pure so it can be unit-tested; TrackModel assembles the inputs.
+ */
+import { asModuleSchematic } from "./moduleSchematic";
+
+export interface EndplateRef {
+  /** layout_modules row id. */
+  placementId: string;
+  /** Endplate id on that module ("A", "B", "C"…). */
+  endplateId: string;
+}
+export interface LayoutJoin {
+  id: string;
+  a: EndplateRef;
+  b: EndplateRef;
+  /** True when derived from the spine order (not user-stored). */
+  implicit?: boolean;
+}
+
+export interface JoinPlacement {
+  /** layout_modules row id. */
+  id: string;
+  moduleId?: string | null;
+  moduleName?: string | null;
+  positionIndex?: number;
+  schematic?: unknown;
+}
+export interface JoinSpine {
+  /** null = main spine, otherwise a branch id. */
+  branchId: string | null;
+  /** Where a branch attaches: a placement + endplate on another spine. */
+  origin?: { placementId: string; endplateId: string };
+  modules: JoinPlacement[];
+}
+
+/** Endplate ids a placement exposes — from its schematic doc, or A/B by default
+ * (a loop module exposes just A, or A+B for an interchange loop). */
+export function moduleEndplates(m: JoinPlacement): string[] {
+  const doc = asModuleSchematic(m.schematic);
+  const ids = (doc?.endplates ?? [])
+    .map((e) => e.id)
+    .filter((id): id is string => typeof id === "string" && id.length > 0);
+  return ids.length ? ids : ["A", "B"];
+}
+
+const refKey = (r: EndplateRef) => `${r.placementId}:${r.endplateId}`;
+/** Order-independent identity of a join (endplate pair). */
+export function joinKey(j: { a: EndplateRef; b: EndplateRef }): string {
+  return [refKey(j.a), refKey(j.b)].sort().join("|");
+}
+
+/**
+ * Joins implied by the spine graph: consecutive modules on a spine mate B→A,
+ * and a branch's first module mates the junction endplate it originates from.
+ */
+export function implicitJoins(spines: JoinSpine[]): LayoutJoin[] {
+  const out: LayoutJoin[] = [];
+  for (const s of spines) {
+    const ordered = [...s.modules].sort(
+      (a, b) => (a.positionIndex ?? 0) - (b.positionIndex ?? 0),
+    );
+    // Branch attaches at its origin endplate ↔ the branch's first module's A.
+    if (s.origin && ordered[0]) {
+      out.push({
+        id: `imp:${s.origin.placementId}:${s.origin.endplateId}-${ordered[0].id}:A`,
+        a: { placementId: s.origin.placementId, endplateId: s.origin.endplateId },
+        b: { placementId: ordered[0].id, endplateId: "A" },
+        implicit: true,
+      });
+    }
+    for (let i = 0; i < ordered.length - 1; i++) {
+      out.push({
+        id: `imp:${ordered[i].id}:B-${ordered[i + 1].id}:A`,
+        a: { placementId: ordered[i].id, endplateId: "B" },
+        b: { placementId: ordered[i + 1].id, endplateId: "A" },
+        implicit: true,
+      });
+    }
+  }
+  return out;
+}
+
+/**
+ * Every join in the layout: the implicit spine joins plus the stored explicit
+ * ones, de-duplicated by endplate pair (implicit wins). Explicit joins that
+ * merely restate an implied connection are dropped.
+ */
+export function layoutJoins(
+  spines: JoinSpine[],
+  stored: LayoutJoin[] = [],
+): LayoutJoin[] {
+  const implicit = implicitJoins(spines);
+  const seen = new Set(implicit.map(joinKey));
+  const out = [...implicit];
+  for (const j of stored) {
+    const k = joinKey(j);
+    if (seen.has(k)) continue;
+    seen.add(k);
+    out.push({ ...j, implicit: false });
+  }
+  return out;
+}
+
+export type JoinStatus = "ok" | "mismatch" | "unknown" | "dangling";
+
+/**
+ * Endplate track config (single/double) for a ref, from the module's schematic
+ * doc — used for join compatibility. Null when unknown.
+ */
+export function endplateConfig(
+  m: JoinPlacement | undefined,
+  endplateId: string,
+): "single" | "double" | null {
+  if (!m) return null;
+  const doc = asModuleSchematic(m.schematic);
+  const ep = (doc?.endplates ?? []).find((e) => e.id === endplateId);
+  const cfg = ep?.tracks?.[0]?.config;
+  return cfg === "double" ? "double" : cfg === "single" ? "single" : null;
+}
+
+/** Per-join compatibility: both endplates must exist and share a track config. */
+export function joinStatus(
+  join: { a: EndplateRef; b: EndplateRef },
+  byId: Map<string, JoinPlacement>,
+): JoinStatus {
+  const ma = byId.get(join.a.placementId);
+  const mb = byId.get(join.b.placementId);
+  if (!ma || !mb) return "dangling";
+  if (
+    !moduleEndplates(ma).includes(join.a.endplateId) ||
+    !moduleEndplates(mb).includes(join.b.endplateId)
+  ) {
+    return "dangling";
+  }
+  const ca = endplateConfig(ma, join.a.endplateId);
+  const cb = endplateConfig(mb, join.b.endplateId);
+  if (ca == null || cb == null) return "unknown";
+  return ca === cb ? "ok" : "mismatch";
+}
+
+/** Parse a jsonb value into stored joins, tolerating junk. */
+export function asJoins(x: unknown): LayoutJoin[] {
+  if (!Array.isArray(x)) return [];
+  const out: LayoutJoin[] = [];
+  const ref = (v: unknown): EndplateRef | null => {
+    if (!v || typeof v !== "object") return null;
+    const r = v as Record<string, unknown>;
+    if (typeof r.placementId !== "string" || typeof r.endplateId !== "string")
+      return null;
+    return { placementId: r.placementId, endplateId: r.endplateId };
+  };
+  for (const v of x) {
+    if (!v || typeof v !== "object") continue;
+    const j = v as Record<string, unknown>;
+    const a = ref(j.a);
+    const b = ref(j.b);
+    if (!a || !b) continue;
+    out.push({ id: typeof j.id === "string" ? j.id : joinKey({ a, b }), a, b });
+  }
+  return out;
+}


### PR DESCRIPTION
Phase 2 of #175 — the layout becomes an **endplate-join graph**. Every endplate is the same standard Free-moN interface, so a join is a pair of endplate refs.

- **`lib/track/layoutJoins.ts`** (pure, 8 tests): `implicitJoins()` derives the spine's B→A chaining + branch-origin joins; `layoutJoins()` merges stored explicit joins (dedup by endplate pair, implicit wins); `joinStatus()` flags per-join compatibility (ok / mismatch / unknown / dangling); `asJoins()` parses.
- `layouts.joins` jsonb + `module_layouts.mirrored` bool (migration 0019). `getLayout` returns `tree.joins` (implicit + explicit, each with status). PATCH `/api/layouts` accepts `joins`; PATCH `/api/modules` accepts `mirrored`.
- **Layout Builder**: an *Endplate joins* section — spine joins auto-listed with a **spine** badge + compatibility dot; an **add-join form to close a circuit** or link any two endplates; a per-module mirror (⇋) toggle.

The chain + branch UX is unchanged — it just *generates* joins now. Foundation for the phase-3 footprint solver (rigid-transform graph walk + closure report).

**Verified in the browser**: a 3-module layout shows 2 implicit B→A joins (ok); an explicit last-B ↔ first-A join closes the circuit; mirror persists. 145 tests + build green.

Known pre-existing (not from this PR, follow-up spawned): repeated placements of the *same* module collide on control-point keys — orthogonal to joins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)