### PR TITLE
feat: footprint solver — accurate layout map from the join graph (#175 phase 3)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -14,6 +14,7 @@ import {
   MODULE_DRAG_MIME,
 } from "@/components/layout/LayoutSchematic";
 import { OperationsSchematic } from "@/components/layout/OperationsSchematic";
+import { FootprintMap } from "@/components/layout/FootprintMap";
 import {
   layoutControlPoints,
   deriveSections,
@@ -72,6 +73,7 @@ interface LayoutModuleNode {
   hasMss: boolean | null;
   geometryType: string | null;
   geometryDegrees: number | null;
+  geometryOffsetInches: number | null;
   flipped: boolean;
   endplates: { label?: string | null; track_config?: string | null }[] | null;
   schematic: unknown;
@@ -1276,6 +1278,31 @@ export default function AdminLayouts() {
                               modules={tree.modules}
                               districts={tree.districts}
                               onDropModule={(rec) => dropAddModule(l.id, rec)}
+                            />
+                          </div>
+
+                          {/* Solved layout map (#175 phase 3) */}
+                          <div>
+                            <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
+                              Layout map (solved)
+                            </div>
+                            <FootprintMap
+                              modules={[
+                                ...tree.modules,
+                                ...tree.branchSpines.flatMap((b) => b.modules),
+                              ].map((m) => ({
+                                id: m.id,
+                                moduleName: m.moduleName,
+                                moduleId: m.moduleId,
+                                lengthTotalInches: m.lengthTotalInches,
+                                mainlineLengthInches: m.mainlineLengthInches,
+                                geometryType: m.geometryType,
+                                geometryDegrees: m.geometryDegrees,
+                                geometryOffsetInches: m.geometryOffsetInches,
+                                mirrored: m.mirrored,
+                                schematic: m.schematic,
+                              }))}
+                              joins={tree.joins}
                             />
                           </div>
 

--- a/components/layout/FootprintMap.tsx
+++ b/components/layout/FootprintMap.tsx
@@ -1,0 +1,134 @@
+/**
+ * FootprintMap (#175 phase 3) — the accurate to-scale layout map, solved from
+ * the endplate-join graph (composeFootprint). Each module's centre-line is
+ * drawn in world coordinates; endplates are ticks; closures report the gap a
+ * setup crew must distribute across joints.
+ */
+"use client";
+
+import { useMemo } from "react";
+import {
+  composeFootprint,
+  type FootprintModule,
+} from "@/lib/track/footprint";
+import type { LayoutJoin } from "@/lib/track/layoutJoins";
+
+export function FootprintMap({
+  modules,
+  joins,
+  colorFor,
+}: {
+  modules: FootprintModule[];
+  joins: LayoutJoin[];
+  /** Optional per-placement stroke (district colour). */
+  colorFor?: (placementId: string) => string | undefined;
+}) {
+  const fp = useMemo(() => composeFootprint(modules, joins), [modules, joins]);
+
+  if (modules.length === 0) {
+    return (
+      <div className="flex h-24 items-center justify-center rounded-md border border-dashed border-slate-700 text-xs text-slate-600">
+        Add modules to solve the layout map.
+      </div>
+    );
+  }
+
+  const { minX, minY, maxX, maxY } = fp.bbox;
+  const pad = 12;
+  const w = Math.max(1, maxX - minX);
+  const h = Math.max(1, maxY - minY);
+  // SVG y is down; the layout uses y-up, so flip vertically.
+  const vb = `${minX - pad} ${-(maxY + pad)} ${w + pad * 2} ${h + pad * 2}`;
+  const fy = (y: number) => -y;
+  const feet = (n: number) => `${Math.round((n / 12) * 10) / 10} ft`;
+
+  const totalGap = fp.closures.reduce((s, c) => s + c.gapInches, 0);
+  const nJoints = joins.length || 1;
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
+        <span>Layout map · solved from joins</span>
+        <span>
+          {feet(w)} × {feet(h)}
+        </span>
+      </div>
+      <svg
+        viewBox={vb}
+        width="100%"
+        height="240"
+        preserveAspectRatio="xMidYMid meet"
+        className="rounded bg-slate-950/40"
+      >
+        {/* Module centre-lines */}
+        {fp.placed.map((m) => {
+          const stroke = colorFor?.(m.id) ?? "#64748b";
+          const pts = m.centerline.map((p) => `${p.x},${fy(p.y)}`).join(" ");
+          return (
+            <g key={m.id}>
+              <polyline
+                points={pts}
+                fill="none"
+                stroke={stroke}
+                strokeWidth={1.6}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+              >
+                <title>{m.moduleName ?? m.id}</title>
+              </polyline>
+              {/* Endplate ticks */}
+              {m.endplates.map((e) => {
+                const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
+                const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
+                const half = 3;
+                return (
+                  <line
+                    key={e.id}
+                    x1={e.x - nx * half}
+                    y1={fy(e.y - ny * half)}
+                    x2={e.x + nx * half}
+                    y2={fy(e.y + ny * half)}
+                    stroke={stroke}
+                    strokeWidth={1.2}
+                  >
+                    <title>{`${m.moduleName ?? m.id} · endplate ${e.id}`}</title>
+                  </line>
+                );
+              })}
+            </g>
+          );
+        })}
+      </svg>
+
+      {/* Closure report */}
+      {fp.closures.length > 0 && (
+        <p className="mt-1 text-xs text-slate-400">
+          {fp.closures.map((c, i) => {
+            const clean = c.gapInches < 0.25 && c.gapDegrees < 0.5;
+            return (
+              <span key={c.joinId} className={clean ? "text-emerald-400" : "text-amber-400"}>
+                {i > 0 && " · "}
+                {clean
+                  ? "Ring closes cleanly"
+                  : `Closure gap ${c.gapInches.toFixed(1)} in / ${c.gapDegrees.toFixed(1)}°`}
+              </span>
+            );
+          })}
+          {totalGap >= 0.25 && (
+            <span className="text-slate-500">
+              {" "}
+              — distributable over {nJoints} joint{nJoints > 1 ? "s" : ""} (
+              {(totalGap / nJoints).toFixed(2)} in each)
+            </span>
+          )}
+        </p>
+      )}
+      {fp.unplaced.length > 0 && (
+        <p className="mt-1 text-xs text-slate-500">
+          {fp.unplaced.length} module{fp.unplaced.length > 1 ? "s" : ""} not
+          connected by any join.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -96,6 +96,7 @@ export interface LayoutModule {
   hasMss: boolean | null;
   geometryType: string | null;
   geometryDegrees: number | null;
+  geometryOffsetInches: number | null;
   flipped: boolean;
   endplates: unknown;
   schematic: unknown;
@@ -463,6 +464,7 @@ class TrackModel {
         hasMss: repoModules.hasMss,
         geometryType: repoModules.geometryType,
         geometryDegrees: repoModules.geometryDegrees,
+        geometryOffsetInches: repoModules.geometryOffsetInches,
         endplates: repoModules.endplates,
         schematic: repoModules.schematic,
         removedFromRepoAt: repoModules.removedFromRepoAt,

--- a/lib/track/__tests__/footprint.test.ts
+++ b/lib/track/__tests__/footprint.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from "vitest";
+import { composeFootprint, type FootprintModule } from "../footprint";
+import type { LayoutJoin } from "../layoutJoins";
+
+const straight = (id: string, L = 100): FootprintModule => ({
+  id,
+  moduleName: id,
+  lengthTotalInches: L,
+  geometryType: "straight",
+});
+const corner = (id: string, L = 100): FootprintModule => ({
+  id,
+  moduleName: id,
+  lengthTotalInches: L,
+  geometryType: "corner_90",
+});
+const join = (aP: string, aE: string, bP: string, bE: string): LayoutJoin => ({
+  id: `${aP}:${aE}-${bP}:${bE}`,
+  a: { placementId: aP, endplateId: aE },
+  b: { placementId: bP, endplateId: bE },
+});
+const ep = (m: { endplates: { id: string; x: number; y: number }[] }, id: string) =>
+  m.endplates.find((e) => e.id === id)!;
+
+describe("composeFootprint", () => {
+  it("chains two straights collinearly (B→A)", () => {
+    const fp = composeFootprint(
+      [straight("m1"), straight("m2")],
+      [join("m1", "B", "m2", "A")],
+    );
+    expect(fp.unplaced).toEqual([]);
+    const m1 = fp.placed.find((p) => p.id === "m1")!;
+    const m2 = fp.placed.find((p) => p.id === "m2")!;
+    expect(ep(m1, "A")).toMatchObject({ x: 0, y: 0 });
+    // m2 sits end-to-end: its A at m1's B (100,0), its B at (200,0).
+    expect(ep(m2, "A").x).toBeCloseTo(100, 3);
+    expect(ep(m2, "A").y).toBeCloseTo(0, 3);
+    expect(ep(m2, "B").x).toBeCloseTo(200, 3);
+    expect(ep(m2, "B").y).toBeCloseTo(0, 3);
+    expect(fp.bbox.maxX).toBeCloseTo(200, 3);
+    expect(fp.closures).toEqual([]);
+  });
+
+  it("a corner turns the following module 90°", () => {
+    const fp = composeFootprint(
+      [corner("c1"), straight("m2")],
+      [join("c1", "B", "m2", "A")],
+    );
+    const r = 100 / (Math.PI / 2);
+    const c1 = fp.placed.find((p) => p.id === "c1")!;
+    const m2 = fp.placed.find((p) => p.id === "m2")!;
+    // corner exits at (r, r) heading north; the straight then runs +100 in Y.
+    expect(ep(c1, "B").x).toBeCloseTo(r, 2);
+    expect(ep(c1, "B").y).toBeCloseTo(r, 2);
+    expect(ep(m2, "B").x).toBeCloseTo(r, 2);
+    expect(ep(m2, "B").y).toBeCloseTo(r + 100, 2);
+  });
+
+  it("four 90° corners close into a loop with ~zero closure error", () => {
+    const mods = [corner("c1"), corner("c2"), corner("c3"), corner("c4")];
+    const joins = [
+      join("c1", "B", "c2", "A"),
+      join("c2", "B", "c3", "A"),
+      join("c3", "B", "c4", "A"),
+      join("c4", "B", "c1", "A"), // close the ring
+    ];
+    const fp = composeFootprint(mods, joins);
+    expect(fp.placed).toHaveLength(4);
+    expect(fp.closures).toHaveLength(1);
+    expect(fp.closures[0].gapInches).toBeCloseTo(0, 2);
+    expect(fp.closures[0].gapDegrees).toBeCloseTo(0, 2);
+  });
+
+  it("reports a real closure gap when the ring doesn't meet", () => {
+    // two straights joined at BOTH ends can't loop — 200in gap.
+    const fp = composeFootprint(
+      [straight("m1"), straight("m2")],
+      [join("m1", "B", "m2", "A"), join("m2", "B", "m1", "A")],
+    );
+    expect(fp.closures).toHaveLength(1);
+    expect(fp.closures[0].gapInches).toBeCloseTo(200, 2);
+  });
+
+  it("a mirrored corner curves the other way", () => {
+    const normal = composeFootprint([corner("c")], []);
+    const mirrored = composeFootprint([{ ...corner("c"), mirrored: true }], []);
+    const r = 100 / (Math.PI / 2);
+    expect(ep(normal.placed[0], "B").y).toBeCloseTo(r, 2); // north
+    expect(ep(mirrored.placed[0], "B").y).toBeCloseTo(-r, 2); // south
+  });
+
+  it("disconnected modules are reported as unplaced", () => {
+    const fp = composeFootprint([straight("m1"), straight("island")], [
+      // island has no join
+    ]);
+    // both seed their own component at origin, so both ARE placed
+    expect(fp.unplaced).toEqual([]);
+    expect(fp.placed).toHaveLength(2);
+  });
+});

--- a/lib/track/footprint.ts
+++ b/lib/track/footprint.ts
@@ -1,0 +1,314 @@
+/**
+ * Footprint solver (#175 phase 3) — compose a layout's modules into an accurate
+ * to-scale 2D map by walking the endplate-join graph and stacking each module's
+ * rigid transform.
+ *
+ * Each module's endplate poses (module-local (x, y, heading) at the track point)
+ * come from the shared package's deriveEndplatePoses. A join says two endplates
+ * are the same physical point facing opposite ways; that constraint places a
+ * neighbour relative to an already-placed module. Cyclic joins (a closed
+ * circuit) don't place anything new — the gap between where the two ends land
+ * is the closure error, reported so a setup crew can distribute it across joints.
+ *
+ * Pure so it can be unit-tested; the SVG component just draws the result.
+ */
+import {
+  deriveEndplatePoses,
+  type EndplatePose,
+} from "@willcgage/module-schematic";
+import {
+  layoutJoins,
+  type JoinSpine,
+  type LayoutJoin,
+} from "./layoutJoins";
+import { asModuleSchematic } from "./moduleSchematic";
+
+export interface Pt {
+  x: number;
+  y: number;
+}
+
+/** A module placement's inputs for the solver. */
+export interface FootprintModule {
+  /** layout_modules row id. */
+  id: string;
+  moduleName?: string | null;
+  moduleId?: string | null;
+  lengthTotalInches?: number | null;
+  mainlineLengthInches?: number | null;
+  geometryType?: string | null;
+  geometryDegrees?: number | null;
+  geometryOffsetInches?: number | null;
+  /** Mirror the module (reflection) — Free-mo modules are two-sided. */
+  mirrored?: boolean;
+  /** The schematic doc (for branch endplates + endplate configs). */
+  schematic?: unknown;
+}
+
+/** A 2D rigid transform: rotate by `rot`° (after an optional Y reflection),
+ * then translate. */
+interface Transform {
+  rot: number;
+  tx: number;
+  ty: number;
+  mirror: boolean;
+}
+
+export interface PlacedModule {
+  id: string;
+  moduleName: string | null;
+  /** Endplate world poses (x, y in layout inches, heading = outward normal°). */
+  endplates: { id: string; x: number; y: number; heading: number }[];
+  /** Module centre-line in world coords (main track A→B). */
+  centerline: Pt[];
+}
+
+export interface ClosureError {
+  joinId: string;
+  /** Distance between where the two joined ends actually land (inches). */
+  gapInches: number;
+  /** How far off the ideal 180° the two outward normals are (degrees). */
+  gapDegrees: number;
+}
+
+export interface Footprint {
+  placed: PlacedModule[];
+  bbox: { minX: number; minY: number; maxX: number; maxY: number };
+  closures: ClosureError[];
+  /** Placement ids the join graph never reached (disconnected). */
+  unplaced: string[];
+}
+
+const DEG = Math.PI / 180;
+const norm180 = (d: number) => {
+  let x = ((d + 180) % 360) - 180;
+  if (x <= -180) x += 360;
+  return x;
+};
+
+function applyPoint(t: Transform, p: Pt): Pt {
+  const py = t.mirror ? -p.y : p.y;
+  const c = Math.cos(t.rot * DEG);
+  const s = Math.sin(t.rot * DEG);
+  return {
+    x: t.tx + p.x * c - py * s,
+    y: t.ty + p.x * s + py * c,
+  };
+}
+function applyHeading(t: Transform, h: number): number {
+  return t.rot + (t.mirror ? -h : h);
+}
+
+/** Module-local centre-line (main A→B), sampling arcs, mirror-agnostic. */
+function localCenterline(m: FootprintModule): Pt[] {
+  const L =
+    (m.mainlineLengthInches && m.mainlineLengthInches > 0
+      ? m.mainlineLengthInches
+      : m.lengthTotalInches && m.lengthTotalInches > 0
+        ? m.lengthTotalInches
+        : 24) || 24;
+  const gt = m.geometryType;
+  if (gt === "dead_end") return [{ x: 0, y: 0 }];
+  if (gt === "offset") {
+    return [
+      { x: 0, y: 0 },
+      { x: L, y: m.geometryOffsetInches ?? 0 },
+    ];
+  }
+  const turn =
+    gt === "corner_45"
+      ? 45
+      : gt === "corner_90"
+        ? 90
+        : gt === "curve"
+          ? (m.geometryDegrees ?? 0)
+          : 0;
+  if (turn === 0)
+    return [
+      { x: 0, y: 0 },
+      { x: L, y: 0 },
+    ];
+  const t = turn * DEG;
+  const r = L / t;
+  const steps = 12;
+  const pts: Pt[] = [];
+  for (let i = 0; i <= steps; i++) {
+    const a = (t * i) / steps;
+    pts.push({ x: r * Math.sin(a), y: r * (1 - Math.cos(a)) });
+  }
+  return pts;
+}
+
+/** Assemble the deriveEndplatePoses input for a module. */
+function poseInput(m: FootprintModule) {
+  const doc = asModuleSchematic(m.schematic);
+  const epById = new Map((doc?.endplates ?? []).map((e) => [e.id, e]));
+  const cfg = (id: string): "single" | "double" =>
+    epById.get(id)?.tracks?.[0]?.config === "double" ? "double" : "single";
+  const branches = (doc?.endplates ?? [])
+    .filter((e) => e.id !== "A" && e.id !== "B" && e.at)
+    .map((e) => ({
+      id: e.id,
+      atPos: e.at!.pos,
+      side: e.at!.side === "down" ? ("down" as const) : ("up" as const),
+      config: cfg(e.id),
+    }));
+  return {
+    lengthInches:
+      (m.mainlineLengthInches && m.mainlineLengthInches > 0
+        ? m.mainlineLengthInches
+        : m.lengthTotalInches && m.lengthTotalInches > 0
+          ? m.lengthTotalInches
+          : 24) || 24,
+    geometryType: m.geometryType,
+    geometryDegrees: m.geometryDegrees,
+    geometryOffsetInches: m.geometryOffsetInches,
+    endplateConfigs: [cfg("A"), cfg("B")],
+    branches,
+  };
+}
+
+/**
+ * Solve the layout footprint: place a root module at the origin, then BFS the
+ * joins placing each neighbour by the mating constraint (shared point, opposite
+ * headings). Joins between two already-placed modules yield a closure error.
+ */
+export function composeFootprint(
+  modules: FootprintModule[],
+  joins: LayoutJoin[],
+): Footprint {
+  const byId = new Map(modules.map((m) => [m.id, m]));
+  // Per-module local poses + a quick pose lookup.
+  const localPoses = new Map<string, EndplatePose[]>();
+  const poseOf = (mid: string, ep: string): EndplatePose | undefined =>
+    localPoses.get(mid)?.find((p) => p.id === ep);
+  for (const m of modules) localPoses.set(m.id, deriveEndplatePoses(poseInput(m)));
+
+  // Adjacency: placement -> joins touching it.
+  const adj = new Map<string, LayoutJoin[]>();
+  for (const j of joins) {
+    for (const pid of [j.a.placementId, j.b.placementId]) {
+      const arr = adj.get(pid) ?? [];
+      arr.push(j);
+      adj.set(pid, arr);
+    }
+  }
+
+  const transforms = new Map<string, Transform>();
+  const closures: ClosureError[] = [];
+  // Each join is handled once (it appears in adjacency from both ends).
+  const usedJoins = new Set<string>();
+
+  // Place a module given its transform, recording world endplate poses.
+  const worldEndplate = (mid: string, ep: string) => {
+    const t = transforms.get(mid)!;
+    const p = poseOf(mid, ep)!;
+    const pt = applyPoint(t, { x: p.x, y: p.y });
+    return { x: pt.x, y: pt.y, heading: applyHeading(t, p.heading) };
+  };
+
+  // BFS over connected components; each unplaced module seeds a component at
+  // the origin (identity, honouring its mirror flag).
+  const queue: string[] = [];
+  for (const root of modules) {
+    if (transforms.has(root.id)) continue;
+    transforms.set(root.id, { rot: 0, tx: 0, ty: 0, mirror: !!root.mirrored });
+    queue.push(root.id);
+    while (queue.length) {
+      const cur = queue.shift()!;
+      for (const j of adj.get(cur) ?? []) {
+        if (usedJoins.has(j.id)) continue; // already a tree edge or a closure
+        // Identify the far side of this join.
+        const near = j.a.placementId === cur ? j.a : j.b;
+        const far = j.a.placementId === cur ? j.b : j.a;
+        if (!byId.has(far.placementId)) continue; // dangling
+        usedJoins.add(j.id);
+        const nearWorld = worldEndplate(cur, near.endplateId);
+        if (transforms.has(far.placementId)) {
+          // Cycle: both placed — measure closure against the far end.
+          const farWorld = worldEndplate(far.placementId, far.endplateId);
+          const gap = Math.hypot(
+            nearWorld.x - farWorld.x,
+            nearWorld.y - farWorld.y,
+          );
+          const angle = Math.abs(
+            norm180(nearWorld.heading + 180 - farWorld.heading),
+          );
+          // A cyclic join places nothing new; its gap is the closure error
+          // (0 = the ring closes cleanly).
+          closures.push({ joinId: j.id, gapInches: gap, gapDegrees: angle });
+          continue;
+        }
+        // Place `far` so its endplate mates the near one: same point, opposite
+        // outward normal.
+        const farLocal = poseOf(far.placementId, far.endplateId);
+        if (!farLocal) continue;
+        const mirror = !!byId.get(far.placementId)?.mirrored;
+        const localH = mirror ? -farLocal.heading : farLocal.heading;
+        const rot = nearWorld.heading + 180 - localH;
+        // t so that rotate(reflect(farLocal.point)) + t = nearWorld.point
+        const base = applyPoint({ rot, tx: 0, ty: 0, mirror }, {
+          x: farLocal.x,
+          y: farLocal.y,
+        });
+        transforms.set(far.placementId, {
+          rot,
+          tx: nearWorld.x - base.x,
+          ty: nearWorld.y - base.y,
+          mirror,
+        });
+        queue.push(far.placementId);
+      }
+    }
+  }
+
+  // Build placed output + bbox.
+  let minX = Infinity;
+  let minY = Infinity;
+  let maxX = -Infinity;
+  let maxY = -Infinity;
+  const track = (p: Pt) => {
+    minX = Math.min(minX, p.x);
+    minY = Math.min(minY, p.y);
+    maxX = Math.max(maxX, p.x);
+    maxY = Math.max(maxY, p.y);
+  };
+  const placed: PlacedModule[] = [];
+  const unplaced: string[] = [];
+  for (const m of modules) {
+    const t = transforms.get(m.id);
+    if (!t) {
+      unplaced.push(m.id);
+      continue;
+    }
+    const centerline = localCenterline(m).map((p) => applyPoint(t, p));
+    centerline.forEach(track);
+    const endplates = (localPoses.get(m.id) ?? []).map((p) => {
+      const w = worldEndplate(m.id, p.id);
+      track(w);
+      return { id: p.id, x: w.x, y: w.y, heading: w.heading };
+    });
+    placed.push({
+      id: m.id,
+      moduleName: m.moduleName ?? null,
+      endplates,
+      centerline,
+    });
+  }
+  if (!isFinite(minX)) {
+    minX = 0;
+    minY = 0;
+    maxX = 0;
+    maxY = 0;
+  }
+  return { placed, bbox: { minX, minY, maxX, maxY }, closures, unplaced };
+}
+
+/** Convenience: build the footprint straight from spines + stored joins. */
+export function layoutFootprint(
+  spines: JoinSpine[],
+  storedJoins: LayoutJoin[],
+  modules: FootprintModule[],
+): Footprint {
+  return composeFootprint(modules, layoutJoins(spines, storedJoins));
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.8.0",
+        "@willcgage/module-schematic": "^0.10.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.8.0.tgz",
-      "integrity": "sha512-egc/YMXMXzeWJ1s4JdlXiybyxwua/pC5QCICL35+3iAxABqzN1rJjNAhcHuvIxDMF9DdY5ypnUD232d3ordKig==",
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.10.0.tgz",
+      "integrity": "sha512-oGPAGZbAoRI1yjraw4uADUMmEbxar9kpI71gebwhfYXuRYc+Idx9QyqSEzW3B7E8ypW4rga6rMBh7SsIzV7sWA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.8.0",
+    "@willcgage/module-schematic": "^0.10.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Phase 3 of #175 — the payoff. Compose a layout into an **accurate to-scale 2D map** by walking the endplate-join graph and stacking each module's rigid transform.

- **`lib/track/footprint.ts`** (pure, 6 tests): `composeFootprint()` derives each module's endplate poses ([`deriveEndplatePoses`](https://www.npmjs.com/package/@willcgage/module-schematic), phase 1), anchors a root at the origin, BFS-places every neighbour by the **mating constraint** (shared point, opposite outward normals), and reports **cyclic joins as closure errors** (gap in inches + degrees). Honours `mirrored` placements (reflection); each join handled once; disconnected modules seed their own component.
- **`FootprintMap.tsx`**: solved centre-lines + endplate ticks + bounding dims + the closure report — *"Ring closes cleanly"* or *"Closure gap X in / Y° — distributable over N joints (Z in each)"*, the setup-crew format from the research.
- Layout Builder shows the **solved map** beside the old approximate footprint.

**Verified in the browser**: four 90° corners solve into a clean closed **circle** ("Ring closes cleanly"); swapping one for a straight breaks the ring → *"Closure gap 70.4 in / 90.0° — distributable over 4 joints (17.59 in each)."* 151 tests + build green.

Completes the #175 core (phases 1-3). Optional 1b (MR pose-override editor for wye/loop) remains for hand-tuned accuracy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)