### PR TITLE
feat: footprint solver honours manual endplate pose overrides (#175 phase 1b)

### DIFF
--- a/lib/track/__tests__/footprint.test.ts
+++ b/lib/track/__tests__/footprint.test.ts
@@ -89,6 +89,26 @@ describe("composeFootprint", () => {
     expect(ep(mirrored.placed[0], "B").y).toBeCloseTo(-r, 2); // south
   });
 
+  it("honours a manual endplate pose override from the module's doc (#175 1b)", () => {
+    // A wye-ish module: B hand-placed at (10, 90) heading 90 via doc.pose.
+    const m: FootprintModule = {
+      id: "w",
+      moduleName: "wye",
+      lengthTotalInches: 100,
+      geometryType: "wye",
+      schematic: {
+        version: 1,
+        endplates: [
+          { id: "A" },
+          { id: "B", pose: { x: 10, y: 90, heading: 90 } },
+        ],
+        tracks: [{ id: "main", role: "main", lane: 0 }],
+      },
+    };
+    const fp = composeFootprint([m], []);
+    expect(ep(fp.placed[0], "B")).toMatchObject({ x: 10, y: 90 });
+  });
+
   it("disconnected modules are reported as unplaced", () => {
     const fp = composeFootprint([straight("m1"), straight("island")], [
       // island has no join

--- a/lib/track/footprint.ts
+++ b/lib/track/footprint.ts
@@ -14,6 +14,7 @@
  */
 import {
   deriveEndplatePoses,
+  poseOverridesFromDoc,
   type EndplatePose,
 } from "@willcgage/module-schematic";
 import {
@@ -165,6 +166,8 @@ function poseInput(m: FootprintModule) {
     geometryOffsetInches: m.geometryOffsetInches,
     endplateConfigs: [cfg("A"), cfg("B")],
     branches,
+    // Manual overrides (#175 phase 1b) win over derivation for wye/freeform.
+    poseOverrides: doc ? poseOverridesFromDoc(doc) : undefined,
   };
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.10.0",
+        "@willcgage/module-schematic": "^0.11.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.10.0.tgz",
-      "integrity": "sha512-oGPAGZbAoRI1yjraw4uADUMmEbxar9kpI71gebwhfYXuRYc+Idx9QyqSEzW3B7E8ypW4rga6rMBh7SsIzV7sWA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.11.0.tgz",
+      "integrity": "sha512-KLjwJ5LfiXmXW3UtUF4Gr01UzmFrIAqczEFyaoRZzSAvwnfURN1P1+IZtD9EZThy+bIho1n3bKahxTtJtVwVgQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.10.0",
+    "@willcgage/module-schematic": "^0.11.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Completes #175. The footprint solver reads each module's doc pose overrides ([`@willcgage/module-schematic@0.11.0`](https://www.npmjs.com/package/@willcgage/module-schematic) `poseOverridesFromDoc`) and feeds them to `deriveEndplatePoses` — so **wye / loop / freeform** modules place at their hand-entered endplate poses instead of the derived arc.

The MR schematic builder gains an **Endplate poses** section: each endplate's derived X/Y/heading is shown and editable, with a *manual* flag + Reset; the section nudges you when the shape (wye/other/loop) needs a hand-entered pose. Lands on modulerepo main separately.

**Verified**: a doc with endplate B pose  places B there in the solved map. 152 tests + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)