### PR TITLE
fix: de-collide control-point signals + live-preview groundwork (#115)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -462,7 +462,10 @@ export function OperationsSchematic({
                 // direction, so two signals at the same spot (opposite ways)
                 // separate instead of stacking.
                 const sx = px(s.posFrac);
-                const sy = s.side === "below" ? laneY(s.lane) + 3 : laneY(s.lane) - 3;
+                // Fan stacked signals (several at one interlocking) away from
+                // the track so they don't overlap (#151 / stack).
+                const off = 3 + s.stack * 3.5;
+                const sy = s.side === "below" ? laneY(s.lane) + off : laneY(s.lane) - off;
                 const dir = s.facing === "BtoA" ? -1 : 1;
                 const L = Math.max(4, c.width * 0.02);
                 // Live aspect: join back to the control point (#151).

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.11.0",
+        "@willcgage/module-schematic": "^0.12.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.11.0.tgz",
-      "integrity": "sha512-KLjwJ5LfiXmXW3UtUF4Gr01UzmFrIAqczEFyaoRZzSAvwnfURN1P1+IZtD9EZThy+bIho1n3bKahxTtJtVwVgQ==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.12.0.tgz",
+      "integrity": "sha512-J3Zr7ooVeChjDln/+AFt0Z5XHF+iEY8VmbdaQiYSK5F8+5ei1kUAtJQUUnjt2kOC3LvAEaQmXX0ya2d4GuygDA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.11.0",
+    "@willcgage/module-schematic": "^0.12.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
**Signal spacing bug**: a control point often carries several signals at one interlocking; signals sharing a lane+side+position stacked exactly on top of each other.

- [`@willcgage/module-schematic@0.12.0`](https://www.npmjs.com/package/@willcgage/module-schematic): `DrawSignal.stack` — each signal gets a 0-based rank within its lane|side|position group.
- **OperationsSchematic** fans stacked signals off the track by `stack`.

**Verified**: a control point with 4 signals (2 above / 2 below at the same position) now renders at 4 distinct y-positions (37.5 / 41 / 47 / 50.5) instead of two overlapping pairs. `moduleFeatures` returns 4 signals with stacks 0,0,1,1 (confirmed via node + an in-browser instrumentation attribute).

Companion MR change (separate commit): the schematic builder gets the **sticky side-panel live preview** (#115 phase 1) and its `+ Signal` button now adds a proper opposite-direction pair. MR also consumes `stack`.

Note: in dev (StrictMode/Fast-Refresh) an orphaned SVG node can linger after heavy in-place navigation — not produced by the render code (which maps 1:1 inside the cell group) and absent from production builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)