### PR TITLE
fix: schematic hand/throat/crossover (module-schematic 0.13.0)

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -381,17 +381,20 @@ export function OperationsSchematic({
               {feat.extraTracks.map((t) => {
                 // A siding is a passing loop: it dips down to the mainline at a
                 // turnout at each end. A spur rises at one end and ends in a stub.
-                const x1 = px(t.fromFrac);
-                const x2 = px(t.toFrac);
                 const yl = laneY(t.lane);
                 // Diverge from the main this track's turnout sits on — a team
                 // track off Main 2 starts at lane 1, not a crossover from Main 1.
                 const ym = laneY(t.divergesFromLane);
-                const thr = Math.max(6, c.width * 0.04);
-                const pts =
-                  t.role === "spur"
-                    ? `${x1},${ym} ${x1 + thr},${yl} ${x2},${yl}`
-                    : `${x1},${ym} ${x1 + thr},${yl} ${x2 - thr},${yl} ${x2},${ym}`;
+                const isSpur = t.role === "spur";
+                // A spur's throat is at its turnout (either end, #bug3); its stub
+                // runs to the far end. A siding dips to the main at both ends.
+                const tx = px(isSpur ? t.throatFrac : t.fromFrac);
+                const ex = px(isSpur ? t.stubFrac : t.toFrac);
+                const dir = ex >= tx ? 1 : -1;
+                const thr = Math.min(Math.max(6, c.width * 0.04), Math.abs(ex - tx));
+                const pts = isSpur
+                  ? `${tx},${ym} ${tx + dir * thr},${yl} ${ex},${yl}`
+                  : `${tx},${ym} ${tx + thr},${yl} ${ex - thr},${yl} ${ex},${ym}`;
                 return (
                   <polyline
                     key={t.id}
@@ -401,7 +404,7 @@ export function OperationsSchematic({
                     strokeWidth={STROKE * 0.8}
                     strokeLinejoin="round"
                     strokeLinecap="round"
-                    strokeDasharray={t.role === "spur" ? "2 2" : undefined}
+                    strokeDasharray={isSpur ? "2 2" : undefined}
                   >
                     <title>
                       {`${t.role}${t.capacityFeet ? ` · ${t.capacityFeet} ft` : ""}`}
@@ -409,6 +412,21 @@ export function OperationsSchematic({
                   </polyline>
                 );
               })}
+              {/* Crossovers — a straight diagonal joining the two mains (#bug2) */}
+              {feat.crossovers.map((x) => (
+                <line
+                  key={x.id}
+                  x1={px(x.fromPosFrac)}
+                  y1={laneY(x.fromLane)}
+                  x2={px(x.toPosFrac)}
+                  y2={laneY(x.toLane)}
+                  stroke={stroke}
+                  strokeWidth={STROKE * 0.8}
+                  strokeLinecap="round"
+                >
+                  <title>{x.name || "Crossover"}</title>
+                </line>
+              ))}
               {feat.turnouts.map((t) => (
                 <circle key={t.id} cx={px(t.posFrac)} cy={laneY(t.onLane)} r={1.2} fill={stroke}>
                   <title>{`Turnout${t.name ? ` · ${t.name}` : ""}`}</title>

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.12.0",
+        "@willcgage/module-schematic": "^0.13.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.12.0.tgz",
-      "integrity": "sha512-J3Zr7ooVeChjDln/+AFt0Z5XHF+iEY8VmbdaQiYSK5F8+5ei1kUAtJQUUnjt2kOC3LvAEaQmXX0ya2d4GuygDA==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.13.0.tgz",
+      "integrity": "sha512-Hz8qxCYAqqLMCD5kMn7pwkBpDXhJ//VUCkw6Fpr52I0rmU2wzszHVLZI7qweVQTlMBbxxUSSDb2am7om900H1A==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.12.0",
+    "@willcgage/module-schematic": "^0.13.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Bumps `@willcgage/module-schematic` to **0.13.0** and renders its new drawables in the operations schematic:

- **Spur throat** drawn at the turnout end (`throatFrac`/`stubFrac`) instead of always snapping west — east-facing spurs now join on the correct end.
- **Crossovers** drawn as a diagonal between the two mains (`feat.crossovers`).
- Turnout-hand-drives-side reconciliation inherited from the resolver (fixes right-hand turnouts that drew left-hand).

Paired with the MR editor/preview update and a one-time data correction of 3 passing sidings so they hold position.

🤖 Generated with [Claude Code](https://claude.com/claude-code)