### PR TITLE
fix: module-schematic 0.13.1 — topological hand resolution

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.13.0",
+        "@willcgage/module-schematic": "^0.13.1",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.13.0.tgz",
-      "integrity": "sha512-Hz8qxCYAqqLMCD5kMn7pwkBpDXhJ//VUCkw6Fpr52I0rmU2wzszHVLZI7qweVQTlMBbxxUSSDb2am7om900H1A==",
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.13.1.tgz",
+      "integrity": "sha512-J6PJcsqXM5YelqIX6lyIjnNJoObB19fgveGXwHZk0BMycGcWAwE6CAJy4+Xl/E9z/vmUhafVG7jyfmLlsioHiQ==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.13.0",
+    "@willcgage/module-schematic": "^0.13.1",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Bumps `@willcgage/module-schematic` to **0.13.1**.

Fixes a regression in 0.13.0 where the turnout-hand-drives-side reconcile was applied relative to the main for *every* diverging track, scrambling ladder yards (e.g. FMN-0025 ELM Yard — rungs flipped across the main, ladders broken). The hand now picks a side only for turnouts on the main centerline; ladder rungs follow their parent's side. Also draws crossovers modelled as two turnouts diverging onto the other main.

Pure dependency bump on the FD side — the operations schematic inherits the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)