### PR TITLE
fix: module-schematic 0.13.2 — single↔double transition on either main

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.13.1",
+        "@willcgage/module-schematic": "^0.13.2",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.13.1",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.13.1.tgz",
-      "integrity": "sha512-J6PJcsqXM5YelqIX6lyIjnNJoObB19fgveGXwHZk0BMycGcWAwE6CAJy4+Xl/E9z/vmUhafVG7jyfmLlsioHiQ==",
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.13.2.tgz",
+      "integrity": "sha512-HRhiI2UlBxXkYO/LHBZSLa71yuKeXi8I3cMyzHWIN3C3NY04Xip2J7ujSyYgknftGrjDMEag/+IggMwpHvEDEw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.13.1",
+    "@willcgage/module-schematic": "^0.13.2",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Bumps `@willcgage/module-schematic` to **0.13.2**.

Fixes single↔double transition modules (e.g. FMN-0043) where the transition turnout is authored on Main 2 diverging to Main 1: the transition was lost (Main 2 drew full length) and 0.13.1 mis-drew the turnout as a crossover. Main 2's extent is now derived from the transition turnout in either representation, so the operations schematic renders the transition correctly.

Pure dependency bump on the FD side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)