### PR TITLE
fix: module-schematic 0.13.3 — transition surviving main follows the turnout

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.13.2",
+        "@willcgage/module-schematic": "^0.13.3",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.13.2",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.13.2.tgz",
-      "integrity": "sha512-HRhiI2UlBxXkYO/LHBZSLa71yuKeXi8I3cMyzHWIN3C3NY04Xip2J7ujSyYgknftGrjDMEag/+IggMwpHvEDEw==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.13.3.tgz",
+      "integrity": "sha512-i6R7Dx3TCUryTdVfXDFxNZzSeTY7BsTUhFz2N9M5KHG0qnvJ8xgwAb3tguF81kA6qGaSQO2ENhV0BBzn4unJoA==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.13.2",
+    "@willcgage/module-schematic": "^0.13.3",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
Bumps `@willcgage/module-schematic` to **0.13.3**.

Single↔double transitions (e.g. FMN-0043) can now have the surviving single track continue on **either** main — it follows the transition turnout's `onTrack` rather than being hard-wired to Main 1. Adds `ModuleFeatures.transition` (throughLane / branchLane / atFrac / doubleSide); FD's operations schematic inherits it.

Pure dependency bump on the FD side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)