### PR TITLE
fix: key control points by placement (no collision when a module is placed twice)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -1569,7 +1569,7 @@ export default function AdminLayouts() {
                                         </span>
                                         {tree.districts.length > 0 && (
                                           <select
-                                            value={assign[cp.key] ?? ""}
+                                            value={assign[cp.key] ?? assign[cp.legacyKey] ?? ""}
                                             disabled={busy}
                                             onChange={(e) =>
                                               assignControlPoint(

--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -486,10 +486,11 @@ export function OperationsSchematic({
                 const sy = s.side === "below" ? laneY(s.lane) + off : laneY(s.lane) - off;
                 const dir = s.facing === "BtoA" ? -1 : 1;
                 const L = Math.max(4, c.width * 0.02);
-                // Live aspect: join back to the control point (#151).
+                // Live aspect: join back to the control point (#151). Keyed by
+                // placement (c.input.id) to match the CP ref's placement key.
                 const aspect =
-                  signalAspects && s.cp && c.input.moduleId
-                    ? signalAspects[`${c.input.moduleId}:${s.cp}`]?.[s.facing]
+                  signalAspects && s.cp && c.input.id
+                    ? signalAspects[`${c.input.id}:${s.cp}`]?.[s.facing]
                     : undefined;
                 const color =
                   aspect === "clear"

--- a/lib/track/__tests__/layoutControlPoints.test.ts
+++ b/lib/track/__tests__/layoutControlPoints.test.ts
@@ -49,6 +49,11 @@ describe("layoutControlPoints", () => {
       mod("FMN-0001", 0, [{ id: "cpA", name: "A" }, { id: "cpB", name: "B" }]),
     ]);
     expect(cps.map((c) => c.key)).toEqual([
+      "pl-FMN-0001:cpA",
+      "pl-FMN-0001:cpB",
+      "pl-FMN-0002:cpC",
+    ]);
+    expect(cps.map((c) => c.legacyKey)).toEqual([
       "FMN-0001:cpA",
       "FMN-0001:cpB",
       "FMN-0002:cpC",
@@ -59,6 +64,30 @@ describe("layoutControlPoints", () => {
       name: "A",
       source: "module",
     });
+  });
+
+  it("gives each placement of the SAME module a distinct key (#d4492d53)", () => {
+    // Two placements of FMN-0007 must not collide — the bug was both keying to
+    // "FMN-0007:cp1" (React dup keys + one district assignment for both).
+    const cps = layoutControlPoints([
+      mod("FMN-0007", 0, [{ id: "cp1", name: "West" }], "pl-a"),
+      mod("FMN-0007", 1, [{ id: "cp1", name: "West" }], "pl-b"),
+    ]);
+    expect(cps.map((c) => c.key)).toEqual(["pl-a:cp1", "pl-b:cp1"]);
+    expect(new Set(cps.map((c) => c.key)).size).toBe(2); // distinct
+    // …but they share the legacy key (why they used to collide).
+    expect(cps.every((c) => c.legacyKey === "FMN-0007:cp1")).toBe(true);
+  });
+
+  it("resolves a district assignment saved under the legacy module key", () => {
+    const modules = [mod("FMN-0001", 0, [{ id: "a", name: "A", pos: 10 }, { id: "b", name: "B", pos: 90 }])];
+    const cps = layoutControlPoints(modules);
+    // Assignment persisted before keys were placement-based (module-keyed).
+    const legacy = { "FMN-0001:a": "d1", "FMN-0001:b": "d1" };
+    expect(deriveSections(cps, legacy).map((s) => s.name)).toEqual(["A – B"]);
+    // Placement-keyed assignment (post-fix) wins when both are present.
+    const placed = { "pl-FMN-0001:a": "d2", "pl-FMN-0001:b": "d2", "FMN-0001:a": "d1", "FMN-0001:b": "d1" };
+    expect(deriveSections(cps, placed).map((s) => s.districtId)).toEqual(["d2"]);
   });
 
   it("orders points within a module by schematic position", () => {
@@ -300,9 +329,9 @@ describe("branch spines (#170)", () => {
       ...layoutControlPoints(branch, [], "br-1"),
     ];
     expect(cps.map((c) => `${c.key}@${c.spineId ?? "main"}`)).toEqual([
-      "FMN-0001:a@main",
-      "FMN-0001:b@main",
-      "FMN-0002:c@br-1",
+      "pl-FMN-0001:a@main",
+      "pl-FMN-0001:b@main",
+      "pl-FMN-0002:c@br-1",
     ]);
   });
 

--- a/lib/track/__tests__/moduleSchematic.test.ts
+++ b/lib/track/__tests__/moduleSchematic.test.ts
@@ -19,8 +19,10 @@ const doc: ModuleSchematicDoc = {
     { id: "spur", role: "spur", lane: 2, from: "swW", to: "spurEnd", fromPos: 6, toPos: 15 },
   ],
   turnouts: [
-    { id: "swW", pos: 6, onTrack: "main", divergeTrack: "sid", kind: "right", name: "West Siding" },
-    { id: "swE", pos: 24, onTrack: "main", divergeTrack: "sid", kind: "left", name: "East Siding" },
+    // Siding above the main: west turnout throws left, east throws right (both
+    // resolve to the "above" side — the hand drives the drawn side, 0.13.0+).
+    { id: "swW", pos: 6, onTrack: "main", divergeTrack: "sid", kind: "left", name: "West Siding" },
+    { id: "swE", pos: 24, onTrack: "main", divergeTrack: "sid", kind: "right", name: "East Siding" },
   ],
   signals: [{ id: "sW", pos: 3, track: "main", facing: "AtoB", name: "CP West" }],
 };

--- a/lib/track/__tests__/signals.test.ts
+++ b/lib/track/__tests__/signals.test.ts
@@ -27,6 +27,7 @@ describe("deriveSectionAspect (#83 virtual signals)", () => {
 describe("cpSignalAspects (#151 live CTC panel)", () => {
   const cp = (key: string): ControlPointRef => ({
     key,
+    legacyKey: key,
     moduleId: key.split(":")[0],
     moduleName: null,
     cpId: key.split(":")[1] ?? key,

--- a/lib/track/layoutControlPoints.ts
+++ b/lib/track/layoutControlPoints.ts
@@ -36,9 +36,15 @@ export interface LayoutCp {
 }
 
 export interface ControlPointRef {
-  /** Stable key within the layout: "<moduleRecordNumber>:<cpId>" for imported
-   * points, "layout:<id>" for layout-level ones. */
+  /** Stable key within the layout, UNIQUE per placement: "<placementId>:<cpId>"
+   * for imported points, "layout:<id>" for layout-level ones. Placement-based so
+   * the same module design placed twice doesn't collide (React keys, per-CP
+   * district assignment). */
   key: string;
+  /** The pre-placement key format "<moduleRecordNumber>:<cpId>" — read as a
+   * fallback so district assignments saved before the key became placement-based
+   * still resolve without a migration. Equals `key` when there's no placement id. */
+  legacyKey: string;
   moduleId: string;
   moduleName: string | null;
   cpId: string;
@@ -83,13 +89,17 @@ export function layoutControlPoints(
   for (const m of ordered) {
     const moduleId = m.moduleId;
     if (!moduleId) continue;
+    // Unique per placement; falls back to the module record when a placement id
+    // isn't supplied (keeping the historical key format in that case).
+    const placementId = m.id ?? moduleId;
     const doc = asModuleSchematic(m.schematic);
     const refs: ControlPointRef[] = [];
     let docIndex = 0;
     for (const cp of doc?.controlPoints ?? []) {
       if (!cp.id) continue;
       refs.push({
-        key: `${moduleId}:${cp.id}`,
+        key: `${placementId}:${cp.id}`,
+        legacyKey: `${moduleId}:${cp.id}`,
         moduleId,
         moduleName: m.moduleName ?? null,
         cpId: cp.id,
@@ -104,6 +114,7 @@ export function layoutControlPoints(
       if (lc.anchor !== (m.id ?? "")) continue;
       refs.push({
         key: `layout:${lc.id}`,
+        legacyKey: `layout:${lc.id}`,
         moduleId,
         moduleName: m.moduleName ?? null,
         cpId: lc.id,
@@ -159,6 +170,11 @@ export function deriveSections(
       .map((m) => ({ moduleId: m.moduleId!, moduleName: m.moduleName ?? null }));
   };
 
+  // Resolve a point's district by its placement key, falling back to the legacy
+  // module-keyed assignment saved before keys became placement-based.
+  const districtOf = (cp: ControlPointRef): string | undefined =>
+    assignments[cp.key] ?? assignments[cp.legacyKey];
+
   const out: DerivedSection[] = [];
   for (let i = 0; i < controlPoints.length - 1; i++) {
     const a = controlPoints[i];
@@ -166,8 +182,8 @@ export function deriveSections(
     // Adjacency is per-spine (#170): a junction terminates the chain — no
     // section spans from a main-spine point onto a branch (or vice versa).
     if ((a.spineId ?? null) !== (b.spineId ?? null)) continue;
-    const da = assignments[a.key];
-    const db = assignments[b.key];
+    const da = districtOf(a);
+    const db = districtOf(b);
     if (da && da === db) {
       out.push({
         districtId: da,


### PR DESCRIPTION
## Problem
`layoutControlPoints` keyed each control point `"<moduleRecordNumber>:<cpId>"`. When the same module design is placed more than once in a layout, both placements produce identical CP keys, causing:
- React **duplicate-key warnings** (`<li key={cp.key}>`)
- **Ambiguous district assignment** — both placements share one `controlPointDistricts[key]` entry, so they can't be assigned to different districts

## Fix
- Key CPs by **placement** (`"<placementId>:<cpId>"`), unique per placement.
- Add `legacyKey` (`"<moduleRecordNumber>:<cpId>"`), read as a **fallback** so district assignments saved under the old format still resolve — no data migration needed.
- `deriveSections` and the admin assignment dropdown prefer the placement key, fall back to legacy.
- `OperationsSchematic` joins live signal aspects by placement id (`c.input.id`) to match the new key.
- Derived sections re-materialize on the next `syncDerivedSections` (self-healing).

Also fixes FD's `moduleSchematic` test fixture to the current hand-drives-side convention (a latent break from module-schematic 0.13.0).

All 154 FD tests pass; typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)