### PR TITLE
feat: Reverse a module end-for-end + merge Footprint and Layout Map

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -9,12 +9,14 @@ import {
   standardLabel,
   standardOptions,
 } from "@/lib/client/standards";
-import {
-  LayoutSchematic,
-  MODULE_DRAG_MIME,
-} from "@/components/layout/LayoutSchematic";
+import { MODULE_DRAG_MIME } from "@/components/layout/LayoutSchematic";
 import { OperationsSchematic } from "@/components/layout/OperationsSchematic";
 import { FootprintMap } from "@/components/layout/FootprintMap";
+import {
+  districtColor,
+  districtLegend,
+  moduleDistrictMap,
+} from "@/lib/track/districts";
 import {
   layoutControlPoints,
   deriveSections,
@@ -904,27 +906,24 @@ export default function AdminLayouts() {
                                       <option value="A">Stg A</option>
                                       <option value="B">Stg B</option>
                                     </select>
-                                    {(m.geometryType === "curve" ||
-                                      m.geometryType === "corner_90") && (
-                                      <button
-                                        disabled={busy}
-                                        onClick={() =>
-                                          flipModule(l.id, m.id, m.flipped)
-                                        }
-                                        title={
-                                          m.flipped
-                                            ? "Flipped — click to un-flip"
-                                            : "Flip curve direction"
-                                        }
-                                        className={`shrink-0 rounded border px-1 py-0.5 text-xs ${
-                                          m.flipped
-                                            ? "border-amber-600/60 bg-amber-600/20 text-amber-300"
-                                            : "border-slate-700 text-slate-400 hover:bg-slate-800"
-                                        }`}
-                                      >
-                                        ⇄
-                                      </button>
-                                    )}
+                                    <button
+                                      disabled={busy}
+                                      onClick={() =>
+                                        flipModule(l.id, m.id, m.flipped)
+                                      }
+                                      title={
+                                        m.flipped
+                                          ? "Reversed (turned end-for-end) — click to restore"
+                                          : "Reverse — turn the module end-for-end (swap which endplate faces each neighbour)"
+                                      }
+                                      className={`shrink-0 rounded border px-1 py-0.5 text-xs ${
+                                        m.flipped
+                                          ? "border-amber-600/60 bg-amber-600/20 text-amber-300"
+                                          : "border-slate-700 text-slate-400 hover:bg-slate-800"
+                                      }`}
+                                    >
+                                      ⟲
+                                    </button>
                                     <button
                                       disabled={busy}
                                       onClick={() => removeModule(l.id, m.id)}
@@ -1269,41 +1268,46 @@ export default function AdminLayouts() {
                               ))}
                           </div>
 
-                          {/* Footprint (to-scale, physical shape) */}
+                          {/* Layout map — one view: solved geometry + district
+                              colours + labels + endplate mismatches (#175). */}
                           <div>
                             <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
-                              Footprint (physical layout)
+                              Layout map
                             </div>
-                            <LayoutSchematic
-                              modules={tree.modules}
-                              districts={tree.districts}
-                              onDropModule={(rec) => dropAddModule(l.id, rec)}
-                            />
-                          </div>
-
-                          {/* Solved layout map (#175 phase 3) */}
-                          <div>
-                            <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
-                              Layout map (solved)
-                            </div>
-                            <FootprintMap
-                              modules={[
-                                ...tree.modules,
-                                ...tree.branchSpines.flatMap((b) => b.modules),
-                              ].map((m) => ({
-                                id: m.id,
-                                moduleName: m.moduleName,
-                                moduleId: m.moduleId,
-                                lengthTotalInches: m.lengthTotalInches,
-                                mainlineLengthInches: m.mainlineLengthInches,
-                                geometryType: m.geometryType,
-                                geometryDegrees: m.geometryDegrees,
-                                geometryOffsetInches: m.geometryOffsetInches,
-                                mirrored: m.mirrored,
-                                schematic: m.schematic,
-                              }))}
-                              joins={tree.joins}
-                            />
+                            {(() => {
+                              const dmap = moduleDistrictMap(tree.districts);
+                              const modById = new Map(
+                                [
+                                  ...tree.modules,
+                                  ...tree.branchSpines.flatMap((b) => b.modules),
+                                ].map((m) => [m.id, m]),
+                              );
+                              const colorFor = (pid: string) => {
+                                const mid = modById.get(pid)?.moduleId;
+                                const d = mid ? dmap.get(mid) : undefined;
+                                return d ? districtColor(d.index) : undefined;
+                              };
+                              return (
+                                <FootprintMap
+                                  modules={[...modById.values()].map((m) => ({
+                                    id: m.id,
+                                    moduleName: m.moduleName,
+                                    moduleId: m.moduleId,
+                                    lengthTotalInches: m.lengthTotalInches,
+                                    mainlineLengthInches: m.mainlineLengthInches,
+                                    geometryType: m.geometryType,
+                                    geometryDegrees: m.geometryDegrees,
+                                    geometryOffsetInches: m.geometryOffsetInches,
+                                    mirrored: m.mirrored,
+                                    schematic: m.schematic,
+                                  }))}
+                                  joins={tree.joins}
+                                  colorFor={colorFor}
+                                  legend={districtLegend(tree.districts)}
+                                  onDropModule={(rec) => dropAddModule(l.id, rec)}
+                                />
+                              );
+                            })()}
                           </div>
 
                           {/* Endplate joins (#175) */}

--- a/components/layout/FootprintMap.tsx
+++ b/components/layout/FootprintMap.tsx
@@ -1,34 +1,69 @@
 /**
- * FootprintMap (#175 phase 3) — the accurate to-scale layout map, solved from
- * the endplate-join graph (composeFootprint). Each module's centre-line is
- * drawn in world coordinates; endplates are ticks; closures report the gap a
- * setup crew must distribute across joints.
+ * FootprintMap (#175 phase 3, merged view) — the one to-scale layout map. Track
+ * centre-lines are solved from the endplate-join graph (composeFootprint) and
+ * drawn in world coordinates; on top of that accurate geometry it carries the
+ * annotations the old node-link Footprint provided: district colours, module
+ * labels, endplate-mismatch flags, and a drop-to-add target. Closures report the
+ * gap a setup crew must distribute across joints.
  */
 "use client";
 
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
   composeFootprint,
   type FootprintModule,
 } from "@/lib/track/footprint";
 import type { LayoutJoin } from "@/lib/track/layoutJoins";
+import { MODULE_DRAG_MIME } from "@/components/layout/LayoutSchematic";
+
+type JoinWithStatus = LayoutJoin & { status?: string };
 
 export function FootprintMap({
   modules,
   joins,
   colorFor,
+  legend,
+  onDropModule,
 }: {
   modules: FootprintModule[];
-  joins: LayoutJoin[];
-  /** Optional per-placement stroke (district colour). */
+  joins: JoinWithStatus[];
+  /** Per-placement stroke (district colour). */
   colorFor?: (placementId: string) => string | undefined;
+  /** District legend swatches. */
+  legend?: { id: string; name: string; color: string }[];
+  /** Called with a catalog record # when one is dropped onto the map. */
+  onDropModule?: (recordNumber: string) => void;
 }) {
   const fp = useMemo(() => composeFootprint(modules, joins), [modules, joins]);
+  const [over, setOver] = useState(false);
+
+  const dropProps = onDropModule
+    ? {
+        onDragOver: (e: React.DragEvent) => {
+          if (e.dataTransfer.types.includes(MODULE_DRAG_MIME)) {
+            e.preventDefault();
+            setOver(true);
+          }
+        },
+        onDragLeave: () => setOver(false),
+        onDrop: (e: React.DragEvent) => {
+          setOver(false);
+          const rec = e.dataTransfer.getData(MODULE_DRAG_MIME);
+          if (rec) onDropModule(rec);
+        },
+      }
+    : {};
+  const ring = over ? "ring-2 ring-sky-500" : "";
 
   if (modules.length === 0) {
     return (
-      <div className="flex h-24 items-center justify-center rounded-md border border-dashed border-slate-700 text-xs text-slate-600">
-        Add modules to solve the layout map.
+      <div
+        {...dropProps}
+        className={`flex h-24 items-center justify-center rounded-md border border-dashed border-slate-700 text-xs text-slate-600 ${ring}`}
+      >
+        {onDropModule
+          ? "No modules yet — drag one from the list, or use Add."
+          : "Add modules to solve the layout map."}
       </div>
     );
   }
@@ -41,9 +76,26 @@ export function FootprintMap({
   const vb = `${minX - pad} ${-(maxY + pad)} ${w + pad * 2} ${h + pad * 2}`;
   const fy = (y: number) => -y;
   const feet = (n: number) => `${Math.round((n / 12) * 10) / 10} ft`;
+  const font = Math.max(w, h) * 0.03 + 2;
 
   const totalGap = fp.closures.reduce((s, c) => s + c.gapInches, 0);
   const nJoints = joins.length || 1;
+
+  // World position of each placed endplate, for flagging mismatched joins.
+  const epWorld = new Map<string, { x: number; y: number }>();
+  for (const m of fp.placed)
+    for (const e of m.endplates) epWorld.set(`${m.id}:${e.id}`, { x: e.x, y: e.y });
+  const nameById = new Map(fp.placed.map((m) => [m.id, m.moduleName ?? m.id]));
+  const mismatches = joins
+    .filter((j) => j.status === "mismatch")
+    .map((j) => {
+      const p = epWorld.get(`${j.a.placementId}:${j.a.endplateId}`) ??
+        epWorld.get(`${j.b.placementId}:${j.b.endplateId}`);
+      return p
+        ? { p, a: nameById.get(j.a.placementId) ?? j.a.placementId, b: nameById.get(j.b.placementId) ?? j.b.placementId }
+        : null;
+    })
+    .filter((x): x is NonNullable<typeof x> => x !== null);
 
   return (
     <div>
@@ -54,29 +106,30 @@ export function FootprintMap({
         </span>
       </div>
       <svg
+        {...dropProps}
         viewBox={vb}
         width="100%"
-        height="240"
+        height="260"
         preserveAspectRatio="xMidYMid meet"
-        className="rounded bg-slate-950/40"
+        className={`rounded-md border border-slate-700 bg-slate-950/40 ${ring}`}
       >
-        {/* Module centre-lines */}
+        {/* Module centre-lines, coloured by district */}
         {fp.placed.map((m) => {
           const stroke = colorFor?.(m.id) ?? "#64748b";
           const pts = m.centerline.map((p) => `${p.x},${fy(p.y)}`).join(" ");
+          const mid = m.centerline[Math.floor(m.centerline.length / 2)];
           return (
             <g key={m.id}>
               <polyline
                 points={pts}
                 fill="none"
                 stroke={stroke}
-                strokeWidth={1.6}
+                strokeWidth={2}
                 strokeLinejoin="round"
                 strokeLinecap="round"
               >
                 <title>{m.moduleName ?? m.id}</title>
               </polyline>
-              {/* Endplate ticks */}
               {m.endplates.map((e) => {
                 const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
                 const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
@@ -95,12 +148,57 @@ export function FootprintMap({
                   </line>
                 );
               })}
+              {mid && (
+                <text
+                  x={mid.x}
+                  y={fy(mid.y) - font * 0.6}
+                  textAnchor="middle"
+                  fontSize={font}
+                  fill="#cbd5e1"
+                  style={{ paintOrder: "stroke", stroke: "#0b1220", strokeWidth: font * 0.28 }}
+                >
+                  {m.moduleName ?? m.id}
+                </text>
+              )}
             </g>
           );
         })}
+        {/* Endplate mismatches — red ring at the offending join */}
+        {mismatches.map((mm, i) => (
+          <g key={i}>
+            <circle cx={mm.p.x} cy={fy(mm.p.y)} r={font * 1.1} fill="#7f1d1d" stroke="#ef4444" strokeWidth={font * 0.22}>
+              <title>{`Endplate mismatch: ${mm.a} ↔ ${mm.b}`}</title>
+            </circle>
+          </g>
+        ))}
       </svg>
 
-      {/* Closure report */}
+      {legend && legend.length > 0 && (
+        <div className="mt-1 flex flex-wrap gap-x-3 gap-y-1 text-[11px] text-slate-400">
+          {legend.map((d) => (
+            <span key={d.id} className="flex items-center gap-1">
+              <span className="inline-block h-2.5 w-2.5 rounded-sm" style={{ backgroundColor: d.color }} />
+              {d.name}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {mismatches.length > 0 && (
+        <div className="mt-1 rounded-md border border-red-900/60 bg-red-950/30 px-2 py-1 text-[11px] text-red-300">
+          <span className="font-semibold">
+            {mismatches.length} endplate {mismatches.length === 1 ? "mismatch" : "mismatches"}:
+          </span>{" "}
+          {mismatches.map((mm, i) => (
+            <span key={i}>
+              {i > 0 && "; "}
+              {mm.a} ↔ {mm.b}
+            </span>
+          ))}
+          <span className="text-red-400/70"> — Reverse a module (⟲) to turn it around.</span>
+        </div>
+      )}
+
       {fp.closures.length > 0 && (
         <p className="mt-1 text-xs text-slate-400">
           {fp.closures.map((c, i) => {
@@ -125,10 +223,12 @@ export function FootprintMap({
       )}
       {fp.unplaced.length > 0 && (
         <p className="mt-1 text-xs text-slate-500">
-          {fp.unplaced.length} module{fp.unplaced.length > 1 ? "s" : ""} not
-          connected by any join.
+          {fp.unplaced.length} module{fp.unplaced.length > 1 ? "s" : ""} not connected by any join.
         </p>
       )}
+      <p className="mt-1 text-[10px] text-slate-600">
+        Solved to scale from the endplate joins — shape, district colours, and mismatches in one map.
+      </p>
     </div>
   );
 }

--- a/lib/track/__tests__/layoutJoins.test.ts
+++ b/lib/track/__tests__/layoutJoins.test.ts
@@ -17,10 +17,12 @@ const mod = (
     { id: "A" },
     { id: "B" },
   ],
+  flipped = false,
 ): JoinPlacement => ({
   id,
   positionIndex,
   moduleId: id,
+  flipped,
   schematic: {
     version: 1,
     endplates: endplates.map((e) => ({
@@ -48,6 +50,30 @@ describe("implicitJoins", () => {
       "p2:B-p3:A",
     ]);
     expect(joins.every((j) => j.implicit)).toBe(true);
+  });
+
+  it("a reversed module mates its FACING endplates (turned end-for-end)", () => {
+    // p2 reversed: its B faces west (toward p1), its A faces east (toward p3).
+    const joins = implicitJoins([
+      { branchId: null, modules: [mod("p1", 0), mod("p2", 1, undefined, true), mod("p3", 2)] },
+    ]);
+    expect(joins.map((j) => `${j.a.placementId}:${j.a.endplateId}-${j.b.placementId}:${j.b.endplateId}`)).toEqual([
+      "p1:B-p2:B",
+      "p2:A-p3:A",
+    ]);
+  });
+
+  it("reversing resolves a single↔double endplate mismatch", () => {
+    // p1 ends double at B; p2 is A=double, B=single. Facing p1 with A (double)
+    // matches; reverse p2 → its B (single) faces p1 → still needs p1 single…
+    // the useful case: p2 single end should face its single neighbour.
+    const p1 = mod("p1", 0, [{ id: "A" }, { id: "B", config: "single" }]);
+    const p2 = mod("p2", 1, [{ id: "A", config: "double" }, { id: "B", config: "single" }], true);
+    const byId = new Map([["p1", p1], ["p2", p2]] as const);
+    const [join] = implicitJoins([{ branchId: null, modules: [p1, p2] }]);
+    // reversed p2 presents B (single) west → single↔single = ok
+    expect(join.b.endplateId).toBe("B");
+    expect(joinStatus(join, byId)).toBe("ok");
   });
 
   it("attaches a branch at its origin endplate ↔ the branch's first A", () => {

--- a/lib/track/layoutJoins.ts
+++ b/lib/track/layoutJoins.ts
@@ -35,6 +35,8 @@ export interface JoinPlacement {
   moduleName?: string | null;
   positionIndex?: number;
   schematic?: unknown;
+  /** Reversed end-for-end (turned around): its A end faces east, B faces west. */
+  flipped?: boolean | null;
 }
 export interface JoinSpine {
   /** null = main spine, otherwise a branch id. */
@@ -66,24 +68,32 @@ export function joinKey(j: { a: EndplateRef; b: EndplateRef }): string {
  */
 export function implicitJoins(spines: JoinSpine[]): LayoutJoin[] {
   const out: LayoutJoin[] = [];
+  // A reversed (turned-around) module presents its B end to the west and A to
+  // the east, so the spine mates the FACING endplates, not always B→A.
+  const westEnd = (m: JoinPlacement) => (m.flipped ? "B" : "A");
+  const eastEnd = (m: JoinPlacement) => (m.flipped ? "A" : "B");
   for (const s of spines) {
     const ordered = [...s.modules].sort(
       (a, b) => (a.positionIndex ?? 0) - (b.positionIndex ?? 0),
     );
-    // Branch attaches at its origin endplate ↔ the branch's first module's A.
+    // Branch attaches at its origin endplate ↔ the branch's first module's
+    // west-facing endplate.
     if (s.origin && ordered[0]) {
+      const w = westEnd(ordered[0]);
       out.push({
-        id: `imp:${s.origin.placementId}:${s.origin.endplateId}-${ordered[0].id}:A`,
+        id: `imp:${s.origin.placementId}:${s.origin.endplateId}-${ordered[0].id}:${w}`,
         a: { placementId: s.origin.placementId, endplateId: s.origin.endplateId },
-        b: { placementId: ordered[0].id, endplateId: "A" },
+        b: { placementId: ordered[0].id, endplateId: w },
         implicit: true,
       });
     }
     for (let i = 0; i < ordered.length - 1; i++) {
+      const e = eastEnd(ordered[i]);
+      const w = westEnd(ordered[i + 1]);
       out.push({
-        id: `imp:${ordered[i].id}:B-${ordered[i + 1].id}:A`,
-        a: { placementId: ordered[i].id, endplateId: "B" },
-        b: { placementId: ordered[i + 1].id, endplateId: "A" },
+        id: `imp:${ordered[i].id}:${e}-${ordered[i + 1].id}:${w}`,
+        a: { placementId: ordered[i].id, endplateId: e },
+        b: { placementId: ordered[i + 1].id, endplateId: w },
         implicit: true,
       });
     }


### PR DESCRIPTION
Two layout-builder improvements requested together.

## Reverse (turn a module around)
"I can't flip modules, which is strange since I can do this in the real world."

- The flip control (previously **curve-only**, labelled *"flip curve direction"*) now appears on **every module** as **Reverse (⟲)** — turning a placement end-for-end so its **A** end faces east and **B** faces west.
- `implicitJoins` is now **facing-aware**: a reversed module mates its *facing* endplates instead of always B→A. So turning a module around **resolves an endplate mismatch** (e.g. Ventura East's single end meeting Maggie's Farm's single end) and places it correctly in the solved map.
- Reuses the existing `flipped` field/API — `endplateConnections` already honoured it, and the footprint solver mates by the join's endplate id, so no schema/solver change was needed.

## Merge Footprint + Layout Map
"I think having both Layout Map and Footprint may be a little redundant. Can they be merged?"

- **One "Layout map"** now: the accurate solved-from-joins geometry **plus** everything the old node-link Footprint carried — district colours, module labels, endplate-mismatch flags (with a *"Reverse to turn it around"* hint), and the drop-to-add target. The separate node-link view is removed.

## Known gap (follow-up)
The straightened **Operations schematic** doesn't yet mirror a *reversed* module's internal cell content (sidings/transition drawn on the original side); its mismatch check is already correct via `flipped`. Full cell-mirroring is a larger change for the eventual drag-and-drop canvas.

All 156 FD tests pass (2 new for facing-aware joins); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)