### PR TITLE
feat: mirror a reversed module's cell in the Operations schematic

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -27,6 +27,7 @@ import {
   type SectionAwareDistrict,
 } from "@/lib/track/sections";
 import { asModuleSchematic, moduleFeatures } from "@/lib/track/moduleSchematic";
+import { reverseModuleFeatures } from "@/lib/track/reverseFeatures";
 
 // All coordinates are in inches (the spine's natural unit); the SVG scales.
 const LANE_GAP = 12; // vertical gap between Main 1 and Main 2
@@ -153,7 +154,18 @@ export function OperationsSchematic({
           // terminal bulb on the outward side — first cell opens west, any
           // other placement opens east.
           const cellDoc = asModuleSchematic(c.input.schematic);
-          const cellFeat = cellDoc ? moduleFeatures(cellDoc) : null;
+          // A reversed (turned-around) placement draws its content mirrored
+          // west↔east, and its end track-counts swap (#reverse).
+          const flip = !!c.input.flipped;
+          // main2Extent / transition come from the module-local moduleFeatures,
+          // which don't know orientation — mirror them when reversed. (The end
+          // track-counts leftTracks/rightTracks are ALREADY flipped-aware, from
+          // inConfig/outConfig, so they must NOT be swapped again.)
+          const cellFeat = cellDoc
+            ? flip
+              ? reverseModuleFeatures(moduleFeatures(cellDoc))
+              : moduleFeatures(cellDoc)
+            : null;
           const isLoop = !!cellFeat?.loop;
           // Main 2 directional return (#165): the balloon is a U joining the
           // two main lanes at the outward side — no bulb.
@@ -311,11 +323,15 @@ export function OperationsSchematic({
                   strokeWidth={0.6}
                 />
               )}
-              {/* Staging yard glyph at the module's staging end */}
+              {/* Staging yard glyph at the module's staging end (mirrors when
+                  the placement is reversed). */}
               {c.input.stagingEnd &&
                 [0, 1, 2].map((k) => {
-                  const ex =
-                    c.input.stagingEnd === "A" ? c.x + 2 + k * 3 : c.x + c.width - 2 - k * 3;
+                  const stagingWest =
+                    (c.input.stagingEnd === "A") !== flip;
+                  const ex = stagingWest
+                    ? c.x + 2 + k * 3
+                    : c.x + c.width - 2 - k * 3;
                   return (
                     <line
                       key={k}
@@ -348,7 +364,7 @@ export function OperationsSchematic({
                     c.leftTracks === c.rightTracks
                       ? `${c.leftTracks === 2 ? "double" : "single"} main`
                       : `${c.leftTracks}→${c.rightTracks} track`
-                  }${c.input.moduleId && dmap.get(c.input.moduleId) ? ` · ${dmap.get(c.input.moduleId)!.name}` : ""}${
+                  }${flip ? " · reversed" : ""}${c.input.moduleId && dmap.get(c.input.moduleId) ? ` · ${dmap.get(c.input.moduleId)!.name}` : ""}${
                     c.input.stagingEnd ? " · staging" : ""
                   }`}
                 </title>
@@ -373,7 +389,10 @@ export function OperationsSchematic({
         {schem.cells.map((c) => {
           const doc = asModuleSchematic(c.input.schematic);
           if (!doc) return null;
-          const feat = moduleFeatures(doc);
+          // Reversed placement: mirror the overlay west↔east (#reverse).
+          const feat = c.input.flipped
+            ? reverseModuleFeatures(moduleFeatures(doc))
+            : moduleFeatures(doc);
           const stroke = colorFor(c.input.moduleId);
           const px = (frac: number) => c.x + frac * c.width;
           return (

--- a/lib/track/__tests__/reverseFeatures.test.ts
+++ b/lib/track/__tests__/reverseFeatures.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { moduleFeatures, type ModuleSchematicDoc } from "../moduleSchematic";
+import { reverseModuleFeatures } from "../reverseFeatures";
+
+describe("reverseModuleFeatures", () => {
+  it("mirrors along-module positions west↔east and flips signal facing", () => {
+    const doc: ModuleSchematicDoc = {
+      version: 1,
+      lengthInches: 100,
+      endplates: [{ id: "A" }, { id: "B" }],
+      tracks: [
+        { id: "main", role: "main", lane: 0, from: "A", to: "B" },
+        { id: "sp", role: "spur", lane: 1, fromPos: 20, toPos: 50 },
+      ],
+      turnouts: [{ id: "sw", pos: 20, onTrack: "main", divergeTrack: "sp", kind: "left" }],
+      controlPoints: [
+        {
+          id: "cp",
+          name: "West",
+          turnouts: ["sw"],
+          signals: [{ id: "s1", pos: 10, track: "main", facing: "AtoB", side: "above" }],
+        },
+      ],
+    };
+    const f = moduleFeatures(doc);
+    const r = reverseModuleFeatures(f);
+
+    const sp = r.extraTracks[0];
+    // spur 0.2–0.5 mirrors to 0.5–0.8, throat (was at the turnout, west end 0.2)
+    // moves to the east end 0.8.
+    expect(sp.fromFrac).toBeCloseTo(0.5);
+    expect(sp.toFrac).toBeCloseTo(0.8);
+    expect(sp.throatFrac).toBeCloseTo(0.8);
+    expect(sp.lane).toBe(1); // lane (N/S) unchanged
+
+    expect(r.turnouts[0].posFrac).toBeCloseTo(0.8);
+    expect(r.signals[0].posFrac).toBeCloseTo(0.9);
+    expect(r.signals[0].facing).toBe("BtoA"); // flipped
+    expect(r.signals[0].side).toBe("above"); // side unchanged
+  });
+
+  it("mirrors the single↔double transition to the other end", () => {
+    // west double, transition turnout at 0.6 → after reverse, double end is east.
+    const doc: ModuleSchematicDoc = {
+      version: 1,
+      lengthInches: 30,
+      endplates: [
+        { id: "A", tracks: [{ trackId: "main", lane: 0, config: "double" }] },
+        { id: "B", tracks: [{ trackId: "main", lane: 0, config: "single" }] },
+      ],
+      tracks: [
+        { id: "main", role: "main", lane: 0, from: "A", to: "B" },
+        { id: "main2", role: "main", lane: 1, from: "A", to: "B" },
+      ],
+      turnouts: [{ id: "sw1", pos: 18, kind: "left", onTrack: "main2", divergeTrack: "main" }],
+    };
+    const f = moduleFeatures(doc);
+    expect(f.transition).toMatchObject({ atFrac: 0.6, doubleSide: "west" });
+    const r = reverseModuleFeatures(f);
+    expect(r.transition).toMatchObject({
+      throughLane: 1,
+      branchLane: 0,
+      atFrac: 0.4, // 1 - 0.6
+      doubleSide: "east",
+    });
+  });
+});

--- a/lib/track/reverseFeatures.ts
+++ b/lib/track/reverseFeatures.ts
@@ -1,0 +1,54 @@
+/**
+ * Reverse a module's resolved features west↔east (#reverse) — used by the
+ * straightened Operations schematic to draw a turned-around placement (flipped)
+ * with its content on the correct end. Every along-module position (a fraction
+ * from the A end) mirrors to `1 - frac`; signal facing flips; the single↔double
+ * transition and Main 2's partial extent mirror with it. Lanes (north/south) are
+ * left as-is — the straightened panel is topological, and the gap this closes is
+ * about which END a feature sits on, not which side.
+ *
+ * Pure so it unit-tests without a database.
+ */
+import type { ModuleFeatures } from "./moduleSchematic";
+
+const flip = (frac: number) => 1 - frac;
+
+export function reverseModuleFeatures(f: ModuleFeatures): ModuleFeatures {
+  return {
+    ...f,
+    extraTracks: f.extraTracks.map((t) => ({
+      ...t,
+      // fromFrac/toFrac stay sorted (west→east) after mirroring.
+      fromFrac: flip(t.toFrac),
+      toFrac: flip(t.fromFrac),
+      throatFrac: flip(t.throatFrac),
+      stubFrac: flip(t.stubFrac),
+    })),
+    turnouts: f.turnouts.map((t) => ({ ...t, posFrac: flip(t.posFrac) })),
+    signals: f.signals.map((s) => ({
+      ...s,
+      posFrac: flip(s.posFrac),
+      facing: s.facing === "AtoB" ? "BtoA" : "AtoB",
+    })),
+    crossings: f.crossings.map((x) => ({ ...x, posFrac: flip(x.posFrac) })),
+    crossovers: f.crossovers.map((x) => ({
+      ...x,
+      fromPosFrac: flip(x.fromPosFrac),
+      toPosFrac: flip(x.toPosFrac),
+    })),
+    branchConnectors: f.branchConnectors.map((b) => ({
+      ...b,
+      posFrac: flip(b.posFrac),
+    })),
+    main2Extent: f.main2Extent
+      ? { fromFrac: flip(f.main2Extent.toFrac), toFrac: flip(f.main2Extent.fromFrac) }
+      : null,
+    transition: f.transition
+      ? {
+          ...f.transition,
+          atFrac: flip(f.transition.atFrac),
+          doubleSide: f.transition.doubleSide === "west" ? "east" : "west",
+        }
+      : null,
+  };
+}


### PR DESCRIPTION
Closes the known gap flagged when Reverse shipped: the straightened **Operations schematic** drew each cell's content by position from the A end, so a reversed placement showed its sidings/transition on the wrong end (the merged Layout Map and the mismatch check were already correct).

## Change
- **`reverseModuleFeatures(f)`** — a pure west↔east mirror of the resolved `ModuleFeatures`: every along-module fraction → `1 − frac`, signal facing flips, and `main2Extent` + the single↔double `transition` mirror with it. Lanes (N/S) are left as-is — the panel is topological and the gap was about which *end* a feature sits on. Unit-tested.
- **`OperationsSchematic`** applies the mirror per cell when `c.input.flipped`, for both the authored overlay and the Main 2 / transition spine, and mirrors the staging-end glyph.
- **`leftTracks`/`rightTracks` are deliberately not swapped** — they come from `inConfig`/`outConfig`, which are already flipped-aware (via `ordered()`); swapping them again double-reverses.

## Verified live
Reversing FMN-0043 (Ventura East) in a running layout moves its Main 2 / double end from the **west** (x 96–105) to the **east** (x 117–126) of its cell, and the tooltip reads **"1→2 track · reversed"**. Non-reversed modules render byte-identically.

158 FD tests pass (2 new for the mirror); typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)