### PR TITLE
feat: drag-and-drop snap canvas (phase 1)

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -12,6 +12,7 @@ import {
 import { MODULE_DRAG_MIME } from "@/components/layout/LayoutSchematic";
 import { OperationsSchematic } from "@/components/layout/OperationsSchematic";
 import { FootprintMap } from "@/components/layout/FootprintMap";
+import { LayoutCanvas } from "@/components/layout/LayoutCanvas";
 import {
   districtColor,
   districtLegend,
@@ -195,6 +196,8 @@ export default function AdminLayouts() {
     sectionId: string;
   } | null>(null);
   const [busy, setBusy] = useState(false);
+  /** Layout ids whose map is in interactive "Arrange" mode (drag-to-connect). */
+  const [arrange, setArrange] = useState<Record<string, boolean>>({});
   const [error, setError] = useState<string | null>(null);
 
   const load = useCallback(async () => {
@@ -1271,8 +1274,25 @@ export default function AdminLayouts() {
                           {/* Layout map — one view: solved geometry + district
                               colours + labels + endplate mismatches (#175). */}
                           <div>
-                            <div className="mb-1 text-xs font-semibold uppercase text-slate-500">
-                              Layout map
+                            <div className="mb-1 flex items-center justify-between">
+                              <div className="text-xs font-semibold uppercase text-slate-500">
+                                Layout map
+                              </div>
+                              <button
+                                type="button"
+                                disabled={busy}
+                                onClick={() =>
+                                  setArrange((s) => ({ ...s, [l.id]: !s[l.id] }))
+                                }
+                                title="Drag modules to connect their endplates (beta)"
+                                className={`rounded border px-2 py-0.5 text-[11px] ${
+                                  arrange[l.id]
+                                    ? "border-sky-600 bg-sky-900/40 text-sky-300"
+                                    : "border-slate-700 text-slate-400 hover:bg-slate-800"
+                                }`}
+                              >
+                                {arrange[l.id] ? "Done arranging" : "Arrange ⤢"}
+                              </button>
                             </div>
                             {(() => {
                               const dmap = moduleDistrictMap(tree.districts);
@@ -1287,20 +1307,33 @@ export default function AdminLayouts() {
                                 const d = mid ? dmap.get(mid) : undefined;
                                 return d ? districtColor(d.index) : undefined;
                               };
-                              return (
+                              const fpModules = [...modById.values()].map((m) => ({
+                                id: m.id,
+                                moduleName: m.moduleName,
+                                moduleId: m.moduleId,
+                                lengthTotalInches: m.lengthTotalInches,
+                                mainlineLengthInches: m.mainlineLengthInches,
+                                geometryType: m.geometryType,
+                                geometryDegrees: m.geometryDegrees,
+                                geometryOffsetInches: m.geometryOffsetInches,
+                                mirrored: m.mirrored,
+                                schematic: m.schematic,
+                              }));
+                              return arrange[l.id] ? (
+                                <LayoutCanvas
+                                  modules={fpModules}
+                                  joins={tree.joins}
+                                  colorFor={colorFor}
+                                  onAddJoin={(j) => {
+                                    const explicit = tree.joins
+                                      .filter((x) => !x.implicit)
+                                      .map((x) => ({ id: x.id, a: x.a, b: x.b }));
+                                    saveJoins(l.id, [...explicit, { id: j.id, a: j.a, b: j.b }]);
+                                  }}
+                                />
+                              ) : (
                                 <FootprintMap
-                                  modules={[...modById.values()].map((m) => ({
-                                    id: m.id,
-                                    moduleName: m.moduleName,
-                                    moduleId: m.moduleId,
-                                    lengthTotalInches: m.lengthTotalInches,
-                                    mainlineLengthInches: m.mainlineLengthInches,
-                                    geometryType: m.geometryType,
-                                    geometryDegrees: m.geometryDegrees,
-                                    geometryOffsetInches: m.geometryOffsetInches,
-                                    mirrored: m.mirrored,
-                                    schematic: m.schematic,
-                                  }))}
+                                  modules={fpModules}
                                   joins={tree.joins}
                                   colorFor={colorFor}
                                   legend={districtLegend(tree.districts)}

--- a/components/layout/LayoutCanvas.tsx
+++ b/components/layout/LayoutCanvas.tsx
@@ -1,0 +1,222 @@
+/**
+ * LayoutCanvas (drag-and-drop snap, phase 1) — the merged Layout Map made
+ * interactive. Modules are drawn at their solved-from-joins positions; drag one
+ * and, when an endplate comes within snapping distance of another module's
+ * endplate, the pair highlights (green = configs match, rose = mismatch). Drop
+ * to write an endplate join — the footprint solver then mates them exactly.
+ *
+ * Positions still come from the join graph (composeFootprint); a drag is a
+ * transient on-screen offset used only to CHOOSE which endplates to connect.
+ */
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { composeFootprint, type FootprintModule } from "@/lib/track/footprint";
+import { endplateConfig, type LayoutJoin } from "@/lib/track/layoutJoins";
+import { findSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
+
+const SNAP_RADIUS = 10; // layout inches
+
+export function LayoutCanvas({
+  modules,
+  joins,
+  onAddJoin,
+  colorFor,
+}: {
+  modules: FootprintModule[];
+  joins: (LayoutJoin & { status?: string })[];
+  /** Create an endplate join (a snapped drop). */
+  onAddJoin: (join: LayoutJoin) => void;
+  colorFor?: (placementId: string) => string | undefined;
+}) {
+  const fp = useMemo(() => composeFootprint(modules, joins), [modules, joins]);
+  const modById = useMemo(
+    () => new Map(modules.map((m) => [m.id, m])),
+    [modules],
+  );
+  const svgRef = useRef<SVGSVGElement | null>(null);
+  const [drag, setDrag] = useState<{ id: string; dx: number; dy: number } | null>(null);
+  const startRef = useRef<{ x: number; y: number } | null>(null);
+  const [hit, setHit] = useState<SnapHit | null>(null);
+
+  if (modules.length === 0) {
+    return (
+      <div className="flex h-24 items-center justify-center rounded-md border border-dashed border-slate-700 text-xs text-slate-600">
+        Add modules to arrange them.
+      </div>
+    );
+  }
+
+  // SVG space: y-up layout → y-down screen.
+  const sy = (y: number) => -y;
+  // Endplates of every placed module, in SVG coords, with config.
+  const placedEndplates: (CanvasEndplate & { sx: number; syy: number })[] = fp.placed.flatMap(
+    (m) =>
+      m.endplates.map((e) => ({
+        placementId: m.id,
+        endplateId: e.id,
+        x: e.x,
+        y: sy(e.y),
+        config: endplateConfig(modById.get(m.id), e.id),
+        sx: e.x,
+        syy: sy(e.y),
+      })),
+  );
+
+  const { minX, minY, maxX, maxY } = fp.bbox;
+  const pad = Math.max(24, (maxX - minX) * 0.12);
+  const w = Math.max(1, maxX - minX);
+  const h = Math.max(1, maxY - minY);
+  const vb = `${minX - pad} ${-(maxY + pad)} ${w + pad * 2} ${h + pad * 2}`;
+
+  const clientToUser = (e: React.PointerEvent) => {
+    const svg = svgRef.current!;
+    const p = svg.createSVGPoint();
+    p.x = e.clientX;
+    p.y = e.clientY;
+    const m = svg.getScreenCTM();
+    return m ? p.matrixTransform(m.inverse()) : { x: 0, y: 0 };
+  };
+
+  const onDown = (e: React.PointerEvent, id: string) => {
+    (e.target as Element).setPointerCapture?.(e.pointerId);
+    startRef.current = clientToUser(e);
+    setDrag({ id, dx: 0, dy: 0 });
+    setHit(null);
+  };
+  const onMove = (e: React.PointerEvent) => {
+    if (!drag || !startRef.current) return;
+    const cur = clientToUser(e);
+    const dx = cur.x - startRef.current.x;
+    const dy = cur.y - startRef.current.y;
+    // Dragged module's endplates, shifted; targets are everyone else's.
+    const dragEps = placedEndplates
+      .filter((p) => p.placementId === drag.id)
+      .map((p) => ({ ...p, x: p.sx + dx, y: p.syy + dy }));
+    const targetEps = placedEndplates.filter((p) => p.placementId !== drag.id);
+    setHit(findSnap(dragEps, targetEps, SNAP_RADIUS));
+    setDrag({ id: drag.id, dx, dy });
+  };
+  const onUp = () => {
+    if (drag && hit) {
+      onAddJoin({
+        id: `usr:${hit.drag.placementId}:${hit.drag.endplateId}-${hit.target.placementId}:${hit.target.endplateId}`,
+        a: { placementId: hit.drag.placementId, endplateId: hit.drag.endplateId },
+        b: { placementId: hit.target.placementId, endplateId: hit.target.endplateId },
+      });
+    }
+    setDrag(null);
+    setHit(null);
+    startRef.current = null;
+  };
+
+  return (
+    <div>
+      <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
+        <span>Arrange · drag a module, endplates snap to connect</span>
+        {hit && (
+          <span className={hit.compatible ? "text-emerald-400" : "text-rose-400"}>
+            {hit.compatible ? "Release to connect" : "Mismatch — connect anyway, then Reverse"}
+          </span>
+        )}
+      </div>
+      <svg
+        ref={svgRef}
+        viewBox={vb}
+        width="100%"
+        height="300"
+        preserveAspectRatio="xMidYMid meet"
+        className="touch-none rounded-md border border-slate-700 bg-slate-950/40"
+        onPointerMove={onMove}
+        onPointerUp={onUp}
+        onPointerLeave={onUp}
+      >
+        {fp.placed.map((m) => {
+          const stroke = colorFor?.(m.id) ?? "#64748b";
+          const off = drag?.id === m.id ? { dx: drag.dx, dy: drag.dy } : { dx: 0, dy: 0 };
+          const pts = m.centerline.map((p) => `${p.x + off.dx},${sy(p.y) + off.dy}`).join(" ");
+          const mid = m.centerline[Math.floor(m.centerline.length / 2)];
+          return (
+            <g
+              key={m.id}
+              onPointerDown={(e) => onDown(e, m.id)}
+              style={{ cursor: drag?.id === m.id ? "grabbing" : "grab" }}
+            >
+              <polyline
+                points={pts}
+                fill="none"
+                stroke={stroke}
+                strokeWidth={drag?.id === m.id ? 3 : 2}
+                strokeLinejoin="round"
+                strokeLinecap="round"
+                opacity={drag && drag.id !== m.id ? 0.6 : 1}
+              >
+                <title>{m.moduleName ?? m.id} — drag to connect</title>
+              </polyline>
+              {m.endplates.map((e) => {
+                const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
+                const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
+                const half = 3.2;
+                return (
+                  <line
+                    key={e.id}
+                    x1={e.x - nx * half + off.dx}
+                    y1={sy(e.y - ny * half) + off.dy}
+                    x2={e.x + nx * half + off.dx}
+                    y2={sy(e.y + ny * half) + off.dy}
+                    stroke="#94a3b8"
+                    strokeWidth={1.4}
+                  />
+                );
+              })}
+              {mid && (
+                <text
+                  x={mid.x + off.dx}
+                  y={sy(mid.y) + off.dy - 4}
+                  textAnchor="middle"
+                  fontSize={Math.max(w, h) * 0.03 + 2}
+                  fill="#cbd5e1"
+                  style={{ paintOrder: "stroke", stroke: "#0b1220", strokeWidth: 1, pointerEvents: "none" }}
+                >
+                  {m.moduleName ?? m.id}
+                </text>
+              )}
+            </g>
+          );
+        })}
+
+        {/* Snap candidate highlight */}
+        {hit && (
+          <g pointerEvents="none">
+            {[
+              { x: hit.drag.x, y: hit.drag.y },
+              { x: hit.target.x, y: hit.target.y },
+            ].map((p, i) => (
+              <circle
+                key={i}
+                cx={p.x}
+                cy={p.y}
+                r={SNAP_RADIUS * 0.5}
+                fill="none"
+                stroke={hit.compatible ? "#34d399" : "#f43f5e"}
+                strokeWidth={1.4}
+              />
+            ))}
+            <line
+              x1={hit.drag.x}
+              y1={hit.drag.y}
+              x2={hit.target.x}
+              y2={hit.target.y}
+              stroke={hit.compatible ? "#34d399" : "#f43f5e"}
+              strokeWidth={1}
+              strokeDasharray="2 2"
+            />
+          </g>
+        )}
+      </svg>
+      <p className="mt-1 text-[10px] text-slate-600">
+        Phase 1: drag a module so one of its endplates meets another module&rsquo;s — release to write a join. Positions are solved from the joins; use Reverse (⟲) in the list to turn a module around.
+      </p>
+    </div>
+  );
+}

--- a/lib/track/__tests__/snap.test.ts
+++ b/lib/track/__tests__/snap.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+import { findSnap, type CanvasEndplate } from "../snap";
+
+const ep = (
+  placementId: string,
+  endplateId: string,
+  x: number,
+  y: number,
+  config: "single" | "double" | null = "single",
+): CanvasEndplate => ({ placementId, endplateId, x, y, config });
+
+describe("findSnap", () => {
+  it("returns the nearest opposing endplate within the radius", () => {
+    const drag = [ep("m", "B", 100, 0), ep("m", "A", 0, 0)];
+    const targets = [ep("n", "A", 103, 1), ep("p", "A", 200, 0)];
+    const hit = findSnap(drag, targets, 6)!;
+    expect(hit.drag.endplateId).toBe("B");
+    expect(hit.target.placementId).toBe("n");
+    expect(hit.compatible).toBe(true);
+  });
+
+  it("returns null when nothing is within the radius", () => {
+    expect(findSnap([ep("m", "B", 0, 0)], [ep("n", "A", 50, 0)], 6)).toBeNull();
+  });
+
+  it("flags a single↔double pair as incompatible but still snaps", () => {
+    const hit = findSnap(
+      [ep("m", "B", 0, 0, "single")],
+      [ep("n", "A", 2, 0, "double")],
+      6,
+    )!;
+    expect(hit).not.toBeNull();
+    expect(hit.compatible).toBe(false);
+  });
+
+  it("never snaps an endplate to its own module", () => {
+    expect(findSnap([ep("m", "B", 0, 0)], [ep("m", "A", 1, 0)], 6)).toBeNull();
+  });
+
+  it("picks the closest of several candidates", () => {
+    const hit = findSnap(
+      [ep("m", "B", 0, 0)],
+      [ep("n", "A", 5, 0), ep("p", "A", 2, 0)],
+      6,
+    )!;
+    expect(hit.target.placementId).toBe("p");
+  });
+});

--- a/lib/track/snap.ts
+++ b/lib/track/snap.ts
@@ -1,0 +1,58 @@
+/**
+ * Snap geometry for the drag-and-drop Layout canvas (#reverse follow-up).
+ *
+ * While a module is dragged, its endplates move with it; when one comes within
+ * a snap radius of another module's endplate, that pair is a candidate join. On
+ * drop the candidate becomes a real endplate join and the footprint solver mates
+ * them exactly. Compatibility (single↔single, double↔double) is advisory — the
+ * canvas still lets an incompatible pair snap, flagged, so a user can Reverse a
+ * module to fix it (matching the mismatch model).
+ *
+ * Pure so it unit-tests without a DOM.
+ */
+
+export interface CanvasEndplate {
+  placementId: string;
+  endplateId: string;
+  /** World position (layout inches). */
+  x: number;
+  y: number;
+  /** Track config for compatibility, or null when unknown. */
+  config: "single" | "double" | null;
+}
+
+export interface SnapHit {
+  drag: CanvasEndplate;
+  target: CanvasEndplate;
+  distance: number;
+  compatible: boolean;
+}
+
+/**
+ * The nearest endplate of another module within `radius` of any dragged
+ * endplate — the pair the drop would join. Null when nothing is close.
+ */
+export function findSnap(
+  dragEndplates: CanvasEndplate[],
+  targetEndplates: CanvasEndplate[],
+  radius: number,
+): SnapHit | null {
+  let best: SnapHit | null = null;
+  for (const d of dragEndplates) {
+    for (const t of targetEndplates) {
+      if (t.placementId === d.placementId) continue;
+      const distance = Math.hypot(d.x - t.x, d.y - t.y);
+      if (distance > radius) continue;
+      if (!best || distance < best.distance) {
+        best = {
+          drag: d,
+          target: t,
+          distance,
+          compatible:
+            d.config != null && t.config != null && d.config === t.config,
+        };
+      }
+    }
+  }
+  return best;
+}


### PR DESCRIPTION
First slice of the drag-and-drop layout editor from the [mockup](https://claude.ai/code/artifact/c4604a8f-3411-4d15-acf9-ff549fa0faff).

## What it does
An **"Arrange ⤢"** toggle on the Layout map turns it interactive: **drag a module**, and when one of its endplates comes within snapping distance of another module's, the pair **highlights** (green = configs match, rose = mismatch). **Release to write an endplate join** — the footprint solver then mates them exactly. Pair it with **Reverse (⟲)** to fix a mismatch.

## How it fits the model
Positions still come from the join graph (`composeFootprint`). A drag is a *transient on-screen offset* used only to **choose which endplates to connect**; the drop creates a real join and the solver re-derives the exact position/orientation. No new position storage, no departure from the join model.

## Pieces
- **`snap.ts`** — pure `findSnap(dragEndplates, targetEndplates, radius)` → nearest cross-module endplate pair + compatibility flag. Unit-tested (5 cases).
- **`LayoutCanvas`** — the merged map made draggable, with live snap highlight.
- **`admin/layouts`** — the toggle; a snapped drop appends an explicit join via `saveJoins`.

## Verified live
- Canvas renders in Arrange mode: draggable module groups, endplate ticks, labels.
- The snap→join **data path** (what a drop triggers): creating the loop-closing join persists and re-solves (`status: ok`).
- 163 FD tests pass; typecheck clean.

The literal pointer-drag gesture wasn't automated (synthetic pointer events can't take `setPointerCapture`), so a manual drag is worth a click when convenient — but render, snap geometry, and the join-persistence path are all verified.

## Next phases
Free rotate/reverse on the canvas · ghost preview of the snapped position · detach (drag off to remove a join) · collision-aware placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)