### PR TITLE
feat: draw modules as physical benchwork footprints

### DIFF
--- a/components/layout/FootprintMap.tsx
+++ b/components/layout/FootprintMap.tsx
@@ -14,6 +14,7 @@ import {
   type FootprintModule,
 } from "@/lib/track/footprint";
 import type { LayoutJoin } from "@/lib/track/layoutJoins";
+import { bandOutline, endplateFaces } from "@/lib/track/outline";
 import { MODULE_DRAG_MIME } from "@/components/layout/LayoutSchematic";
 
 type JoinWithStatus = LayoutJoin & { status?: string };
@@ -113,41 +114,70 @@ export function FootprintMap({
         preserveAspectRatio="xMidYMid meet"
         className={`rounded-md border border-slate-700 bg-slate-950/40 ${ring}`}
       >
-        {/* Module centre-lines, coloured by district */}
+        {/* Modules as physical benchwork footprints (12″ Free-moN band), the
+            track centre-line drawn on top, coloured by district. */}
         {fp.placed.map((m) => {
           const stroke = colorFor?.(m.id) ?? "#64748b";
           const pts = m.centerline.map((p) => `${p.x},${fy(p.y)}`).join(" ");
+          const band = bandOutline(m.centerline);
+          const bandPts = band.map((p) => `${p.x},${fy(p.y)}`).join(" ");
           const mid = m.centerline[Math.floor(m.centerline.length / 2)];
           return (
             <g key={m.id}>
+              {band.length > 0 && (
+                <polygon
+                  points={bandPts}
+                  fill={stroke}
+                  fillOpacity={0.16}
+                  stroke={stroke}
+                  strokeOpacity={0.5}
+                  strokeWidth={0.7}
+                  strokeLinejoin="round"
+                />
+              )}
+              {endplateFaces(m.centerline).map((f, i) => (
+                <line
+                  key={`face${i}`}
+                  x1={f.p1.x}
+                  y1={fy(f.p1.y)}
+                  x2={f.p2.x}
+                  y2={fy(f.p2.y)}
+                  stroke={stroke}
+                  strokeWidth={1.6}
+                  strokeLinecap="round"
+                />
+              ))}
               <polyline
                 points={pts}
                 fill="none"
                 stroke={stroke}
-                strokeWidth={2}
+                strokeWidth={1.4}
                 strokeLinejoin="round"
                 strokeLinecap="round"
               >
                 <title>{m.moduleName ?? m.id}</title>
               </polyline>
-              {m.endplates.map((e) => {
-                const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
-                const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
-                const half = 3;
-                return (
-                  <line
-                    key={e.id}
-                    x1={e.x - nx * half}
-                    y1={fy(e.y - ny * half)}
-                    x2={e.x + nx * half}
-                    y2={fy(e.y + ny * half)}
-                    stroke={stroke}
-                    strokeWidth={1.2}
-                  >
-                    <title>{`${m.moduleName ?? m.id} · endplate ${e.id}`}</title>
-                  </line>
-                );
-              })}
+              {/* Branch endplates (C/D…) — the A/B faces are the band ends. */}
+              {m.endplates
+                .filter((e) => e.id !== "A" && e.id !== "B")
+                .map((e) => {
+                  const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
+                  const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
+                  const half = 6;
+                  return (
+                    <line
+                      key={e.id}
+                      x1={e.x - nx * half}
+                      y1={fy(e.y - ny * half)}
+                      x2={e.x + nx * half}
+                      y2={fy(e.y + ny * half)}
+                      stroke={stroke}
+                      strokeWidth={1.6}
+                    >
+                      <title>{`${m.moduleName ?? m.id} · endplate ${e.id}`}</title>
+                    </line>
+                  );
+                })}
               {mid && (
                 <text
                   x={mid.x}

--- a/components/layout/LayoutCanvas.tsx
+++ b/components/layout/LayoutCanvas.tsx
@@ -13,6 +13,7 @@
 import { useMemo, useRef, useState } from "react";
 import { composeFootprint, type FootprintModule } from "@/lib/track/footprint";
 import { endplateConfig, type LayoutJoin } from "@/lib/track/layoutJoins";
+import { bandOutline, endplateFaces } from "@/lib/track/outline";
 import { findSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
 
 const SNAP_RADIUS = 10; // layout inches
@@ -135,13 +136,42 @@ export function LayoutCanvas({
           const stroke = colorFor?.(m.id) ?? "#64748b";
           const off = drag?.id === m.id ? { dx: drag.dx, dy: drag.dy } : { dx: 0, dy: 0 };
           const pts = m.centerline.map((p) => `${p.x + off.dx},${sy(p.y) + off.dy}`).join(" ");
+          const bandPts = bandOutline(m.centerline)
+            .map((p) => `${p.x + off.dx},${sy(p.y) + off.dy}`)
+            .join(" ");
+          const dragging = drag?.id === m.id;
           const mid = m.centerline[Math.floor(m.centerline.length / 2)];
           return (
             <g
               key={m.id}
               onPointerDown={(e) => onDown(e, m.id)}
-              style={{ cursor: drag?.id === m.id ? "grabbing" : "grab" }}
+              style={{ cursor: dragging ? "grabbing" : "grab" }}
             >
+              {/* Physical benchwork footprint — the solid piece you grab. */}
+              {bandPts && (
+                <polygon
+                  points={bandPts}
+                  fill={stroke}
+                  fillOpacity={dragging ? 0.28 : 0.16}
+                  stroke={stroke}
+                  strokeOpacity={dragging ? 0.9 : 0.5}
+                  strokeWidth={0.8}
+                  strokeLinejoin="round"
+                  opacity={drag && !dragging ? 0.6 : 1}
+                />
+              )}
+              {endplateFaces(m.centerline).map((f, i) => (
+                <line
+                  key={`face${i}`}
+                  x1={f.p1.x + off.dx}
+                  y1={sy(f.p1.y) + off.dy}
+                  x2={f.p2.x + off.dx}
+                  y2={sy(f.p2.y) + off.dy}
+                  stroke={stroke}
+                  strokeWidth={1.6}
+                  strokeLinecap="round"
+                />
+              ))}
               <polyline
                 points={pts}
                 fill="none"
@@ -153,22 +183,24 @@ export function LayoutCanvas({
               >
                 <title>{m.moduleName ?? m.id} — drag to connect</title>
               </polyline>
-              {m.endplates.map((e) => {
-                const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
-                const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
-                const half = 3.2;
-                return (
-                  <line
-                    key={e.id}
-                    x1={e.x - nx * half + off.dx}
-                    y1={sy(e.y - ny * half) + off.dy}
-                    x2={e.x + nx * half + off.dx}
-                    y2={sy(e.y + ny * half) + off.dy}
-                    stroke="#94a3b8"
-                    strokeWidth={1.4}
-                  />
-                );
-              })}
+              {m.endplates
+                .filter((e) => e.id !== "A" && e.id !== "B")
+                .map((e) => {
+                  const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
+                  const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
+                  const half = 6;
+                  return (
+                    <line
+                      key={e.id}
+                      x1={e.x - nx * half + off.dx}
+                      y1={sy(e.y - ny * half) + off.dy}
+                      x2={e.x + nx * half + off.dx}
+                      y2={sy(e.y + ny * half) + off.dy}
+                      stroke="#94a3b8"
+                      strokeWidth={1.6}
+                    />
+                  );
+                })}
               {mid && (
                 <text
                   x={mid.x + off.dx}

--- a/lib/track/__tests__/outline.test.ts
+++ b/lib/track/__tests__/outline.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { bandOutline, endplateFaces, FREEMON_ENDPLATE_WIDTH_INCHES } from "../outline";
+
+describe("bandOutline", () => {
+  it("turns a straight centre-line into a rectangle of the given depth", () => {
+    // horizontal A→B, depth 12 → rectangle ±6 around y=0
+    const poly = bandOutline([{ x: 0, y: 0 }, { x: 40, y: 0 }], 12);
+    expect(poly).toHaveLength(4);
+    const ys = poly.map((p) => p.y).sort((a, b) => a - b);
+    expect(ys[0]).toBeCloseTo(-6);
+    expect(ys[3]).toBeCloseTo(6);
+    const xs = poly.map((p) => p.x);
+    expect(Math.min(...xs)).toBeCloseTo(0);
+    expect(Math.max(...xs)).toBeCloseTo(40);
+  });
+
+  it("defaults to the 12 inch Free-moN endplate width", () => {
+    const poly = bandOutline([{ x: 0, y: 0 }, { x: 10, y: 0 }]);
+    expect(FREEMON_ENDPLATE_WIDTH_INCHES).toBe(12);
+    expect(Math.max(...poly.map((p) => p.y))).toBeCloseTo(6);
+  });
+
+  it("returns empty for a degenerate centre-line", () => {
+    expect(bandOutline([{ x: 0, y: 0 }])).toEqual([]);
+  });
+});
+
+describe("endplateFaces", () => {
+  it("gives a face across each end, midpoint at the endplate point", () => {
+    const [a, b] = endplateFaces([{ x: 0, y: 0 }, { x: 40, y: 0 }], 12);
+    expect(a.mid).toEqual({ x: 0, y: 0 });
+    expect(b.mid).toEqual({ x: 40, y: 0 });
+    // the A face spans the full depth across the end (y from -6 to +6)
+    expect(Math.abs(a.p1.y - a.p2.y)).toBeCloseTo(12);
+    expect(a.p1.x).toBeCloseTo(0);
+  });
+});

--- a/lib/track/outline.ts
+++ b/lib/track/outline.ts
@@ -1,0 +1,65 @@
+/**
+ * Module benchwork outline (physical footprint) — a ribbon of the standard
+ * Free-moN endplate width, centred on the module's main-track centre-line. This
+ * turns the layout map from hairline tracks into solid pieces you can see and
+ * grab, with endplate FACES (an edge across the module end) you position and
+ * mate. Pure so it unit-tests without a DOM.
+ *
+ * Free-moN endplates are 12″ wide (min) and 6″ high; height is elevation, not
+ * seen in a top-down map, so the plan-view band is 12″ deep.
+ */
+import type { Pt } from "./footprint";
+
+/** Standard Free-moN endplate width (module depth in plan view), inches. */
+export const FREEMON_ENDPLATE_WIDTH_INCHES = 12;
+
+/** Unit perpendicular (left normal) of the local direction at each vertex. */
+function normals(center: Pt[]): Pt[] {
+  return center.map((_, i) => {
+    const a = center[Math.max(0, i - 1)];
+    const b = center[Math.min(center.length - 1, i + 1)];
+    let dx = b.x - a.x;
+    let dy = b.y - a.y;
+    const len = Math.hypot(dx, dy) || 1;
+    dx /= len;
+    dy /= len;
+    return { x: -dy, y: dx }; // left normal
+  });
+}
+
+/** Closed benchwork polygon: the centre-line offset ±depth/2, out and back. */
+export function bandOutline(
+  center: Pt[],
+  depth = FREEMON_ENDPLATE_WIDTH_INCHES,
+): Pt[] {
+  if (center.length < 2) return [];
+  const half = depth / 2;
+  const n = normals(center);
+  const left = center.map((p, i) => ({ x: p.x + n[i].x * half, y: p.y + n[i].y * half }));
+  const right = center.map((p, i) => ({ x: p.x - n[i].x * half, y: p.y - n[i].y * half }));
+  return [...left, ...right.reverse()];
+}
+
+export interface OutlineFace {
+  /** The two corners of the endplate face (across the module end). */
+  p1: Pt;
+  p2: Pt;
+  /** Face midpoint (the endplate point) and outward direction. */
+  mid: Pt;
+}
+
+/** The two endplate faces (the ribbon's flat ends): [A end, B end]. */
+export function endplateFaces(
+  center: Pt[],
+  depth = FREEMON_ENDPLATE_WIDTH_INCHES,
+): OutlineFace[] {
+  if (center.length < 2) return [];
+  const half = depth / 2;
+  const n = normals(center);
+  const face = (i: number): OutlineFace => ({
+    p1: { x: center[i].x + n[i].x * half, y: center[i].y + n[i].y * half },
+    p2: { x: center[i].x - n[i].x * half, y: center[i].y - n[i].y * half },
+    mid: { x: center[i].x, y: center[i].y },
+  });
+  return [face(0), face(center.length - 1)];
+}


### PR DESCRIPTION
Manual testing showed the Arrange drag felt clumsy — because modules were hairline centre-lines, not physical pieces. This draws them as **solid Free-moN benchwork footprints** so grabbing and snapping read physically.

## What changed
- **`outline.ts`** — pure `bandOutline(centreline, depth)` → the benchwork polygon (centre-line offset ±depth/2), and `endplateFaces()` → the face across each module end. Standard **12″ Free-moN endplate width** = module depth in plan view (the 6″ height is elevation, not drawn top-down). Unit-tested (4 cases).
- **`FootprintMap` + `LayoutCanvas`** — fill the band (district-tinted), draw the track on top, mark the A/B endplate faces; the **Arrange canvas grabs the solid band** instead of a line.

Derived from the centre-line the footprint solver already computes — **no schema or package change**.

## Verified live
- Layout Map: modules render as benchwork bands (4-point rectangles for straights, district-tinted) with track + faces.
- Arrange canvas: each draggable module has a solid benchwork polygon as its grab surface (+ endplate face lines).
- 167 FD tests pass; typecheck clean.

## Next (Phase B)
Author real per-module depth / custom outlines in the Module Repository and sync to FD; until then this uses the 12″ standard. Then the Arrange snapping can go face-to-face on real shapes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)