### PR TITLE
feat: face-to-face endplate snapping

### DIFF
--- a/components/layout/FootprintMap.tsx
+++ b/components/layout/FootprintMap.tsx
@@ -14,6 +14,7 @@ import {
   type FootprintModule,
 } from "@/lib/track/footprint";
 import type { LayoutJoin } from "@/lib/track/layoutJoins";
+import { bandOutline, endplateFaces } from "@/lib/track/outline";
 import { MODULE_DRAG_MIME } from "@/components/layout/LayoutSchematic";
 
 type JoinWithStatus = LayoutJoin & { status?: string };
@@ -113,41 +114,70 @@ export function FootprintMap({
         preserveAspectRatio="xMidYMid meet"
         className={`rounded-md border border-slate-700 bg-slate-950/40 ${ring}`}
       >
-        {/* Module centre-lines, coloured by district */}
+        {/* Modules as physical benchwork footprints (12″ Free-moN band), the
+            track centre-line drawn on top, coloured by district. */}
         {fp.placed.map((m) => {
           const stroke = colorFor?.(m.id) ?? "#64748b";
           const pts = m.centerline.map((p) => `${p.x},${fy(p.y)}`).join(" ");
+          const band = bandOutline(m.centerline);
+          const bandPts = band.map((p) => `${p.x},${fy(p.y)}`).join(" ");
           const mid = m.centerline[Math.floor(m.centerline.length / 2)];
           return (
             <g key={m.id}>
+              {band.length > 0 && (
+                <polygon
+                  points={bandPts}
+                  fill={stroke}
+                  fillOpacity={0.16}
+                  stroke={stroke}
+                  strokeOpacity={0.5}
+                  strokeWidth={0.7}
+                  strokeLinejoin="round"
+                />
+              )}
+              {endplateFaces(m.centerline).map((f, i) => (
+                <line
+                  key={`face${i}`}
+                  x1={f.p1.x}
+                  y1={fy(f.p1.y)}
+                  x2={f.p2.x}
+                  y2={fy(f.p2.y)}
+                  stroke={stroke}
+                  strokeWidth={1.6}
+                  strokeLinecap="round"
+                />
+              ))}
               <polyline
                 points={pts}
                 fill="none"
                 stroke={stroke}
-                strokeWidth={2}
+                strokeWidth={1.4}
                 strokeLinejoin="round"
                 strokeLinecap="round"
               >
                 <title>{m.moduleName ?? m.id}</title>
               </polyline>
-              {m.endplates.map((e) => {
-                const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
-                const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
-                const half = 3;
-                return (
-                  <line
-                    key={e.id}
-                    x1={e.x - nx * half}
-                    y1={fy(e.y - ny * half)}
-                    x2={e.x + nx * half}
-                    y2={fy(e.y + ny * half)}
-                    stroke={stroke}
-                    strokeWidth={1.2}
-                  >
-                    <title>{`${m.moduleName ?? m.id} · endplate ${e.id}`}</title>
-                  </line>
-                );
-              })}
+              {/* Branch endplates (C/D…) — the A/B faces are the band ends. */}
+              {m.endplates
+                .filter((e) => e.id !== "A" && e.id !== "B")
+                .map((e) => {
+                  const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
+                  const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
+                  const half = 6;
+                  return (
+                    <line
+                      key={e.id}
+                      x1={e.x - nx * half}
+                      y1={fy(e.y - ny * half)}
+                      x2={e.x + nx * half}
+                      y2={fy(e.y + ny * half)}
+                      stroke={stroke}
+                      strokeWidth={1.6}
+                    >
+                      <title>{`${m.moduleName ?? m.id} · endplate ${e.id}`}</title>
+                    </line>
+                  );
+                })}
               {mid && (
                 <text
                   x={mid.x}

--- a/components/layout/LayoutCanvas.tsx
+++ b/components/layout/LayoutCanvas.tsx
@@ -13,6 +13,7 @@
 import { useMemo, useRef, useState } from "react";
 import { composeFootprint, type FootprintModule } from "@/lib/track/footprint";
 import { endplateConfig, type LayoutJoin } from "@/lib/track/layoutJoins";
+import { bandOutline, endplateFaces } from "@/lib/track/outline";
 import { findSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
 
 const SNAP_RADIUS = 10; // layout inches
@@ -135,13 +136,42 @@ export function LayoutCanvas({
           const stroke = colorFor?.(m.id) ?? "#64748b";
           const off = drag?.id === m.id ? { dx: drag.dx, dy: drag.dy } : { dx: 0, dy: 0 };
           const pts = m.centerline.map((p) => `${p.x + off.dx},${sy(p.y) + off.dy}`).join(" ");
+          const bandPts = bandOutline(m.centerline)
+            .map((p) => `${p.x + off.dx},${sy(p.y) + off.dy}`)
+            .join(" ");
+          const dragging = drag?.id === m.id;
           const mid = m.centerline[Math.floor(m.centerline.length / 2)];
           return (
             <g
               key={m.id}
               onPointerDown={(e) => onDown(e, m.id)}
-              style={{ cursor: drag?.id === m.id ? "grabbing" : "grab" }}
+              style={{ cursor: dragging ? "grabbing" : "grab" }}
             >
+              {/* Physical benchwork footprint — the solid piece you grab. */}
+              {bandPts && (
+                <polygon
+                  points={bandPts}
+                  fill={stroke}
+                  fillOpacity={dragging ? 0.28 : 0.16}
+                  stroke={stroke}
+                  strokeOpacity={dragging ? 0.9 : 0.5}
+                  strokeWidth={0.8}
+                  strokeLinejoin="round"
+                  opacity={drag && !dragging ? 0.6 : 1}
+                />
+              )}
+              {endplateFaces(m.centerline).map((f, i) => (
+                <line
+                  key={`face${i}`}
+                  x1={f.p1.x + off.dx}
+                  y1={sy(f.p1.y) + off.dy}
+                  x2={f.p2.x + off.dx}
+                  y2={sy(f.p2.y) + off.dy}
+                  stroke={stroke}
+                  strokeWidth={1.6}
+                  strokeLinecap="round"
+                />
+              ))}
               <polyline
                 points={pts}
                 fill="none"
@@ -153,22 +183,24 @@ export function LayoutCanvas({
               >
                 <title>{m.moduleName ?? m.id} — drag to connect</title>
               </polyline>
-              {m.endplates.map((e) => {
-                const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
-                const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
-                const half = 3.2;
-                return (
-                  <line
-                    key={e.id}
-                    x1={e.x - nx * half + off.dx}
-                    y1={sy(e.y - ny * half) + off.dy}
-                    x2={e.x + nx * half + off.dx}
-                    y2={sy(e.y + ny * half) + off.dy}
-                    stroke="#94a3b8"
-                    strokeWidth={1.4}
-                  />
-                );
-              })}
+              {m.endplates
+                .filter((e) => e.id !== "A" && e.id !== "B")
+                .map((e) => {
+                  const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
+                  const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
+                  const half = 6;
+                  return (
+                    <line
+                      key={e.id}
+                      x1={e.x - nx * half + off.dx}
+                      y1={sy(e.y - ny * half) + off.dy}
+                      x2={e.x + nx * half + off.dx}
+                      y2={sy(e.y + ny * half) + off.dy}
+                      stroke="#94a3b8"
+                      strokeWidth={1.6}
+                    />
+                  );
+                })}
               {mid && (
                 <text
                   x={mid.x + off.dx}

--- a/components/layout/LayoutCanvas.tsx
+++ b/components/layout/LayoutCanvas.tsx
@@ -1,22 +1,36 @@
 /**
- * LayoutCanvas (drag-and-drop snap, phase 1) — the merged Layout Map made
- * interactive. Modules are drawn at their solved-from-joins positions; drag one
- * and, when an endplate comes within snapping distance of another module's
- * endplate, the pair highlights (green = configs match, rose = mismatch). Drop
- * to write an endplate join — the footprint solver then mates them exactly.
+ * LayoutCanvas (drag-and-drop, face-to-face snap) — the merged Layout Map made
+ * interactive. Modules are physical benchwork pieces; drag one and, when its
+ * endplate FACE comes alongside another module's face pointing back at it, the
+ * module magnetically MATES — rotating and sliding so the two 24″ faces clamp
+ * together (the way real modules connect). Release writes the endplate join and
+ * the footprint solver locks it in.
  *
- * Positions still come from the join graph (composeFootprint); a drag is a
- * transient on-screen offset used only to CHOOSE which endplates to connect.
+ * All drag math is in world coordinates (y-up); the SVG flips y once at render.
  */
 "use client";
 
 import { useMemo, useRef, useState } from "react";
-import { composeFootprint, type FootprintModule } from "@/lib/track/footprint";
+import { composeFootprint, type FootprintModule, type Pt } from "@/lib/track/footprint";
 import { endplateConfig, type LayoutJoin } from "@/lib/track/layoutJoins";
 import { bandOutline, endplateFaces } from "@/lib/track/outline";
-import { findSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
+import { findFaceSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
 
-const SNAP_RADIUS = 10; // layout inches
+const SNAP_RADIUS = 14; // world inches — endplate faces within this mate
+
+type Pose =
+  | { kind: "free"; dx: number; dy: number }
+  | { kind: "mate"; rot: number; px: number; py: number; tx: number; ty: number };
+
+function applyPose(p: Pt, pose: Pose): Pt {
+  if (pose.kind === "free") return { x: p.x + pose.dx, y: p.y + pose.dy };
+  const a = (pose.rot * Math.PI) / 180;
+  const c = Math.cos(a);
+  const s = Math.sin(a);
+  const rx = (p.x - pose.px) * c - (p.y - pose.py) * s;
+  const ry = (p.x - pose.px) * s + (p.y - pose.py) * c;
+  return { x: rx + pose.tx, y: ry + pose.ty };
+}
 
 export function LayoutCanvas({
   modules,
@@ -26,19 +40,35 @@ export function LayoutCanvas({
 }: {
   modules: FootprintModule[];
   joins: (LayoutJoin & { status?: string })[];
-  /** Create an endplate join (a snapped drop). */
   onAddJoin: (join: LayoutJoin) => void;
   colorFor?: (placementId: string) => string | undefined;
 }) {
   const fp = useMemo(() => composeFootprint(modules, joins), [modules, joins]);
-  const modById = useMemo(
-    () => new Map(modules.map((m) => [m.id, m])),
-    [modules],
-  );
+  const modById = useMemo(() => new Map(modules.map((m) => [m.id, m])), [modules]);
   const svgRef = useRef<SVGSVGElement | null>(null);
-  const [drag, setDrag] = useState<{ id: string; dx: number; dy: number } | null>(null);
   const startRef = useRef<{ x: number; y: number } | null>(null);
-  const [hit, setHit] = useState<SnapHit | null>(null);
+  const [state, setState] = useState<{ id: string; pose: Pose; hit: SnapHit | null } | null>(null);
+
+  // Every placed module's endplates in WORLD coords, with heading + config.
+  const worldEndplates: CanvasEndplate[] = useMemo(
+    () =>
+      fp.placed.flatMap((m) =>
+        m.endplates.map((e) => ({
+          placementId: m.id,
+          endplateId: e.id,
+          x: e.x,
+          y: e.y,
+          heading: e.heading,
+          config: endplateConfig(modById.get(m.id), e.id),
+        })),
+      ),
+    [fp.placed, modById],
+  );
+  const solvedByKey = useMemo(() => {
+    const m = new Map<string, CanvasEndplate>();
+    for (const e of worldEndplates) m.set(`${e.placementId}:${e.endplateId}`, e);
+    return m;
+  }, [worldEndplates]);
 
   if (modules.length === 0) {
     return (
@@ -48,76 +78,79 @@ export function LayoutCanvas({
     );
   }
 
-  // SVG space: y-up layout → y-down screen.
   const sy = (y: number) => -y;
-  // Endplates of every placed module, in SVG coords, with config.
-  const placedEndplates: (CanvasEndplate & { sx: number; syy: number })[] = fp.placed.flatMap(
-    (m) =>
-      m.endplates.map((e) => ({
-        placementId: m.id,
-        endplateId: e.id,
-        x: e.x,
-        y: sy(e.y),
-        config: endplateConfig(modById.get(m.id), e.id),
-        sx: e.x,
-        syy: sy(e.y),
-      })),
-  );
-
   const { minX, minY, maxX, maxY } = fp.bbox;
-  const pad = Math.max(24, (maxX - minX) * 0.12);
+  const pad = Math.max(30, (maxX - minX) * 0.12);
   const w = Math.max(1, maxX - minX);
   const h = Math.max(1, maxY - minY);
   const vb = `${minX - pad} ${-(maxY + pad)} ${w + pad * 2} ${h + pad * 2}`;
+  const font = Math.max(w, h) * 0.03 + 2;
 
-  const clientToUser = (e: React.PointerEvent) => {
+  // Pointer → world (SVG user space is screen space with y flipped).
+  const toWorld = (e: React.PointerEvent) => {
     const svg = svgRef.current!;
     const p = svg.createSVGPoint();
     p.x = e.clientX;
     p.y = e.clientY;
     const m = svg.getScreenCTM();
-    return m ? p.matrixTransform(m.inverse()) : { x: 0, y: 0 };
+    const u = m ? p.matrixTransform(m.inverse()) : { x: 0, y: 0 };
+    return { x: u.x, y: -u.y };
   };
 
   const onDown = (e: React.PointerEvent, id: string) => {
-    (e.target as Element).setPointerCapture?.(e.pointerId);
-    startRef.current = clientToUser(e);
-    setDrag({ id, dx: 0, dy: 0 });
-    setHit(null);
+    try {
+      (e.target as Element).setPointerCapture?.(e.pointerId);
+    } catch {
+      /* capture is best-effort; a synthetic or already-released pointer is fine */
+    }
+    startRef.current = toWorld(e);
+    setState({ id, pose: { kind: "free", dx: 0, dy: 0 }, hit: null });
   };
   const onMove = (e: React.PointerEvent) => {
-    if (!drag || !startRef.current) return;
-    const cur = clientToUser(e);
+    if (!state || !startRef.current) return;
+    const cur = toWorld(e);
     const dx = cur.x - startRef.current.x;
     const dy = cur.y - startRef.current.y;
-    // Dragged module's endplates, shifted; targets are everyone else's.
-    const dragEps = placedEndplates
-      .filter((p) => p.placementId === drag.id)
-      .map((p) => ({ ...p, x: p.sx + dx, y: p.syy + dy }));
-    const targetEps = placedEndplates.filter((p) => p.placementId !== drag.id);
-    setHit(findSnap(dragEps, targetEps, SNAP_RADIUS));
-    setDrag({ id: drag.id, dx, dy });
+    // Dragged module's faces, shifted by the raw drag; targets are the rest.
+    const dragged = worldEndplates
+      .filter((p) => p.placementId === state.id)
+      .map((p) => ({ ...p, x: p.x + dx, y: p.y + dy }));
+    const targets = worldEndplates.filter((p) => p.placementId !== state.id);
+    const hit = findFaceSnap(dragged, targets, SNAP_RADIUS);
+    if (hit) {
+      // Magnetic mate: rotate the solved module so its face opposes the target,
+      // and slide that face onto the target face.
+      const solvedD = solvedByKey.get(`${hit.drag.placementId}:${hit.drag.endplateId}`)!;
+      const rot = (hit.target.heading ?? 0) + 180 - (solvedD.heading ?? 0);
+      setState({
+        id: state.id,
+        hit,
+        pose: { kind: "mate", rot, px: solvedD.x, py: solvedD.y, tx: hit.target.x, ty: hit.target.y },
+      });
+    } else {
+      setState({ id: state.id, hit: null, pose: { kind: "free", dx, dy } });
+    }
   };
   const onUp = () => {
-    if (drag && hit) {
+    if (state?.hit) {
+      const { drag, target } = state.hit;
       onAddJoin({
-        id: `usr:${hit.drag.placementId}:${hit.drag.endplateId}-${hit.target.placementId}:${hit.target.endplateId}`,
-        a: { placementId: hit.drag.placementId, endplateId: hit.drag.endplateId },
-        b: { placementId: hit.target.placementId, endplateId: hit.target.endplateId },
+        id: `usr:${drag.placementId}:${drag.endplateId}-${target.placementId}:${target.endplateId}`,
+        a: { placementId: drag.placementId, endplateId: drag.endplateId },
+        b: { placementId: target.placementId, endplateId: target.endplateId },
       });
     }
-    setDrag(null);
-    setHit(null);
+    setState(null);
     startRef.current = null;
   };
 
   return (
     <div>
       <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
-        <span>Arrange · drag a module, endplates snap to connect</span>
-        {hit && (
-          <span className={hit.compatible ? "text-emerald-400" : "text-rose-400"}>
-            {hit.compatible ? "Release to connect" : "Mismatch — connect anyway, then Reverse"}
+        <span>Arrange · drag a module; endplate faces clamp together</span>
+        {state?.hit && (
+          <span className={state.hit.compatible ? "text-emerald-400" : "text-rose-400"}>
+            {state.hit.compatible ? "Release to connect" : "Faces mate, but track counts differ — Reverse to fix"}
           </span>
         )}
       </div>
@@ -125,7 +158,7 @@ export function LayoutCanvas({
         ref={svgRef}
         viewBox={vb}
         width="100%"
-        height="300"
+        height="320"
         preserveAspectRatio="xMidYMid meet"
         className="touch-none rounded-md border border-slate-700 bg-slate-950/40"
         onPointerMove={onMove}
@@ -134,120 +167,106 @@ export function LayoutCanvas({
       >
         {fp.placed.map((m) => {
           const stroke = colorFor?.(m.id) ?? "#64748b";
-          const off = drag?.id === m.id ? { dx: drag.dx, dy: drag.dy } : { dx: 0, dy: 0 };
-          const pts = m.centerline.map((p) => `${p.x + off.dx},${sy(p.y) + off.dy}`).join(" ");
+          const dragging = state?.id === m.id;
+          const pose: Pose | null = dragging ? state!.pose : null;
+          const tp = (p: Pt) => (pose ? applyPose(p, pose) : p);
           const bandPts = bandOutline(m.centerline)
-            .map((p) => `${p.x + off.dx},${sy(p.y) + off.dy}`)
+            .map(tp)
+            .map((p) => `${p.x},${sy(p.y)}`)
             .join(" ");
-          const dragging = drag?.id === m.id;
-          const mid = m.centerline[Math.floor(m.centerline.length / 2)];
+          const track = m.centerline
+            .map(tp)
+            .map((p) => `${p.x},${sy(p.y)}`)
+            .join(" ");
+          const mid = tp(m.centerline[Math.floor(m.centerline.length / 2)]);
+          const mating = dragging && state!.hit;
           return (
             <g
               key={m.id}
               onPointerDown={(e) => onDown(e, m.id)}
               style={{ cursor: dragging ? "grabbing" : "grab" }}
             >
-              {/* Physical benchwork footprint — the solid piece you grab. */}
               {bandPts && (
                 <polygon
                   points={bandPts}
                   fill={stroke}
-                  fillOpacity={dragging ? 0.28 : 0.16}
+                  fillOpacity={dragging ? 0.3 : 0.16}
                   stroke={stroke}
-                  strokeOpacity={dragging ? 0.9 : 0.5}
+                  strokeOpacity={dragging ? 0.95 : 0.5}
                   strokeWidth={0.8}
                   strokeLinejoin="round"
-                  opacity={drag && !dragging ? 0.6 : 1}
-                />
+                  opacity={state && !dragging ? 0.6 : 1}
+                >
+                  <title>{m.moduleName ?? m.id} — drag to connect</title>
+                </polygon>
               )}
-              {endplateFaces(m.centerline).map((f, i) => (
-                <line
-                  key={`face${i}`}
-                  x1={f.p1.x + off.dx}
-                  y1={sy(f.p1.y) + off.dy}
-                  x2={f.p2.x + off.dx}
-                  y2={sy(f.p2.y) + off.dy}
-                  stroke={stroke}
-                  strokeWidth={1.6}
-                  strokeLinecap="round"
-                />
-              ))}
+              {/* Endplate faces (24″ Free-moN interface) */}
+              {endplateFaces(m.centerline).map((f, i) => {
+                const p1 = tp(f.p1);
+                const p2 = tp(f.p2);
+                return (
+                  <line
+                    key={`face${i}`}
+                    x1={p1.x}
+                    y1={sy(p1.y)}
+                    x2={p2.x}
+                    y2={sy(p2.y)}
+                    stroke={stroke}
+                    strokeWidth={2}
+                    strokeLinecap="round"
+                  />
+                );
+              })}
               <polyline
-                points={pts}
+                points={track}
                 fill="none"
                 stroke={stroke}
-                strokeWidth={drag?.id === m.id ? 3 : 2}
+                strokeWidth={1.4}
                 strokeLinejoin="round"
                 strokeLinecap="round"
-                opacity={drag && drag.id !== m.id ? 0.6 : 1}
-              >
-                <title>{m.moduleName ?? m.id} — drag to connect</title>
-              </polyline>
+              />
+              {/* Branch endplates (C/D…) — the A/B are the band ends */}
               {m.endplates
                 .filter((e) => e.id !== "A" && e.id !== "B")
                 .map((e) => {
                   const nx = Math.cos((e.heading + 90) * (Math.PI / 180));
                   const ny = Math.sin((e.heading + 90) * (Math.PI / 180));
-                  const half = 6;
+                  const a = tp({ x: e.x - nx * 12, y: e.y - ny * 12 });
+                  const b = tp({ x: e.x + nx * 12, y: e.y + ny * 12 });
                   return (
-                    <line
-                      key={e.id}
-                      x1={e.x - nx * half + off.dx}
-                      y1={sy(e.y - ny * half) + off.dy}
-                      x2={e.x + nx * half + off.dx}
-                      y2={sy(e.y + ny * half) + off.dy}
-                      stroke="#94a3b8"
-                      strokeWidth={1.6}
-                    />
+                    <line key={e.id} x1={a.x} y1={sy(a.y)} x2={b.x} y2={sy(b.y)} stroke="#94a3b8" strokeWidth={1.6} />
                   );
                 })}
               {mid && (
                 <text
-                  x={mid.x + off.dx}
-                  y={sy(mid.y) + off.dy - 4}
+                  x={mid.x}
+                  y={sy(mid.y) - 4}
                   textAnchor="middle"
-                  fontSize={Math.max(w, h) * 0.03 + 2}
+                  fontSize={font}
                   fill="#cbd5e1"
                   style={{ paintOrder: "stroke", stroke: "#0b1220", strokeWidth: 1, pointerEvents: "none" }}
                 >
                   {m.moduleName ?? m.id}
                 </text>
               )}
+              {/* Highlight the joined face (where the two clamp) */}
+              {mating && (
+                <circle
+                  cx={state!.hit!.target.x}
+                  cy={sy(state!.hit!.target.y)}
+                  r={7}
+                  fill="none"
+                  stroke={state!.hit!.compatible ? "#34d399" : "#f43f5e"}
+                  strokeWidth={1.6}
+                  pointerEvents="none"
+                />
+              )}
             </g>
           );
         })}
-
-        {/* Snap candidate highlight */}
-        {hit && (
-          <g pointerEvents="none">
-            {[
-              { x: hit.drag.x, y: hit.drag.y },
-              { x: hit.target.x, y: hit.target.y },
-            ].map((p, i) => (
-              <circle
-                key={i}
-                cx={p.x}
-                cy={p.y}
-                r={SNAP_RADIUS * 0.5}
-                fill="none"
-                stroke={hit.compatible ? "#34d399" : "#f43f5e"}
-                strokeWidth={1.4}
-              />
-            ))}
-            <line
-              x1={hit.drag.x}
-              y1={hit.drag.y}
-              x2={hit.target.x}
-              y2={hit.target.y}
-              stroke={hit.compatible ? "#34d399" : "#f43f5e"}
-              strokeWidth={1}
-              strokeDasharray="2 2"
-            />
-          </g>
-        )}
       </svg>
       <p className="mt-1 text-[10px] text-slate-600">
-        Phase 1: drag a module so one of its endplates meets another module&rsquo;s — release to write a join. Positions are solved from the joins; use Reverse (⟲) in the list to turn a module around.
+        Modules are physical 24″-endplate pieces; drag one so its endplate face meets another&rsquo;s and it clamps into place. Positions solve from the joins; use Reverse (⟲) in the list to turn a module around.
       </p>
     </div>
   );

--- a/lib/track/__tests__/outline.test.ts
+++ b/lib/track/__tests__/outline.test.ts
@@ -14,10 +14,10 @@ describe("bandOutline", () => {
     expect(Math.max(...xs)).toBeCloseTo(40);
   });
 
-  it("defaults to the 12 inch Free-moN endplate width", () => {
+  it("defaults to the 24 inch recommended Free-moN endplate width", () => {
     const poly = bandOutline([{ x: 0, y: 0 }, { x: 10, y: 0 }]);
-    expect(FREEMON_ENDPLATE_WIDTH_INCHES).toBe(12);
-    expect(Math.max(...poly.map((p) => p.y))).toBeCloseTo(6);
+    expect(FREEMON_ENDPLATE_WIDTH_INCHES).toBe(24);
+    expect(Math.max(...poly.map((p) => p.y))).toBeCloseTo(12);
   });
 
   it("returns empty for a degenerate centre-line", () => {

--- a/lib/track/__tests__/outline.test.ts
+++ b/lib/track/__tests__/outline.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { bandOutline, endplateFaces, FREEMON_ENDPLATE_WIDTH_INCHES } from "../outline";
+
+describe("bandOutline", () => {
+  it("turns a straight centre-line into a rectangle of the given depth", () => {
+    // horizontal A→B, depth 12 → rectangle ±6 around y=0
+    const poly = bandOutline([{ x: 0, y: 0 }, { x: 40, y: 0 }], 12);
+    expect(poly).toHaveLength(4);
+    const ys = poly.map((p) => p.y).sort((a, b) => a - b);
+    expect(ys[0]).toBeCloseTo(-6);
+    expect(ys[3]).toBeCloseTo(6);
+    const xs = poly.map((p) => p.x);
+    expect(Math.min(...xs)).toBeCloseTo(0);
+    expect(Math.max(...xs)).toBeCloseTo(40);
+  });
+
+  it("defaults to the 12 inch Free-moN endplate width", () => {
+    const poly = bandOutline([{ x: 0, y: 0 }, { x: 10, y: 0 }]);
+    expect(FREEMON_ENDPLATE_WIDTH_INCHES).toBe(12);
+    expect(Math.max(...poly.map((p) => p.y))).toBeCloseTo(6);
+  });
+
+  it("returns empty for a degenerate centre-line", () => {
+    expect(bandOutline([{ x: 0, y: 0 }])).toEqual([]);
+  });
+});
+
+describe("endplateFaces", () => {
+  it("gives a face across each end, midpoint at the endplate point", () => {
+    const [a, b] = endplateFaces([{ x: 0, y: 0 }, { x: 40, y: 0 }], 12);
+    expect(a.mid).toEqual({ x: 0, y: 0 });
+    expect(b.mid).toEqual({ x: 40, y: 0 });
+    // the A face spans the full depth across the end (y from -6 to +6)
+    expect(Math.abs(a.p1.y - a.p2.y)).toBeCloseTo(12);
+    expect(a.p1.x).toBeCloseTo(0);
+  });
+});

--- a/lib/track/__tests__/snap.test.ts
+++ b/lib/track/__tests__/snap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findSnap, type CanvasEndplate } from "../snap";
+import { findSnap, findFaceSnap, type CanvasEndplate } from "../snap";
 
 const ep = (
   placementId: string,
@@ -7,7 +7,8 @@ const ep = (
   x: number,
   y: number,
   config: "single" | "double" | null = "single",
-): CanvasEndplate => ({ placementId, endplateId, x, y, config });
+  heading?: number,
+): CanvasEndplate => ({ placementId, endplateId, x, y, config, heading });
 
 describe("findSnap", () => {
   it("returns the nearest opposing endplate within the radius", () => {
@@ -44,5 +45,40 @@ describe("findSnap", () => {
       6,
     )!;
     expect(hit.target.placementId).toBe("p");
+  });
+});
+
+describe("findFaceSnap", () => {
+  it("mates faces whose normals point at each other (~opposite)", () => {
+    // m:B faces east (0°); n:A faces west (180°) → they meet.
+    const hit = findFaceSnap(
+      [ep("m", "B", 0, 0, "single", 0)],
+      [ep("n", "A", 3, 0, "single", 180)],
+      8,
+    )!;
+    expect(hit).not.toBeNull();
+    expect(hit.target.placementId).toBe("n");
+    expect(hit.compatible).toBe(true);
+  });
+
+  it("does NOT snap faces that point the same way (can't clamp)", () => {
+    // both face east — near, but not opposing.
+    expect(
+      findFaceSnap(
+        [ep("m", "B", 0, 0, "single", 0)],
+        [ep("n", "A", 3, 0, "single", 0)],
+        8,
+      ),
+    ).toBeNull();
+  });
+
+  it("respects the radius even when faces oppose", () => {
+    expect(
+      findFaceSnap(
+        [ep("m", "B", 0, 0, "single", 0)],
+        [ep("n", "A", 40, 0, "single", 180)],
+        8,
+      ),
+    ).toBeNull();
   });
 });

--- a/lib/track/outline.ts
+++ b/lib/track/outline.ts
@@ -1,0 +1,65 @@
+/**
+ * Module benchwork outline (physical footprint) — a ribbon of the standard
+ * Free-moN endplate width, centred on the module's main-track centre-line. This
+ * turns the layout map from hairline tracks into solid pieces you can see and
+ * grab, with endplate FACES (an edge across the module end) you position and
+ * mate. Pure so it unit-tests without a DOM.
+ *
+ * Free-moN endplates are 12″ wide (min) and 6″ high; height is elevation, not
+ * seen in a top-down map, so the plan-view band is 12″ deep.
+ */
+import type { Pt } from "./footprint";
+
+/** Standard Free-moN endplate width (module depth in plan view), inches. */
+export const FREEMON_ENDPLATE_WIDTH_INCHES = 12;
+
+/** Unit perpendicular (left normal) of the local direction at each vertex. */
+function normals(center: Pt[]): Pt[] {
+  return center.map((_, i) => {
+    const a = center[Math.max(0, i - 1)];
+    const b = center[Math.min(center.length - 1, i + 1)];
+    let dx = b.x - a.x;
+    let dy = b.y - a.y;
+    const len = Math.hypot(dx, dy) || 1;
+    dx /= len;
+    dy /= len;
+    return { x: -dy, y: dx }; // left normal
+  });
+}
+
+/** Closed benchwork polygon: the centre-line offset ±depth/2, out and back. */
+export function bandOutline(
+  center: Pt[],
+  depth = FREEMON_ENDPLATE_WIDTH_INCHES,
+): Pt[] {
+  if (center.length < 2) return [];
+  const half = depth / 2;
+  const n = normals(center);
+  const left = center.map((p, i) => ({ x: p.x + n[i].x * half, y: p.y + n[i].y * half }));
+  const right = center.map((p, i) => ({ x: p.x - n[i].x * half, y: p.y - n[i].y * half }));
+  return [...left, ...right.reverse()];
+}
+
+export interface OutlineFace {
+  /** The two corners of the endplate face (across the module end). */
+  p1: Pt;
+  p2: Pt;
+  /** Face midpoint (the endplate point) and outward direction. */
+  mid: Pt;
+}
+
+/** The two endplate faces (the ribbon's flat ends): [A end, B end]. */
+export function endplateFaces(
+  center: Pt[],
+  depth = FREEMON_ENDPLATE_WIDTH_INCHES,
+): OutlineFace[] {
+  if (center.length < 2) return [];
+  const half = depth / 2;
+  const n = normals(center);
+  const face = (i: number): OutlineFace => ({
+    p1: { x: center[i].x + n[i].x * half, y: center[i].y + n[i].y * half },
+    p2: { x: center[i].x - n[i].x * half, y: center[i].y - n[i].y * half },
+    mid: { x: center[i].x, y: center[i].y },
+  });
+  return [face(0), face(center.length - 1)];
+}

--- a/lib/track/outline.ts
+++ b/lib/track/outline.ts
@@ -10,8 +10,12 @@
  */
 import type { Pt } from "./footprint";
 
-/** Standard Free-moN endplate width (module depth in plan view), inches. */
-export const FREEMON_ENDPLATE_WIDTH_INCHES = 12;
+/**
+ * Standard Free-moN endplate width (module depth in plan view), inches — the
+ * connection interface. 12″ is the spec minimum, 24″ the recommended default;
+ * we render the recommended width until a module authors its own.
+ */
+export const FREEMON_ENDPLATE_WIDTH_INCHES = 24;
 
 /** Unit perpendicular (left normal) of the local direction at each vertex. */
 function normals(center: Pt[]): Pt[] {

--- a/lib/track/snap.ts
+++ b/lib/track/snap.ts
@@ -17,8 +17,16 @@ export interface CanvasEndplate {
   /** World position (layout inches). */
   x: number;
   y: number;
+  /** Outward normal (degrees) — for face-to-face mating; optional for point snap. */
+  heading?: number;
   /** Track config for compatibility, or null when unknown. */
   config: "single" | "double" | null;
+}
+
+/** Smallest angle between two headings, 0–180°. */
+function angleBetween(a: number, b: number): number {
+  const d = (((a - b) % 360) + 360) % 360;
+  return d > 180 ? 360 - d : d;
 }
 
 export interface SnapHit {
@@ -43,6 +51,41 @@ export function findSnap(
       if (t.placementId === d.placementId) continue;
       const distance = Math.hypot(d.x - t.x, d.y - t.y);
       if (distance > radius) continue;
+      if (!best || distance < best.distance) {
+        best = {
+          drag: d,
+          target: t,
+          distance,
+          compatible:
+            d.config != null && t.config != null && d.config === t.config,
+        };
+      }
+    }
+  }
+  return best;
+}
+
+/**
+ * Face-to-face variant: the dragged endplate FACE must also be pointing at the
+ * target (their outward normals within `angleTol` of opposite), so the two
+ * modules meet the way you'd physically clamp their endplates — not merely be
+ * near each other. This is what drives the magnetic mate.
+ */
+export function findFaceSnap(
+  dragEndplates: CanvasEndplate[],
+  targetEndplates: CanvasEndplate[],
+  radius: number,
+  angleTol = 40,
+): SnapHit | null {
+  let best: SnapHit | null = null;
+  for (const d of dragEndplates) {
+    if (d.heading == null) continue;
+    for (const t of targetEndplates) {
+      if (t.placementId === d.placementId || t.heading == null) continue;
+      const distance = Math.hypot(d.x - t.x, d.y - t.y);
+      if (distance > radius) continue;
+      // Faces meet when the outward normals are ~opposite (180° apart).
+      if (angleBetween(d.heading, t.heading + 180) > angleTol) continue;
       if (!best || distance < best.distance) {
         best = {
           drag: d,


### PR DESCRIPTION
Building on "the endplate is the standardized interface" — mating is now **face-to-face**, not point-proximity.

## What it does
Drag a module and, when its endplate **face** comes alongside another module's face **pointing back at it**, the module **magnetically mates** — rotating and sliding so the two 24″ faces clamp together, the way real modules connect. Release writes the join; the solver locks it in.

## Changes
- **`findFaceSnap`** — requires the two outward normals to be ~opposite (faces meet), not merely near. Unit-tested (opposing snaps; same-direction doesn't; radius respected).
- **24″ endplate faces** — the recommended Free-moN width (12″ min); band + face default is now 24″.
- **`LayoutCanvas`** — drag math reworked into world coordinates; on a face-snap the dragged module renders at the **mated pose** (rotate about its face + slide onto the target) with the joined face highlighted; drop persists the join. `setPointerCapture` is now fault-tolerant.

## Verified
- Endplate faces render at 24″ (84px on screen) — live.
- Canvas renders draggable module pieces — live.
- `findFaceSnap` opposing-face logic — unit-tested; **170 FD tests pass**; typecheck clean.
- Mate transform is correct by construction (maps the dragged face exactly onto the target face, opposing).

**Honest note:** I couldn't reliably automate the literal pointer-drag gesture (React state timing between synthetic pointer events), so a manual drag of two in-line modules is worth a click. Every piece under the gesture is verified.

## Next
A **rotate control** so you can mate a face that currently points elsewhere (a corner's free end) — pure translation only reaches faces already within ~40° of opposing. Then: per-module authored endplate width in the Module Repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)