### PR TITLE
feat: delete layouts from the admin Layouts page

### DIFF
--- a/app/admin/layouts/page.tsx
+++ b/app/admin/layouts/page.tsx
@@ -552,6 +552,33 @@ export default function AdminLayouts() {
     }
   }
 
+  /** Permanently delete a layout and everything scoped to it (admin). */
+  async function deleteLayout(id: string, name: string, inSession: boolean) {
+    const warning = inSession
+      ? `Delete "${name}"? It's in the active session — the session will lose its layout.\n\nThis also removes its districts, sections, blocks, and module placements. This cannot be undone.`
+      : `Delete "${name}"? This removes its districts, sections, blocks, and module placements. This cannot be undone.`;
+    if (!window.confirm(warning)) return;
+    setBusy(true);
+    try {
+      await apiSend("DELETE", `/api/layouts/${id}`);
+      setTrees((prev) => {
+        const next = { ...prev };
+        delete next[id];
+        return next;
+      });
+      setExpanded((prev) => {
+        const next = new Set(prev);
+        next.delete(id);
+        return next;
+      });
+      await load();
+    } catch (e) {
+      alert(e instanceof Error ? e.message : "delete failed");
+    } finally {
+      setBusy(false);
+    }
+  }
+
   // ---- draft mutations ---------------------------------------------------
   const mutate = (fn: (d: LayoutDraft) => void) =>
     setDraft((prev) => {
@@ -742,6 +769,14 @@ export default function AdminLayouts() {
                         {sessionLayoutId ? "Switch to this" : "Use in session"}
                       </button>
                     )}
+                    <button
+                      disabled={busy}
+                      onClick={() => deleteLayout(l.id, l.name, isCurrent)}
+                      title="Delete this layout permanently"
+                      className="shrink-0 rounded-md border border-slate-700 px-2 py-1 text-xs font-medium text-slate-400 hover:border-red-700/60 hover:bg-red-900/20 hover:text-red-300 disabled:opacity-40"
+                    >
+                      Delete
+                    </button>
                   </div>
                   {expanded.has(l.id) && (
                     <div className="mt-2 space-y-3 pl-5 text-sm">

--- a/app/api/layouts/[id]/route.ts
+++ b/app/api/layouts/[id]/route.ts
@@ -95,3 +95,22 @@ export async function PATCH(
   await trackModel.syncDerivedSections(id);
   return NextResponse.json({ ok: true });
 }
+
+/**
+ * DELETE /api/layouts/:id — permanently delete a layout and everything scoped
+ * to it (Admin). Sessions pointing at it lose the reference (layoutId → null).
+ */
+export async function DELETE(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const guard = requireRole(req, ["admin"]);
+  if (!guard.ok) return guard.response;
+  const { id } = await params;
+
+  const deleted = await trackModel.deleteLayout(id);
+  if (!deleted) {
+    return NextResponse.json({ error: "layout not found" }, { status: 404 });
+  }
+  return NextResponse.json({ ok: true });
+}

--- a/lib/server/TrackModel.ts
+++ b/lib/server/TrackModel.ts
@@ -270,6 +270,20 @@ class TrackModel {
   }
 
   /**
+   * Delete a layout and everything scoped to it. The DB cascades do the work:
+   * districts → sections → blocks, module_layouts → staging_tracks. Any session
+   * pointing at it has its layoutId set null (sessions outlive layouts). Returns
+   * false when no such layout exists (so the route can 404).
+   */
+  async deleteLayout(layoutId: string): Promise<boolean> {
+    const deleted = await db
+      .delete(layouts)
+      .where(eq(layouts.id, layoutId))
+      .returning({ id: layouts.id });
+    return deleted.length > 0;
+  }
+
+  /**
    * All layouts, each with a count of at-risk placements — modules that were
    * removed from the repo or marked inactive/archived by their owner (#160).
    * Surfaced on the layout list so risk is visible without expanding.


### PR DESCRIPTION
Adds the ability to **delete a layout** from FD — requested as groundwork before continuing on the Arrange canvas.

## What it does
Each layout row gets a **Delete** button. Deleting removes the layout and everything scoped to it — **districts → sections → blocks** and **module placements → staging tracks** (the DB `onDelete: cascade` foreign keys do the work). Any **session** pointing at it has its `layoutId` set to null (sessions outlive layouts), so nothing dangles.

## Changes
- **`trackModel.deleteLayout(id)`** — cascade delete; returns `false` when the layout doesn't exist.
- **`DELETE /api/layouts/:id`** (admin-gated) — `200 {ok:true}`, or `404` when not found.
- **Layouts page** — Delete button + `confirm()` that adds an extra warning when the layout is **in the active session**; on success the row is pruned from local state and the list reloads.

## Verified live
- API round-trip: create → in list → `DELETE` → **200 {ok}** → gone from list → `DELETE` again → **404 layout not found**. Cascade confirmed (a layout with a district/section/block/turnout deleted cleanly).
- UI: created a throwaway layout, clicked its **Delete** button (confirm accepted) → the row disappeared.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)