### PR TITLE
feat: rotate control for the Arrange canvas

### DIFF
--- a/components/layout/LayoutCanvas.tsx
+++ b/components/layout/LayoutCanvas.tsx
@@ -1,10 +1,16 @@
 /**
- * LayoutCanvas (drag-and-drop, face-to-face snap) — the merged Layout Map made
- * interactive. Modules are physical benchwork pieces; drag one and, when its
- * endplate FACE comes alongside another module's face pointing back at it, the
- * module magnetically MATES — rotating and sliding so the two 24″ faces clamp
- * together (the way real modules connect). Release writes the endplate join and
+ * LayoutCanvas (drag-and-drop, face-to-face snap, rotate) — the merged Layout
+ * Map made interactive. Modules are physical benchwork pieces; drag one and,
+ * when its endplate FACE comes alongside another module's face pointing back at
+ * it, the module magnetically MATES — the two 24″ faces clamp together (the way
+ * real modules connect). Release, or hit Connect, writes the endplate join and
  * the footprint solver locks it in.
+ *
+ * A ROTATE control turns a selected module in place: a corner module's free
+ * face points off at an angle, so pure translation can't bring it around to
+ * oppose a neighbour. Rotating it does — then the same mate fires. Rotation is
+ * transient (a gesture aid); once a join is committed the solver owns the real
+ * orientation, so nothing about the turn is persisted.
  *
  * All drag math is in world coordinates (y-up); the SVG flips y once at render.
  */
@@ -14,16 +20,17 @@ import { useMemo, useRef, useState } from "react";
 import { composeFootprint, type FootprintModule, type Pt } from "@/lib/track/footprint";
 import { endplateConfig, type LayoutJoin } from "@/lib/track/layoutJoins";
 import { bandOutline, endplateFaces } from "@/lib/track/outline";
+import { applyXf, xfEndplate, ZERO_XF, type Xf } from "@/lib/track/arrange";
 import { findFaceSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
 
 const SNAP_RADIUS = 14; // world inches — endplate faces within this mate
+const ROT_STEP = 15; // degrees per rotate-button click
 
-type Pose =
-  | { kind: "free"; dx: number; dy: number }
-  | { kind: "mate"; rot: number; px: number; py: number; tx: number; ty: number };
+/** The exact "clamped" pose for a mating module: rotate about its face, slide
+ * that face onto the target. */
+type MatePose = { rot: number; px: number; py: number; tx: number; ty: number };
 
-function applyPose(p: Pt, pose: Pose): Pt {
-  if (pose.kind === "free") return { x: p.x + pose.dx, y: p.y + pose.dy };
+function applyMate(p: Pt, pose: MatePose): Pt {
   const a = (pose.rot * Math.PI) / 180;
   const c = Math.cos(a);
   const s = Math.sin(a);
@@ -46,10 +53,14 @@ export function LayoutCanvas({
   const fp = useMemo(() => composeFootprint(modules, joins), [modules, joins]);
   const modById = useMemo(() => new Map(modules.map((m) => [m.id, m])), [modules]);
   const svgRef = useRef<SVGSVGElement | null>(null);
-  const startRef = useRef<{ x: number; y: number } | null>(null);
-  const [state, setState] = useState<{ id: string; pose: Pose; hit: SnapHit | null } | null>(null);
+  const dragRef = useRef<{ id: string; start: Pt; base: Xf } | null>(null);
+  // Transient per-module manual transforms (nudge + rotate). Cleared on commit.
+  const [xf, setXf] = useState<Record<string, Xf>>({});
+  const [sel, setSel] = useState<string | null>(null);
+  // Bump to force a re-render while dragging (dragRef is a ref, not state).
+  const [, force] = useState(0);
 
-  // Every placed module's endplates in WORLD coords, with heading + config.
+  // Every placed module's endplates in solved WORLD coords, with heading+config.
   const worldEndplates: CanvasEndplate[] = useMemo(
     () =>
       fp.placed.flatMap((m) =>
@@ -64,11 +75,62 @@ export function LayoutCanvas({
       ),
     [fp.placed, modById],
   );
+  const pivotOf = useMemo(() => {
+    const m = new Map<string, Pt>();
+    for (const p of fp.placed)
+      m.set(p.id, p.centerline[Math.floor(p.centerline.length / 2)] ?? { x: 0, y: 0 });
+    return m;
+  }, [fp.placed]);
   const solvedByKey = useMemo(() => {
     const m = new Map<string, CanvasEndplate>();
     for (const e of worldEndplates) m.set(`${e.placementId}:${e.endplateId}`, e);
     return m;
   }, [worldEndplates]);
+  // Endplates already clamped to a neighbour. A face can only mate one other, so
+  // these are neither offered as a target nor as a fresh join from the dragged
+  // module — otherwise selecting an already-joined module would "re-mate" it.
+  const occupied = useMemo(() => {
+    const s = new Set<string>();
+    for (const j of joins) {
+      s.add(`${j.a.placementId}:${j.a.endplateId}`);
+      s.add(`${j.b.placementId}:${j.b.endplateId}`);
+    }
+    return s;
+  }, [joins]);
+
+  // The module currently being manipulated (dragged, else selected).
+  const activeId = dragRef.current?.id ?? sel;
+
+  // Best mate for the active module at its current transform, plus the exact
+  // clamp pose to render when it hits.
+  const { hit, matePose } = useMemo((): {
+    hit: SnapHit | null;
+    matePose: MatePose | null;
+  } => {
+    if (!activeId) return { hit: null, matePose: null };
+    const a = xf[activeId] ?? ZERO_XF;
+    const pivot = pivotOf.get(activeId) ?? { x: 0, y: 0 };
+    const dragged = worldEndplates
+      .filter(
+        (p) =>
+          p.placementId === activeId &&
+          !occupied.has(`${p.placementId}:${p.endplateId}`),
+      )
+      .map((p) => xfEndplate(p, a, pivot));
+    const targets = worldEndplates.filter(
+      (p) =>
+        p.placementId !== activeId &&
+        !occupied.has(`${p.placementId}:${p.endplateId}`),
+    );
+    const h = findFaceSnap(dragged, targets, SNAP_RADIUS);
+    if (!h) return { hit: null, matePose: null };
+    const solvedD = solvedByKey.get(`${h.drag.placementId}:${h.drag.endplateId}`)!;
+    const rot = (h.target.heading ?? 0) + 180 - (solvedD.heading ?? 0);
+    return {
+      hit: h,
+      matePose: { rot, px: solvedD.x, py: solvedD.y, tx: h.target.x, ty: h.target.y },
+    };
+  }, [activeId, xf, worldEndplates, pivotOf, solvedByKey, occupied]);
 
   if (modules.length === 0) {
     return (
@@ -97,63 +159,125 @@ export function LayoutCanvas({
     return { x: u.x, y: -u.y };
   };
 
+  const commit = (hh: SnapHit) => {
+    onAddJoin({
+      id: `usr:${hh.drag.placementId}:${hh.drag.endplateId}-${hh.target.placementId}:${hh.target.endplateId}`,
+      a: { placementId: hh.drag.placementId, endplateId: hh.drag.endplateId },
+      b: { placementId: hh.target.placementId, endplateId: hh.target.endplateId },
+    });
+    // The solver re-lays-out everything from the new join; drop all transient
+    // transforms so nothing double-offsets.
+    setXf({});
+    setSel(null);
+    dragRef.current = null;
+  };
+
   const onDown = (e: React.PointerEvent, id: string) => {
     try {
       (e.target as Element).setPointerCapture?.(e.pointerId);
     } catch {
       /* capture is best-effort; a synthetic or already-released pointer is fine */
     }
-    startRef.current = toWorld(e);
-    setState({ id, pose: { kind: "free", dx: 0, dy: 0 }, hit: null });
+    setSel(id);
+    dragRef.current = { id, start: toWorld(e), base: xf[id] ?? ZERO_XF };
+    force((n) => n + 1);
   };
   const onMove = (e: React.PointerEvent) => {
-    if (!state || !startRef.current) return;
+    const d = dragRef.current;
+    if (!d) return;
     const cur = toWorld(e);
-    const dx = cur.x - startRef.current.x;
-    const dy = cur.y - startRef.current.y;
-    // Dragged module's faces, shifted by the raw drag; targets are the rest.
-    const dragged = worldEndplates
-      .filter((p) => p.placementId === state.id)
-      .map((p) => ({ ...p, x: p.x + dx, y: p.y + dy }));
-    const targets = worldEndplates.filter((p) => p.placementId !== state.id);
-    const hit = findFaceSnap(dragged, targets, SNAP_RADIUS);
-    if (hit) {
-      // Magnetic mate: rotate the solved module so its face opposes the target,
-      // and slide that face onto the target face.
-      const solvedD = solvedByKey.get(`${hit.drag.placementId}:${hit.drag.endplateId}`)!;
-      const rot = (hit.target.heading ?? 0) + 180 - (solvedD.heading ?? 0);
-      setState({
-        id: state.id,
-        hit,
-        pose: { kind: "mate", rot, px: solvedD.x, py: solvedD.y, tx: hit.target.x, ty: hit.target.y },
-      });
-    } else {
-      setState({ id: state.id, hit: null, pose: { kind: "free", dx, dy } });
-    }
+    setXf((prev) => ({
+      ...prev,
+      [d.id]: {
+        rot: d.base.rot,
+        dx: d.base.dx + (cur.x - d.start.x),
+        dy: d.base.dy + (cur.y - d.start.y),
+      },
+    }));
   };
   const onUp = () => {
-    if (state?.hit) {
-      const { drag, target } = state.hit;
-      onAddJoin({
-        id: `usr:${drag.placementId}:${drag.endplateId}-${target.placementId}:${target.endplateId}`,
-        a: { placementId: drag.placementId, endplateId: drag.endplateId },
-        b: { placementId: target.placementId, endplateId: target.endplateId },
-      });
-    }
-    setState(null);
-    startRef.current = null;
+    const d = dragRef.current;
+    dragRef.current = null;
+    if (!d) return;
+    if (hit) commit(hit);
+    else force((n) => n + 1); // keep the module where it was dropped
   };
+
+  const rotate = (delta: number) => {
+    if (!sel) return;
+    setXf((prev) => {
+      const cur = prev[sel] ?? ZERO_XF;
+      return { ...prev, [sel]: { ...cur, rot: cur.rot + delta } };
+    });
+  };
+
+  const selName =
+    (sel && (fp.placed.find((m) => m.id === sel)?.moduleName ?? sel)) || null;
 
   return (
     <div>
-      <div className="mb-1 flex items-center justify-between text-xs text-slate-500">
-        <span>Arrange · drag a module; endplate faces clamp together</span>
-        {state?.hit && (
-          <span className={state.hit.compatible ? "text-emerald-400" : "text-rose-400"}>
-            {state.hit.compatible ? "Release to connect" : "Faces mate, but track counts differ — Reverse to fix"}
+      <div className="mb-1 flex flex-wrap items-center gap-2 text-xs text-slate-500">
+        <span>Arrange · drag to move, select to rotate; endplate faces clamp together</span>
+        {hit && (
+          <span className={hit.compatible ? "text-emerald-400" : "text-rose-400"}>
+            {hit.compatible ? "Faces mate — Connect" : "Faces mate, but track counts differ — Reverse to fix"}
           </span>
         )}
       </div>
+
+      {/* Rotate / connect toolbar for the selected module */}
+      {selName && (
+        <div className="mb-1 flex flex-wrap items-center gap-1.5 rounded-md border border-slate-800 bg-slate-900/60 px-2 py-1 text-xs">
+          <span className="text-slate-400">
+            Selected: <span className="text-slate-200">{selName}</span>
+          </span>
+          <span className="ml-1 text-slate-600">rotate</span>
+          <button
+            type="button"
+            onClick={() => rotate(-ROT_STEP)}
+            title={`Rotate ${ROT_STEP}° counter-clockwise`}
+            className="rounded border border-slate-700 px-2 py-0.5 text-slate-300 hover:bg-slate-800"
+          >
+            ↺
+          </button>
+          <button
+            type="button"
+            onClick={() => rotate(ROT_STEP)}
+            title={`Rotate ${ROT_STEP}° clockwise`}
+            className="rounded border border-slate-700 px-2 py-0.5 text-slate-300 hover:bg-slate-800"
+          >
+            ↻
+          </button>
+          {(xf[sel!]?.rot ?? 0) !== 0 && (
+            <span className="font-mono text-slate-500">
+              {(((xf[sel!]!.rot % 360) + 360) % 360).toFixed(0)}°
+            </span>
+          )}
+          {hit && (
+            <button
+              type="button"
+              onClick={() => commit(hit)}
+              disabled={!hit.compatible}
+              title={
+                hit.compatible
+                  ? "Connect the mating endplates"
+                  : "Track counts differ — Reverse a module first"
+              }
+              className="rounded border border-emerald-700/60 bg-emerald-900/30 px-2 py-0.5 font-medium text-emerald-300 hover:bg-emerald-900/50 disabled:opacity-40"
+            >
+              Connect
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setSel(null)}
+            className="ml-auto rounded border border-slate-700 px-2 py-0.5 text-slate-400 hover:bg-slate-800"
+          >
+            Done
+          </button>
+        </div>
+      )}
+
       <svg
         ref={svgRef}
         viewBox={vb}
@@ -167,9 +291,14 @@ export function LayoutCanvas({
       >
         {fp.placed.map((m) => {
           const stroke = colorFor?.(m.id) ?? "#64748b";
-          const dragging = state?.id === m.id;
-          const pose: Pose | null = dragging ? state!.pose : null;
-          const tp = (p: Pt) => (pose ? applyPose(p, pose) : p);
+          const active = activeId === m.id;
+          const selected = sel === m.id;
+          const myXf = xf[m.id] ?? ZERO_XF;
+          const pivot = pivotOf.get(m.id) ?? { x: 0, y: 0 };
+          // When the active module has a mate, render the exact clamp; otherwise
+          // render its transient manual transform.
+          const tp = (p: Pt): Pt =>
+            active && matePose ? applyMate(p, matePose) : applyXf(p, myXf, pivot);
           const bandPts = bandOutline(m.centerline)
             .map(tp)
             .map((p) => `${p.x},${sy(p.y)}`)
@@ -179,25 +308,25 @@ export function LayoutCanvas({
             .map((p) => `${p.x},${sy(p.y)}`)
             .join(" ");
           const mid = tp(m.centerline[Math.floor(m.centerline.length / 2)]);
-          const mating = dragging && state!.hit;
+          const mating = active && hit;
           return (
             <g
               key={m.id}
               onPointerDown={(e) => onDown(e, m.id)}
-              style={{ cursor: dragging ? "grabbing" : "grab" }}
+              style={{ cursor: active ? "grabbing" : "grab" }}
             >
               {bandPts && (
                 <polygon
                   points={bandPts}
                   fill={stroke}
-                  fillOpacity={dragging ? 0.3 : 0.16}
-                  stroke={stroke}
-                  strokeOpacity={dragging ? 0.95 : 0.5}
-                  strokeWidth={0.8}
+                  fillOpacity={active ? 0.3 : selected ? 0.24 : 0.16}
+                  stroke={selected ? "#38bdf8" : stroke}
+                  strokeOpacity={active || selected ? 0.95 : 0.5}
+                  strokeWidth={selected ? 1.4 : 0.8}
                   strokeLinejoin="round"
-                  opacity={state && !dragging ? 0.6 : 1}
+                  opacity={activeId && !active && !selected ? 0.6 : 1}
                 >
-                  <title>{m.moduleName ?? m.id} — drag to connect</title>
+                  <title>{m.moduleName ?? m.id} — drag to move, click to select &amp; rotate</title>
                 </polygon>
               )}
               {/* Endplate faces (24″ Free-moN interface) */}
@@ -252,11 +381,11 @@ export function LayoutCanvas({
               {/* Highlight the joined face (where the two clamp) */}
               {mating && (
                 <circle
-                  cx={state!.hit!.target.x}
-                  cy={sy(state!.hit!.target.y)}
+                  cx={hit!.target.x}
+                  cy={sy(hit!.target.y)}
                   r={7}
                   fill="none"
-                  stroke={state!.hit!.compatible ? "#34d399" : "#f43f5e"}
+                  stroke={hit!.compatible ? "#34d399" : "#f43f5e"}
                   strokeWidth={1.6}
                   pointerEvents="none"
                 />
@@ -266,7 +395,7 @@ export function LayoutCanvas({
         })}
       </svg>
       <p className="mt-1 text-[10px] text-slate-600">
-        Modules are physical 24″-endplate pieces; drag one so its endplate face meets another&rsquo;s and it clamps into place. Positions solve from the joins; use Reverse (⟲) in the list to turn a module around.
+        Modules are physical 24″-endplate pieces. Drag one so its endplate face meets another&rsquo;s and it clamps into place; for a corner, click it to select, then rotate (↺ ↻) until its face swings around to oppose a neighbour. Positions solve from the joins.
       </p>
     </div>
   );

--- a/lib/track/__tests__/arrange.test.ts
+++ b/lib/track/__tests__/arrange.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { applyXf, xfEndplate, ZERO_XF } from "../arrange";
+import { findFaceSnap, type CanvasEndplate } from "../snap";
+
+const ep = (
+  placementId: string,
+  endplateId: string,
+  x: number,
+  y: number,
+  heading: number,
+): CanvasEndplate => ({ placementId, endplateId, x, y, heading, config: "single" });
+
+describe("applyXf", () => {
+  it("is the identity for the zero transform", () => {
+    expect(applyXf({ x: 5, y: -2 }, ZERO_XF, { x: 0, y: 0 })).toEqual({ x: 5, y: -2 });
+  });
+
+  it("rotates about the pivot, then translates", () => {
+    // 90° about origin sends (1,0) → (0,1); then +(3,4).
+    const p = applyXf({ x: 1, y: 0 }, { dx: 3, dy: 4, rot: 90 }, { x: 0, y: 0 });
+    expect(p.x).toBeCloseTo(3);
+    expect(p.y).toBeCloseTo(5);
+  });
+
+  it("leaves the pivot fixed under pure rotation", () => {
+    const p = applyXf({ x: 2, y: 2 }, { dx: 0, dy: 0, rot: 137 }, { x: 2, y: 2 });
+    expect(p.x).toBeCloseTo(2);
+    expect(p.y).toBeCloseTo(2);
+  });
+});
+
+describe("xfEndplate turns a face into mating range", () => {
+  // A corner module's free face points NORTH (90°); the target face points
+  // WEST (180°). They do NOT oppose, so nothing mates as-is…
+  const cornerFace = ep("corner", "B", 0, 0, 90);
+  const target = ep("straight", "A", 3, 0, 180);
+
+  it("does not mate before rotating", () => {
+    expect(findFaceSnap([cornerFace], [target], 8)).toBeNull();
+  });
+
+  it("mates once rotated so the face opposes the target", () => {
+    // Rotate −90° about the face point: heading 90 → 0 (faces EAST), which
+    // opposes the target's WEST-facing normal. Position stays within radius.
+    const turned = xfEndplate(cornerFace, { dx: 0, dy: 0, rot: -90 }, { x: 0, y: 0 });
+    expect(turned.heading).toBeCloseTo(0);
+    const hit = findFaceSnap([turned], [target], 8);
+    expect(hit).not.toBeNull();
+    expect(hit!.target.placementId).toBe("straight");
+    expect(hit!.compatible).toBe(true);
+  });
+
+  it("mates even at a partial rotation within the 40° tolerance", () => {
+    // 60° of the needed 90° leaves the face 30° off opposing — inside tol.
+    const turned = xfEndplate(cornerFace, { dx: 0, dy: 0, rot: -60 }, { x: 0, y: 0 });
+    expect(findFaceSnap([turned], [target], 8)).not.toBeNull();
+  });
+});

--- a/lib/track/arrange.ts
+++ b/lib/track/arrange.ts
@@ -1,0 +1,48 @@
+/**
+ * Arrange-canvas transient transforms (#face-to-face follow-up: rotate control).
+ *
+ * While arranging, a module can be manually nudged (dx, dy) and ROTATED (rot°)
+ * on top of its solved pose — purely to bring an endplate FACE around to oppose
+ * a neighbour so the magnetic mate can fire. Nothing here is persisted: once a
+ * join is committed the footprint solver owns the real orientation. Pure so it
+ * unit-tests without a DOM.
+ */
+import type { Pt } from "./footprint";
+
+/** A transient manual transform: rotate `rot`° about a pivot, then translate. */
+export interface Xf {
+  dx: number;
+  dy: number;
+  rot: number;
+}
+
+export const ZERO_XF: Xf = { dx: 0, dy: 0, rot: 0 };
+
+const DEG = Math.PI / 180;
+
+/** Rotate `p` about `pivot` by `xf.rot`°, then translate by (dx, dy). */
+export function applyXf(p: Pt, xf: Xf, pivot: Pt): Pt {
+  const a = xf.rot * DEG;
+  const c = Math.cos(a);
+  const s = Math.sin(a);
+  const ox = p.x - pivot.x;
+  const oy = p.y - pivot.y;
+  return {
+    x: pivot.x + ox * c - oy * s + xf.dx,
+    y: pivot.y + ox * s + oy * c + xf.dy,
+  };
+}
+
+/**
+ * Apply an Xf to an endplate: its point rotates+translates about the pivot and
+ * its outward normal (heading) turns by `rot`. Position drives proximity; the
+ * turned heading is what lets a corner's face come around to oppose a target.
+ */
+export function xfEndplate<T extends { x: number; y: number; heading?: number }>(
+  e: T,
+  xf: Xf,
+  pivot: Pt,
+): T {
+  const p = applyXf(e, xf, pivot);
+  return { ...e, x: p.x, y: p.y, heading: (e.heading ?? 0) + xf.rot };
+}


### PR DESCRIPTION
Completes face-to-face mating for **corner modules**. Previously pure translation only reached faces already within ~40° of opposing, so a corner's free face (pointing off at 90°) could never be brought around to clamp. Now you can **turn a module in place**.

## What it does
- **Click a module to select it** (blue outline). A toolbar appears with **↺ / ↻** rotate buttons, a live **angle readout**, **Connect**, and **Done**.
- **Rotating** turns the module about its centroid. Once a face swings within the mate tolerance of an opposing **free** face, the same magnetic clamp fires — hit **Connect** (or release a drag) to write the join.
- Rotation is a **transient gesture aid**: the footprint solver owns the real orientation once a join exists, so nothing about the turn is persisted (no schema/API change).

## Correctness fix (found in live testing)
Mate candidates now **exclude endplates already clamped to a neighbour** — a face can only mate one other. Without this, selecting an already-joined module would re-detect its existing neighbour as a "hit" and releasing would commit a spurious duplicate join.

## Verified
- **Unit (pure math, `lib/track/arrange.ts`):** a corner face rotated into opposition mates via `findFaceSnap`, including at a partial turn inside the 40° tolerance; `applyXf` rotates-about-pivot-then-translates and is exactly reversible. **176 tests pass**, typecheck clean.
- **Live (dev server, "Geometry Demo"):** selecting a module shows the toolbar and **survives release without connecting** (fix confirmed); **↻×3** turns it a readout-confirmed **45°** and visibly re-renders the benchwork band; **↺×3** returns it exactly to the start. Screenshot shows the selected module turned 45° off the chain with joins unchanged.

## Next
Per-module authored endplate width (12–24″) in the Module Repository, so footprints use each module's real face size instead of the recommended-24″ default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)