### PR TITLE
feat: flush endplate mating for corners (drag auto-rotates to clamp)

### DIFF
--- a/components/layout/LayoutCanvas.tsx
+++ b/components/layout/LayoutCanvas.tsx
@@ -1,10 +1,13 @@
 /**
- * LayoutCanvas (drag-and-drop, face-to-face snap) — the merged Layout Map made
- * interactive. Modules are physical benchwork pieces; drag one and, when its
- * endplate FACE comes alongside another module's face pointing back at it, the
- * module magnetically MATES — rotating and sliding so the two 24″ faces clamp
- * together (the way real modules connect). Release writes the endplate join and
- * the footprint solver locks it in.
+ * LayoutCanvas (drag-and-drop, flush endplate mating) — the merged Layout Map
+ * made interactive. Modules are physical benchwork pieces; drag one so its free
+ * endplate comes near another module's free endplate and it magnetically MATES:
+ * the module rotates and slides until the two 24″ faces are FLUSH — coincident
+ * and pointing into each other (the way real modules clamp). The rotation is
+ * whatever the mate takes, so a corner's free face swings fully around; it is
+ * never dialed in by hand, and a module can't rest with an endplate floating in
+ * open space — release with no mate in range and it returns to where the solver
+ * had it. Release on a mate writes the endplate join and the solver locks it in.
  *
  * All drag math is in world coordinates (y-up); the SVG flips y once at render.
  */
@@ -14,7 +17,8 @@ import { useMemo, useRef, useState } from "react";
 import { composeFootprint, type FootprintModule, type Pt } from "@/lib/track/footprint";
 import { endplateConfig, type LayoutJoin } from "@/lib/track/layoutJoins";
 import { bandOutline, endplateFaces } from "@/lib/track/outline";
-import { findFaceSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
+import { flushMatePose } from "@/lib/track/mate";
+import { findSnap, type CanvasEndplate, type SnapHit } from "@/lib/track/snap";
 
 const SNAP_RADIUS = 14; // world inches — endplate faces within this mate
 
@@ -69,6 +73,18 @@ export function LayoutCanvas({
     for (const e of worldEndplates) m.set(`${e.placementId}:${e.endplateId}`, e);
     return m;
   }, [worldEndplates]);
+  // Endplates already clamped to a neighbour. A face mates exactly one other, so
+  // an occupied endplate is neither a mate target nor a fresh mate from the
+  // dragged module — otherwise a module's existing joins would re-snap the
+  // instant you grabbed it and drop a duplicate join.
+  const occupied = useMemo(() => {
+    const s = new Set<string>();
+    for (const j of joins) {
+      s.add(`${j.a.placementId}:${j.a.endplateId}`);
+      s.add(`${j.b.placementId}:${j.b.endplateId}`);
+    }
+    return s;
+  }, [joins]);
 
   if (modules.length === 0) {
     return (
@@ -111,22 +127,31 @@ export function LayoutCanvas({
     const cur = toWorld(e);
     const dx = cur.x - startRef.current.x;
     const dy = cur.y - startRef.current.y;
-    // Dragged module's faces, shifted by the raw drag; targets are the rest.
+    // The dragged module's FREE endplates, shifted by the raw drag; candidates
+    // are every other module's free endplates. Nearest within radius wins.
     const dragged = worldEndplates
-      .filter((p) => p.placementId === state.id)
+      .filter(
+        (p) =>
+          p.placementId === state.id &&
+          !occupied.has(`${p.placementId}:${p.endplateId}`),
+      )
       .map((p) => ({ ...p, x: p.x + dx, y: p.y + dy }));
-    const targets = worldEndplates.filter((p) => p.placementId !== state.id);
-    const hit = findFaceSnap(dragged, targets, SNAP_RADIUS);
+    const targets = worldEndplates.filter(
+      (p) =>
+        p.placementId !== state.id &&
+        !occupied.has(`${p.placementId}:${p.endplateId}`),
+    );
+    const hit = findSnap(dragged, targets, SNAP_RADIUS);
     if (hit) {
-      // Magnetic mate: rotate the solved module so its face opposes the target,
-      // and slide that face onto the target face.
+      // Magnetic FLUSH mate: land the dragged endplate exactly on the target,
+      // outward normals opposite — rotating the module however much that takes
+      // (a corner's free face swings all the way around).
       const solvedD = solvedByKey.get(`${hit.drag.placementId}:${hit.drag.endplateId}`)!;
-      const rot = (hit.target.heading ?? 0) + 180 - (solvedD.heading ?? 0);
-      setState({
-        id: state.id,
-        hit,
-        pose: { kind: "mate", rot, px: solvedD.x, py: solvedD.y, tx: hit.target.x, ty: hit.target.y },
-      });
+      const mp = flushMatePose(
+        { x: solvedD.x, y: solvedD.y, heading: solvedD.heading ?? 0 },
+        { x: hit.target.x, y: hit.target.y, heading: hit.target.heading ?? 0 },
+      );
+      setState({ id: state.id, hit, pose: { kind: "mate", ...mp } });
     } else {
       setState({ id: state.id, hit: null, pose: { kind: "free", dx, dy } });
     }

--- a/lib/track/__tests__/mate.test.ts
+++ b/lib/track/__tests__/mate.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { flushMatePose, applyMatePose, matedHeading } from "../mate";
+
+describe("flushMatePose lands endplates flush from any angle", () => {
+  it("mates two already-opposing faces (no rotation needed)", () => {
+    const drag = { x: 0, y: 0, heading: 0 }; // faces east
+    const target = { x: 3, y: 0, heading: 180 }; // faces west
+    const pose = flushMatePose(drag, target);
+    // the dragged endplate point lands exactly on the target point…
+    const p = applyMatePose({ x: drag.x, y: drag.y }, pose);
+    expect(p.x).toBeCloseTo(3);
+    expect(p.y).toBeCloseTo(0);
+    // …and its outward normal is opposite the target's.
+    expect(((matedHeading(drag.heading, pose) % 360) + 360) % 360).toBeCloseTo(0);
+    expect(((pose.rot % 360) + 360) % 360).toBeCloseTo(0);
+  });
+
+  it("swings a corner's free face fully around to clamp (90° start)", () => {
+    // corner free face points NORTH (90°); neighbour's free face points WEST.
+    const corner = { x: 0, y: 0, heading: 90 };
+    const target = { x: 5, y: 2, heading: 180 };
+    const pose = flushMatePose(corner, target);
+    const p = applyMatePose({ x: corner.x, y: corner.y }, pose);
+    expect(p.x).toBeCloseTo(5);
+    expect(p.y).toBeCloseTo(2);
+    // outward normals end up opposite: corner → EAST (0°), target → WEST (180°).
+    const h = ((matedHeading(corner.heading, pose) % 360) + 360) % 360;
+    expect(h).toBeCloseTo(0);
+  });
+
+  it("carries the rest of the module rigidly (a second point rotates with it)", () => {
+    // A straight module: endplate at origin facing north, other end 24″ north.
+    const drag = { x: 0, y: 0, heading: 90 };
+    const target = { x: 0, y: 0, heading: 0 }; // faces east → module must face west
+    const pose = flushMatePose(drag, target);
+    // The far end (0,24) is 24″ from the mated endplate; after mating the whole
+    // body is rigid, so it stays 24″ from the target point.
+    const far = applyMatePose({ x: 0, y: 24 }, pose);
+    const d = Math.hypot(far.x - target.x, far.y - target.y);
+    expect(d).toBeCloseTo(24);
+  });
+});

--- a/lib/track/__tests__/snap.test.ts
+++ b/lib/track/__tests__/snap.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { findSnap, findFaceSnap, type CanvasEndplate } from "../snap";
+import { findSnap, type CanvasEndplate } from "../snap";
 
 const ep = (
   placementId: string,
@@ -45,40 +45,5 @@ describe("findSnap", () => {
       6,
     )!;
     expect(hit.target.placementId).toBe("p");
-  });
-});
-
-describe("findFaceSnap", () => {
-  it("mates faces whose normals point at each other (~opposite)", () => {
-    // m:B faces east (0°); n:A faces west (180°) → they meet.
-    const hit = findFaceSnap(
-      [ep("m", "B", 0, 0, "single", 0)],
-      [ep("n", "A", 3, 0, "single", 180)],
-      8,
-    )!;
-    expect(hit).not.toBeNull();
-    expect(hit.target.placementId).toBe("n");
-    expect(hit.compatible).toBe(true);
-  });
-
-  it("does NOT snap faces that point the same way (can't clamp)", () => {
-    // both face east — near, but not opposing.
-    expect(
-      findFaceSnap(
-        [ep("m", "B", 0, 0, "single", 0)],
-        [ep("n", "A", 3, 0, "single", 0)],
-        8,
-      ),
-    ).toBeNull();
-  });
-
-  it("respects the radius even when faces oppose", () => {
-    expect(
-      findFaceSnap(
-        [ep("m", "B", 0, 0, "single", 0)],
-        [ep("n", "A", 40, 0, "single", 180)],
-        8,
-      ),
-    ).toBeNull();
   });
 });

--- a/lib/track/mate.ts
+++ b/lib/track/mate.ts
@@ -1,0 +1,58 @@
+/**
+ * Flush endplate mating for the Arrange canvas.
+ *
+ * Modules connect endplate-to-endplate, always FLUSH — a module can never rest
+ * with an endplate floating in open space. So when a dragged module's free
+ * endplate is brought near another module's free endplate, we compute the rigid
+ * transform that lands the two faces flush: the same physical point, outward
+ * normals exactly opposite. The rotation is whatever that takes — a corner
+ * module's free face swings fully around to meet its neighbour. Rotation is
+ * therefore never dialed in by hand; it is entirely derived from the endplate
+ * being matched. Pure so it unit-tests without a DOM.
+ */
+import type { Pt } from "./footprint";
+
+/** Rotate `rot`° about a pivot, then translate so the pivot lands on (tx, ty). */
+export interface MatePose {
+  rot: number;
+  px: number;
+  py: number;
+  tx: number;
+  ty: number;
+}
+
+const DEG = Math.PI / 180;
+
+/**
+ * The pose that lands the dragged module's `drag` endplate flush on `target`:
+ * coincident point, opposite outward normal. Independent of the dragged
+ * module's starting angle — that's what lets a corner's face come around to
+ * clamp.
+ */
+export function flushMatePose(
+  drag: { x: number; y: number; heading: number },
+  target: { x: number; y: number; heading: number },
+): MatePose {
+  return {
+    rot: target.heading + 180 - drag.heading,
+    px: drag.x,
+    py: drag.y,
+    tx: target.x,
+    ty: target.y,
+  };
+}
+
+/** Apply a mate pose to a point (rotate about the pivot, then translate). */
+export function applyMatePose(p: Pt, pose: MatePose): Pt {
+  const a = pose.rot * DEG;
+  const c = Math.cos(a);
+  const s = Math.sin(a);
+  const rx = (p.x - pose.px) * c - (p.y - pose.py) * s;
+  const ry = (p.x - pose.px) * s + (p.y - pose.py) * c;
+  return { x: rx + pose.tx, y: ry + pose.ty };
+}
+
+/** How a heading (outward normal) turns under a mate pose. */
+export function matedHeading(heading: number, pose: MatePose): number {
+  return heading + pose.rot;
+}

--- a/lib/track/snap.ts
+++ b/lib/track/snap.ts
@@ -23,12 +23,6 @@ export interface CanvasEndplate {
   config: "single" | "double" | null;
 }
 
-/** Smallest angle between two headings, 0–180°. */
-function angleBetween(a: number, b: number): number {
-  const d = (((a - b) % 360) + 360) % 360;
-  return d > 180 ? 360 - d : d;
-}
-
 export interface SnapHit {
   drag: CanvasEndplate;
   target: CanvasEndplate;
@@ -51,41 +45,6 @@ export function findSnap(
       if (t.placementId === d.placementId) continue;
       const distance = Math.hypot(d.x - t.x, d.y - t.y);
       if (distance > radius) continue;
-      if (!best || distance < best.distance) {
-        best = {
-          drag: d,
-          target: t,
-          distance,
-          compatible:
-            d.config != null && t.config != null && d.config === t.config,
-        };
-      }
-    }
-  }
-  return best;
-}
-
-/**
- * Face-to-face variant: the dragged endplate FACE must also be pointing at the
- * target (their outward normals within `angleTol` of opposite), so the two
- * modules meet the way you'd physically clamp their endplates — not merely be
- * near each other. This is what drives the magnetic mate.
- */
-export function findFaceSnap(
-  dragEndplates: CanvasEndplate[],
-  targetEndplates: CanvasEndplate[],
-  radius: number,
-  angleTol = 40,
-): SnapHit | null {
-  let best: SnapHit | null = null;
-  for (const d of dragEndplates) {
-    if (d.heading == null) continue;
-    for (const t of targetEndplates) {
-      if (t.placementId === d.placementId || t.heading == null) continue;
-      const distance = Math.hypot(d.x - t.x, d.y - t.y);
-      if (distance > radius) continue;
-      // Faces meet when the outward normals are ~opposite (180° apart).
-      if (angleBetween(d.heading, t.heading + 180) > angleTol) continue;
       if (!best || distance < best.distance) {
         best = {
           drag: d,


### PR DESCRIPTION
Replaces the earlier (closed) rotate-control approach, which was wrong: free-form rotation let a module rest with its endplate **floating in open space**, which is physically impossible.

## The rule this enforces
Endplates clamp **flush** — same point, outward normals opposite. A module can only ever be turned **to meet another endplate**, never dialed to an arbitrary angle, and can never rest disconnected in space.

## How it works now
Drag a module so its **free** endplate comes near another module's **free** endplate → it rotates and slides until the two 24″ faces are **flush**. The rotation is whatever the mate takes, so a **corner's free face swings fully around** to clamp. Release with no mate in range → the module **returns to where the solver had it**.

## Changes
- **Replaces the angle-gated `findFaceSnap`** (only snapped faces already within ~40° of opposing — the reason corners never mated) with proximity **`findSnap`** over free endplates + a flush mate transform.
- **`flushMatePose`** (`lib/track/mate.ts`, pure + unit-tested): lands the dragged endplate exactly on the target with opposite normal, **from any starting angle**, carrying the rest of the module rigidly.
- **Excludes already-clamped endplates** from mate candidates, so an existing join can't re-snap and drop a duplicate the instant you grab a module.
- Removes `findFaceSnap` / `angleBetween` and their tests.

## Verified (dev server, live)
- **No free-rotate control** anywhere.
- Dragging a module into empty space **returns it home** — it never rests floating/turned.
- Dragging a straight module's free **B** endplate (pointing well away — a 279 px drag) onto a curve's free **A** endplate **auto-rotated it flush** and wrote the join (explicit joins 0 → 1); the single/double compatibility flag fired correctly.
- **170 tests pass**, typecheck clean. Throwaway test layout cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)