### PR TITLE
feat: render a module's authored benchwork outline

### DIFF
--- a/components/layout/FootprintMap.tsx
+++ b/components/layout/FootprintMap.tsx
@@ -122,7 +122,8 @@ export function FootprintMap({
           // Per-endplate authored face widths (A end / B end); band tapers between.
           const wA = m.endplates.find((e) => e.id === "A")?.width ?? 24;
           const wB = m.endplates.find((e) => e.id === "B")?.width ?? 24;
-          const band = bandOutline(m.centerline, wA, wB);
+          // The authored benchwork outline if drawn, else the derived band.
+          const band = m.outline ?? bandOutline(m.centerline, wA, wB);
           const bandPts = band.map((p) => `${p.x},${fy(p.y)}`).join(" ");
           const mid = m.centerline[Math.floor(m.centerline.length / 2)];
           return (

--- a/components/layout/LayoutCanvas.tsx
+++ b/components/layout/LayoutCanvas.tsx
@@ -253,7 +253,8 @@ export function LayoutCanvas({
           // Per-endplate authored face widths (A end / B end); band tapers between.
           const wA = m.endplates.find((e) => e.id === "A")?.width ?? 24;
           const wB = m.endplates.find((e) => e.id === "B")?.width ?? 24;
-          const bandPts = bandOutline(m.centerline, wA, wB)
+          // The authored benchwork outline if drawn, else the derived band.
+          const bandPts = (m.outline ?? bandOutline(m.centerline, wA, wB))
             .map(tp)
             .map((p) => `${p.x},${sy(p.y)}`)
             .join(" ");

--- a/lib/track/__tests__/footprint.test.ts
+++ b/lib/track/__tests__/footprint.test.ts
@@ -44,6 +44,40 @@ describe("composeFootprint endplate widths", () => {
     expect(m.endplates.find((e) => e.id === "A")!.width).toBe(12);
     expect(m.endplates.find((e) => e.id === "B")!.width).toBe(24); // recommended default
   });
+
+  it("transforms an authored benchwork outline into world coords, else null", () => {
+    const ring = [
+      { x: 0, y: -10 },
+      { x: 100, y: -10 },
+      { x: 100, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    const withOutline: FootprintModule = {
+      id: "m",
+      moduleName: "m",
+      lengthTotalInches: 100,
+      geometryType: "straight",
+      schematic: {
+        version: 1,
+        lengthInches: 100,
+        endplates: [{ id: "A" }, { id: "B" }],
+        tracks: [{ id: "main", role: "main", lane: 0, from: "A", to: "B" }],
+        outline: ring,
+      },
+    };
+    // Root module places at the origin (identity) → outline passes through unchanged.
+    const fp = composeFootprint([withOutline], []);
+    expect(fp.placed[0].outline).toEqual(ring);
+    // No outline → null (renderers fall back to the band).
+    expect(composeFootprint([straight("s")], []).placed[0].outline).toBeNull();
+    // A <3-point ring isn't a benchwork outline.
+    expect(
+      composeFootprint(
+        [{ ...withOutline, schematic: { ...withOutline.schematic, outline: ring.slice(0, 2) } } as FootprintModule],
+        [],
+      ).placed[0].outline,
+    ).toBeNull();
+  });
 });
 
 describe("composeFootprint", () => {

--- a/lib/track/footprint.ts
+++ b/lib/track/footprint.ts
@@ -67,6 +67,9 @@ export interface PlacedModule {
   endplates: { id: string; x: number; y: number; heading: number; width: number }[];
   /** Module centre-line in world coords (main track A→B). */
   centerline: Pt[];
+  /** Authored benchwork footprint outline in world coords (closed ring), or
+   * null when the module hasn't drawn one (render the derived band instead). */
+  outline: Pt[] | null;
 }
 
 export interface ClosureError {
@@ -203,6 +206,17 @@ export function composeFootprint(
     const w = e?.widthInches;
     return typeof w === "number" && w > 0 ? w : RECOMMENDED_ENDPLATE_WIDTH_INCHES;
   };
+  // Authored benchwork outline (module-local inches), read defensively so it
+  // renders the moment a doc carries it. A ring needs ≥3 finite points.
+  const outlineOf = (mid: string): Pt[] | null => {
+    const doc = asModuleSchematic(byId.get(mid)?.schematic) as
+      | { outline?: { x: number; y: number }[] | null }
+      | null;
+    const pts = (doc?.outline ?? []).filter(
+      (p) => p && Number.isFinite(p.x) && Number.isFinite(p.y),
+    );
+    return pts.length >= 3 ? pts.map((p) => ({ x: p.x, y: p.y })) : null;
+  };
 
   // Adjacency: placement -> joins touching it.
   const adj = new Map<string, LayoutJoin[]>();
@@ -308,11 +322,17 @@ export function composeFootprint(
       track(w);
       return { id: p.id, x: w.x, y: w.y, heading: w.heading, width: widthOf(m.id, p.id) };
     });
+    const localOutline = outlineOf(m.id);
+    const outline = localOutline
+      ? localOutline.map((p) => applyPoint(t, p))
+      : null;
+    outline?.forEach(track);
     placed.push({
       id: m.id,
       moduleName: m.moduleName ?? null,
       endplates,
       centerline,
+      outline,
     });
   }
   if (!isFinite(minX)) {


### PR DESCRIPTION
The FD half of **benchwork-outline authoring** (shared contract is [module-schematic #4](https://github.com/willcgage/module-schematic/pull/4); the MR shape editor is a separate PR). Ships **independently and green** — reads the outline defensively from the doc, no package bump.

## What it does
When a module authors a benchwork footprint outline, the layout map draws **that actual polygon** — real board shapes (corners, L-shapes, angled fronts) to scale — instead of the approximate endplate-width band. Modules without an outline are unchanged.

## Changes
- **`composeFootprint`** reads the doc's `outline` (defensively) and transforms it by the module's **solved placement** into world coords → `PlacedModule.outline`; the ring contributes to the layout bbox. `null` when a module hasn't drawn one.
- **`FootprintMap` + `LayoutCanvas`** draw `m.outline` when present, else the derived band; endplate faces still mark the standard interface at the ends.

## Verified
- **Unit:** the solver transforms an authored ring into world coords and returns `null` for none / <3 points. **173 tests pass**, typecheck clean.
- **Live:** an **L-shaped** outline authored on a real module (via the production doc) synced through and rendered as the **exact 6-vertex polygon** — `(0,-12)→(60,-12)→(60,-30)→(96,-30)→(96,12)→(0,12)`, matching point-for-point. Modules without an outline render exactly as before.

## Pairs with
- Contract: [module-schematic #4](https://github.com/willcgage/module-schematic/pull/4).
- Authoring: the MR schematic shape editor (separate PR) writes `outline`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)