### PR TITLE
feat: render curved benchwork edges (arc tessellation)

### DIFF
--- a/lib/track/__tests__/footprint.test.ts
+++ b/lib/track/__tests__/footprint.test.ts
@@ -73,10 +73,38 @@ describe("composeFootprint endplate widths", () => {
     // A <3-point ring isn't a benchwork outline.
     expect(
       composeFootprint(
-        [{ ...withOutline, schematic: { ...withOutline.schematic, outline: ring.slice(0, 2) } } as FootprintModule],
+        [{ ...withOutline, schematic: { ...(withOutline.schematic as object), outline: ring.slice(0, 2) } } as FootprintModule],
         [],
       ).placed[0].outline,
     ).toBeNull();
+  });
+
+  it("tessellates a curved (bulged) edge into an arc", () => {
+    const curvedRing = [
+      { x: 0, y: -10, bulge: -8 }, // bottom edge (→ +x) bows outward (down) by 8
+      { x: 100, y: -10 },
+      { x: 100, y: 10 },
+      { x: 0, y: 10 },
+    ];
+    const mod: FootprintModule = {
+      id: "m",
+      moduleName: "m",
+      lengthTotalInches: 100,
+      geometryType: "straight",
+      schematic: {
+        version: 1,
+        lengthInches: 100,
+        endplates: [{ id: "A" }, { id: "B" }],
+        tracks: [{ id: "main", role: "main", lane: 0, from: "A", to: "B" }],
+        outline: curvedRing,
+      },
+    };
+    const out = composeFootprint([mod], []).placed[0].outline!;
+    // Arc tessellation adds points beyond the 4 raw vertices…
+    expect(out.length).toBeGreaterThan(4);
+    // …and the bottom edge dips to ~ -18 (chord at -10, sagitta 8 outward/down).
+    const minY = Math.min(...out.map((p) => p.y));
+    expect(minY).toBeCloseTo(-18, 0);
   });
 });
 

--- a/lib/track/footprint.ts
+++ b/lib/track/footprint.ts
@@ -23,6 +23,7 @@ import {
   type LayoutJoin,
 } from "./layoutJoins";
 import { asModuleSchematic } from "./moduleSchematic";
+import { sampleOutline, type OutlineVertex } from "./outlineSample";
 
 export interface Pt {
   x: number;
@@ -207,15 +208,22 @@ export function composeFootprint(
     return typeof w === "number" && w > 0 ? w : RECOMMENDED_ENDPLATE_WIDTH_INCHES;
   };
   // Authored benchwork outline (module-local inches), read defensively so it
-  // renders the moment a doc carries it. A ring needs ≥3 finite points.
-  const outlineOf = (mid: string): Pt[] | null => {
+  // renders the moment a doc carries it. A ring needs ≥3 finite points; each
+  // vertex may carry a `bulge` (curved edge), preserved for arc sampling.
+  const outlineOf = (mid: string): OutlineVertex[] | null => {
     const doc = asModuleSchematic(byId.get(mid)?.schematic) as
-      | { outline?: { x: number; y: number }[] | null }
+      | { outline?: OutlineVertex[] | null }
       | null;
     const pts = (doc?.outline ?? []).filter(
       (p) => p && Number.isFinite(p.x) && Number.isFinite(p.y),
     );
-    return pts.length >= 3 ? pts.map((p) => ({ x: p.x, y: p.y })) : null;
+    return pts.length >= 3
+      ? pts.map((p) => ({
+          x: p.x,
+          y: p.y,
+          ...(Number.isFinite(p.bulge) && p.bulge ? { bulge: p.bulge } : {}),
+        }))
+      : null;
   };
 
   // Adjacency: placement -> joins touching it.
@@ -323,8 +331,10 @@ export function composeFootprint(
       return { id: p.id, x: w.x, y: w.y, heading: w.heading, width: widthOf(m.id, p.id) };
     });
     const localOutline = outlineOf(m.id);
+    // Sample arcs into a polyline in module-local coords, then transform rigidly
+    // (a reflected/rotated circular arc is still that arc).
     const outline = localOutline
-      ? localOutline.map((p) => applyPoint(t, p))
+      ? sampleOutline(localOutline).map((p) => applyPoint(t, p))
       : null;
     outline?.forEach(track);
     placed.push({

--- a/lib/track/outlineSample.ts
+++ b/lib/track/outlineSample.ts
@@ -1,0 +1,71 @@
+/**
+ * Benchwork-outline arc sampling — expand an authored outline (whose edges may
+ * be circular arcs via a per-vertex `bulge`) into a dense closed polyline. This
+ * mirrors `sampleBenchworkOutline` in @willcgage/module-schematic exactly so a
+ * curve looks identical in the Repository preview and here; kept local so FD
+ * renders curves without depending on the package's published typings. Pure.
+ */
+import type { Pt } from "./footprint";
+
+export interface OutlineVertex {
+  x: number;
+  y: number;
+  /** Signed sagitta (inches) of the arc from this vertex to the next; the arc
+   * midpoint is offset `bulge` perpendicular (+ = left of P→next) from the
+   * chord. 0/absent = straight edge. */
+  bulge?: number;
+}
+
+/** Expand an outline into a closed polyline, tessellating each bulged edge. */
+export function sampleOutline(pts: OutlineVertex[], segsPerArc = 20): Pt[] {
+  const n = pts.length;
+  if (n < 2) return pts.map((p) => ({ x: p.x, y: p.y }));
+  const out: Pt[] = [];
+  for (let i = 0; i < n; i++) {
+    const p0 = pts[i];
+    const p1 = pts[(i + 1) % n];
+    out.push({ x: p0.x, y: p0.y });
+    const bulge = p0.bulge ?? 0;
+    if (!bulge) continue;
+    const dx = p1.x - p0.x;
+    const dy = p1.y - p0.y;
+    const c = Math.hypot(dx, dy);
+    if (c < 1e-6) continue;
+    const nx = -dy / c;
+    const ny = dx / c;
+    const mid = { x: (p0.x + p1.x) / 2 + nx * bulge, y: (p0.y + p1.y) / 2 + ny * bulge };
+    const circ = circleThrough(p0, mid, p1);
+    if (!circ) continue;
+    const a0 = Math.atan2(p0.y - circ.cy, p0.x - circ.cx);
+    const am = Math.atan2(mid.y - circ.cy, mid.x - circ.cx);
+    const a1 = Math.atan2(p1.y - circ.cy, p1.x - circ.cx);
+    const sweep = arcSweep(a0, a1, am);
+    for (let s = 1; s < segsPerArc; s++) {
+      const a = a0 + (sweep * s) / segsPerArc;
+      out.push({ x: circ.cx + circ.r * Math.cos(a), y: circ.cy + circ.r * Math.sin(a) });
+    }
+  }
+  return out;
+}
+
+function circleThrough(a: Pt, b: Pt, c: Pt): { cx: number; cy: number; r: number } | null {
+  const d = 2 * (a.x * (b.y - c.y) + b.x * (c.y - a.y) + c.x * (a.y - b.y));
+  if (Math.abs(d) < 1e-9) return null;
+  const a2 = a.x * a.x + a.y * a.y;
+  const b2 = b.x * b.x + b.y * b.y;
+  const c2 = c.x * c.x + c.y * c.y;
+  const cx = (a2 * (b.y - c.y) + b2 * (c.y - a.y) + c2 * (a.y - b.y)) / d;
+  const cy = (a2 * (c.x - b.x) + b2 * (a.x - c.x) + c2 * (b.x - a.x)) / d;
+  return { cx, cy, r: Math.hypot(a.x - cx, a.y - cy) };
+}
+
+function arcSweep(a0: number, a1: number, am: number): number {
+  const norm = (x: number) => {
+    let v = (x - a0) % (2 * Math.PI);
+    if (v < 0) v += 2 * Math.PI;
+    return v;
+  };
+  const m = norm(am);
+  const one = norm(a1);
+  return m <= one ? one : one - 2 * Math.PI;
+}


### PR DESCRIPTION
The FD half of **curved benchwork edges** (shared contract is [module-schematic #5](https://github.com/willcgage/module-schematic/pull/5); the MR full-width curve editor is a separate PR). Ships **independently and green** — a local sampler mirrors the shared math, no package bump.

## What it does
A benchwork outline edge with a `bulge` draws as a **true circular arc** in the layout map instead of a straight chord — curved fronts, corner arcs. Straight edges and modules without an outline are unchanged.

## Changes
- **`lib/track/outlineSample.ts`** — `sampleOutline()` expands an outline into a dense polyline, tessellating each bulged edge along its circular arc (circle-through-3-points + arc sweep). Mirrors `sampleBenchworkOutline` in the shared package **exactly**, so a curve is identical in the Repository preview and here; kept local so FD renders curves without waiting on the publish.
- **`composeFootprint`** reads each vertex's `bulge`, samples arcs in **module-local** coords, then transforms rigidly (a rotated/reflected circular arc is still that arc).

## Verified
- **Unit:** a bulged edge tessellates to >4 points and dips to its sagitta. **174 tests pass**, typecheck clean.
- **Live:** a front edge bowed 10″ on a real module rendered as a **23-point arc** reaching **minY −22** (chord −12 + sagitta 10) with its **apex at x=48** (edge midpoint) — an exact arc (screenshot shows the bowed front).

## Pairs with
- Contract: [module-schematic #5](https://github.com/willcgage/module-schematic/pull/5).
- Authoring: the MR full-width benchwork page with drag-to-bow curves (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)