### PR TITLE
docs: drop SignPath as a signing option (application rejected)

### DIFF
--- a/docs/SIGNING.md
+++ b/docs/SIGNING.md
@@ -128,9 +128,13 @@ publisher" click-through. ~$9.99/month, no USB token, clears SmartScreen.
 Then run the Package workflow (`v*` tag or **Actions → Package installers → Run
 workflow**) — the Windows job produces a signed `.exe`.
 
-> Cheaper alternatives if you reconsider: **SignPath Foundation** (free for
-> open-source projects) or a **Certum** open-source cert (~$50). Plain `.pfx`
-> files are no longer issued — the private key must live on an HSM/token.
+> Alternatives if you reconsider: a **Certum** open-source cert (~$50). Plain
+> `.pfx` files are no longer issued — the private key must live on an HSM/token.
+>
+> **SignPath Foundation** (free for open source) was applied for and **rejected**
+> (2026-07), so it's not an option here. Azure Trusted Signing was attempted
+> first and abandoned when identity validation repeatedly failed — the setup
+> above is kept only in case that's revisited.
 
 ---
 


### PR DESCRIPTION
SignPath Foundation **rejected the application**, so it's not a route for this project. Removing the recommendation rather than leaving a dead end for the next reader.

## Changes
- `docs/SIGNING.md` — SignPath is no longer suggested. The note now records **why each option is gone** (Azure Trusted Signing abandoned after identity validation repeatedly failed; SignPath rejected 2026-07) so it isn't re-attempted from scratch. **Certum** (~$50) is the only remaining route if ever revisited.
- Dropped a stale `WebFetch(domain:signpath.org)` entry from local settings.

## No build change
SignPath was only ever a doc suggestion — it was never wired into the workflow. Windows installers continue to ship **unsigned** (SmartScreen click-through), which the doc's status table already stated. The dormant Azure plumbing stays put (it builds unsigned when the secrets are absent) in case that's ever revisited.

The **MIT license** added for SignPath eligibility stays — worth having regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)