### PR TITLE
feat: render authored industries in the operations schematic

### DIFF
--- a/components/layout/OperationsSchematic.tsx
+++ b/components/layout/OperationsSchematic.tsx
@@ -525,6 +525,52 @@ export function OperationsSchematic({
                   </g>
                 );
               })}
+              {/* Industries — a car-spot span beside its track, with a name +
+                  car-count label. What crews set out and the dispatcher reads. */}
+              {feat.industries.map((ind) => {
+                const x1 = px(ind.fromFrac);
+                const x2 = px(ind.toFrac);
+                const sideSign = ind.side === "below" ? 1 : -1;
+                const y = laneY(ind.lane) + sideSign * 3.5;
+                const cars = ind.cars > 0 ? `${ind.cars} car${ind.cars === 1 ? "" : "s"}` : "";
+                const label =
+                  ind.labelMode === "cars" && cars
+                    ? `${ind.name} · ${cars}`
+                    : ind.name;
+                return (
+                  <g key={`ind-${ind.id}`}>
+                    <line
+                      x1={x1}
+                      y1={y}
+                      x2={x2}
+                      y2={y}
+                      stroke="#d97706"
+                      strokeWidth={STROKE * 0.7}
+                      strokeLinecap="round"
+                    />
+                    {/* end ticks — the spot's extent */}
+                    <line x1={x1} y1={y - 1.6} x2={x1} y2={y + 1.6} stroke="#d97706" strokeWidth={0.9} />
+                    <line x1={x2} y1={y - 1.6} x2={x2} y2={y + 1.6} stroke="#d97706" strokeWidth={0.9} />
+                    {c.width > 24 && ind.labelMode !== "none" && label && (
+                      <text
+                        x={(x1 + x2) / 2}
+                        y={y + sideSign * 5}
+                        textAnchor="middle"
+                        fontSize="5"
+                        className="fill-amber-700"
+                        dominantBaseline={ind.side === "below" ? "hanging" : "auto"}
+                      >
+                        {label}
+                      </text>
+                    )}
+                    <title>
+                      {`${ind.name || "Industry"}${cars ? ` · ${cars}` : ""}${
+                        ind.carTypes.length ? ` (${ind.carTypes.join(", ")})` : ""
+                      }`}
+                    </title>
+                  </g>
+                );
+              })}
             </g>
           );
         })}

--- a/lib/track/__tests__/reverseFeatures.test.ts
+++ b/lib/track/__tests__/reverseFeatures.test.ts
@@ -39,6 +39,26 @@ describe("reverseModuleFeatures", () => {
     expect(r.signals[0].side).toBe("above"); // side unchanged
   });
 
+  it("mirrors an industry's span west↔east (lane/side unchanged)", () => {
+    const doc: ModuleSchematicDoc = {
+      version: 1,
+      lengthInches: 100,
+      endplates: [{ id: "A" }, { id: "B" }],
+      tracks: [
+        { id: "main", role: "main", lane: 0, from: "A", to: "B" },
+        { id: "sp", role: "spur", lane: 1, fromPos: 10, toPos: 60 },
+      ],
+      industries: [
+        { id: "i1", name: "Ace Feed", track: "sp", fromPos: 20, toPos: 53, side: "below" },
+      ],
+    };
+    const r = reverseModuleFeatures(moduleFeatures(doc));
+    expect(r.industries[0].fromFrac).toBeCloseTo(0.47); // 1 - 0.53
+    expect(r.industries[0].toFrac).toBeCloseTo(0.8); // 1 - 0.2
+    expect(r.industries[0].lane).toBe(1);
+    expect(r.industries[0].side).toBe("below");
+  });
+
   it("mirrors the single↔double transition to the other end", () => {
     // west double, transition turnout at 0.6 → after reverse, double end is east.
     const doc: ModuleSchematicDoc = {

--- a/lib/track/reverseFeatures.ts
+++ b/lib/track/reverseFeatures.ts
@@ -40,6 +40,12 @@ export function reverseModuleFeatures(f: ModuleFeatures): ModuleFeatures {
       ...b,
       posFrac: flip(b.posFrac),
     })),
+    industries: f.industries.map((ind) => ({
+      ...ind,
+      // Span stays sorted west→east after mirroring; lane/side left as-is.
+      fromFrac: flip(ind.toFrac),
+      toFrac: flip(ind.fromFrac),
+    })),
     main2Extent: f.main2Extent
       ? { fromFrac: flip(f.main2Extent.toFrac), toFrac: flip(f.main2Extent.fromFrac) }
       : null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@electric-sql/pglite": "^0.5.2",
-        "@willcgage/module-schematic": "^0.17.0",
+        "@willcgage/module-schematic": "^0.18.0",
         "bonjour-service": "^1.4.1",
         "drizzle-orm": "^0.45.2",
         "electron-updater": "^6.8.9",
@@ -4453,9 +4453,9 @@
       }
     },
     "node_modules/@willcgage/module-schematic": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.17.0.tgz",
-      "integrity": "sha512-2Tr+EF9xvW9Dvw5vpbP2oZj6celBNTyfU4EZ7eR9TyooRqdmQK3cEGDfXQPeMFErkq92EqpWGD32nV2iHJaLHA==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@willcgage/module-schematic/-/module-schematic-0.18.0.tgz",
+      "integrity": "sha512-eF6UwC8lgz0Q4cMAc0/y9ByrrSJjtyALj8E9swo+xxOxEWTGgTISYrpdre35TVfHV8yO+t8da3E+/VPzceM0Hw==",
       "license": "MIT",
       "engines": {
         "node": ">=18"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "@electric-sql/pglite": "^0.5.2",
-    "@willcgage/module-schematic": "^0.17.0",
+    "@willcgage/module-schematic": "^0.18.0",
     "bonjour-service": "^1.4.1",
     "drizzle-orm": "^0.45.2",
     "electron-updater": "^6.8.9",


### PR DESCRIPTION
The payoff of the industries work: **draw them in Free-Dispatcher**, where the dispatcher and crews actually read them. Consumes `@willcgage/module-schematic@0.18.0`; `features.industries` (`DrawIndustry`) comes resolved from the contract, so this is a **rendering** change.

## What's new
- **Industry overlay** in the straightened operations schematic — each industry draws as a **car-spot span** beside its track's lane, on its `side`, with **end ticks** and a **name + car-count** label (respecting the authored `labelMode`). The `<title>` tooltip lists the **car types** received.
- **Reverse fix** — `reverseModuleFeatures` now mirrors an industry's span west↔east (`fromFrac`/`toFrac`), so a **flipped** placement shows the industry on the correct end. Lane/side stay as-is, consistent with how tracks and signals reverse.

## Verification
Browser harness rendering `OperationsSchematic` with a module whose schematic carries an industry (deleted before commit):
- The span + two end ticks render (**3 amber marks**).
- Label reads **"Ace Feed · 10 cars"** (33″ ÷ 3.3 ✓).
- Tooltip: **"Ace Feed · 10 cars (covered_hopper, boxcar)"**.
- `tsc`, `eslint`, and the full suite (**170 tests**, +1 for the reverse mirroring) all pass.

Screenshots were unavailable in the preview browser this session, so the **visual polish** (placement, label legibility against the panel) is best eyeballed once real synced modules with industries are on a layout.

## The industries thread is now end-to-end
MR authors (span, capacity, car types) → contract carries → **FD renders**. Remaining polish: the click-to-place "I" tool in MR, and a "suggest a car type" affordance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)