### PR TITLE
fix: a junction module's branch endplates are not its axial ends

### DIFF
--- a/lib/track/__tests__/endplates.test.ts
+++ b/lib/track/__tests__/endplates.test.ts
@@ -81,6 +81,74 @@ describe("endplateConnections", () => {
   });
 });
 
+// modulerepo #245 — a junction module carries endplates C, D… placed along its
+// SIDE. They are not the ends it presents to its neighbours, and the axial
+// faces were being picked positionally, so the last record won.
+describe("a junction module's branch endplates are not its axial ends", () => {
+  /** FMN-0024's shape: A and B single (the through line), C and D double
+   * (the second railroad, in and out along the side). Four records today. */
+  const junction = (flipped = false): ModuleEndplates => ({
+    id: "j",
+    flipped,
+    endplates: [
+      { endplate_number: 1, label: "UP Spokane N", track_config: "single" },
+      { endplate_number: 2, label: "UP Plummer W", track_config: "single" },
+      { endplate_number: 3, label: "MR St Maries e", track_config: "double" },
+      { endplate_number: 4, label: "MR Plummer S", track_config: "double" },
+    ],
+  });
+
+  it("reads A and B, not the first and last record", () => {
+    expect(inConfig(junction())).toBe("single");
+    // ⛔ Positionally this was endplate D — "double" — so a junction module
+    // joined to a single-track neighbour reported a mismatch that isn't there.
+    expect(outConfig(junction())).toBe("single");
+  });
+
+  it("still mismatches on a real disagreement at the axial ends", () => {
+    const conns = endplateConnections([
+      junction(),
+      { id: "n", endplates: [{ endplate_number: 1, track_config: "double" }] },
+    ]);
+    expect(conns[0].status).toBe("mismatch");
+  });
+
+  it("does not report a mismatch that only the branch plates would cause", () => {
+    const conns = endplateConnections([
+      junction(),
+      { id: "n", endplates: [{ endplate_number: 1, track_config: "single" }] },
+    ]);
+    expect(conns[0].status).toBe("ok");
+  });
+
+  it("flip still swaps the two axial ends, and only those", () => {
+    const asym: ModuleEndplates = {
+      id: "t",
+      flipped: true,
+      endplates: [
+        { endplate_number: 1, track_config: "single" },
+        { endplate_number: 2, track_config: "double" },
+        { endplate_number: 3, track_config: "single" },
+      ],
+    };
+    expect(inConfig(asym)).toBe("double");
+    expect(outConfig(asym)).toBe("single");
+  });
+
+  it("falls back to the first two when the payload carries no numbers", () => {
+    // Older sync payloads, and every fixture written before #245.
+    const legacy: ModuleEndplates = {
+      id: "l",
+      endplates: [
+        { track_config: "single" },
+        { track_config: "double" },
+      ],
+    };
+    expect(inConfig(legacy)).toBe("single");
+    expect(outConfig(legacy)).toBe("double");
+  });
+});
+
 describe("endplateMismatches", () => {
   it("returns only the mismatched joins", () => {
     const mismatches = endplateMismatches([

--- a/lib/track/endplates.ts
+++ b/lib/track/endplates.ts
@@ -10,6 +10,11 @@
  */
 
 export interface EndplateInfo {
+  /** Which face this is: 1 = A, 2 = B. 3+ are BRANCH endplates (modulerepo
+   * #170) — a junction module's extra connections, which are not part of the
+   * linear chain and must never be mistaken for its axial ends. Absent on
+   * payloads older than modulerepo #245; see `axialEnds`. */
+  endplate_number?: number | null;
   label?: string | null;
   track_config?: string | null;
 }
@@ -41,22 +46,46 @@ function norm(v: string | null | undefined): string | null {
   return t.length > 0 ? t : null;
 }
 
-/** Endplates in facing order (flip reverses which end is in vs out). */
-function ordered(m: ModuleEndplates): EndplateInfo[] {
+/**
+ * The module's two AXIAL ends — A then B — in facing order.
+ *
+ * ⛔ THIS USED TO BE `eps[0]` AND `eps[eps.length - 1]`, which is only ever
+ * right for a module with exactly two endplates (modulerepo #245). A junction
+ * module has more: endplates C, D… are BRANCH connections placed along its
+ * side, not the ends it presents to the modules before and after it in the
+ * chain. Positionally, the last element of a four-plate module is D — so the
+ * builder was comparing a branch connection against the next module's front
+ * face and calling the result a mismatch.
+ *
+ * That is not hypothetical: FMN-0012, FMN-0017 and FMN-0024 each carry four
+ * endplate records today.
+ *
+ * `endplate_number` identifies the face (1 = A, 2 = B) and has always been in
+ * the payload — it simply wasn't read. When it is absent (an older payload, or
+ * a test fixture that omits it) we fall back to the first two entries, which is
+ * exactly the old behaviour for the two-plate case that fallback can arise in.
+ */
+function axialEnds(m: ModuleEndplates): EndplateInfo[] {
   const eps = m.endplates ?? [];
-  return m.flipped ? [...eps].reverse() : eps;
+  const numbered = eps.some((e) => e.endplate_number != null);
+  const ends = numbered
+    ? ([1, 2]
+        .map((n) => eps.find((e) => e.endplate_number === n))
+        .filter((e): e is EndplateInfo => e != null))
+    : eps.slice(0, 2);
+  return m.flipped ? [...ends].reverse() : ends;
 }
 
 /** The track_config of the endplate that faces the NEXT module. */
 export function outConfig(m: ModuleEndplates): string | null {
-  const eps = ordered(m);
-  return eps.length > 0 ? norm(eps[eps.length - 1].track_config) : null;
+  const ends = axialEnds(m);
+  return ends.length > 0 ? norm(ends[ends.length - 1].track_config) : null;
 }
 
 /** The track_config of the endplate that faces the PREVIOUS module. */
 export function inConfig(m: ModuleEndplates): string | null {
-  const eps = ordered(m);
-  return eps.length > 0 ? norm(eps[0].track_config) : null;
+  const ends = axialEnds(m);
+  return ends.length > 0 ? norm(ends[0].track_config) : null;
 }
 
 /**


### PR DESCRIPTION
One half of modulerepo [#245](https://github.com/willcgage/modulerepo/issues/245). **This is a live bug today**, independent of anything in that issue's title.

## The defect

`outConfig`/`inConfig` took `eps[0]` and `eps[eps.length - 1]` as the two faces a module presents to its neighbours. That is only ever right for a module with **exactly two** endplates.

A junction module has more. Endplates C, D… are **branch connections placed along its side** (modulerepo #170) — not the ends it offers to the modules before and after it in the chain. Positionally, the last record of a four-plate module is **D**, so the layout builder was comparing a branch connection against the next module's front face and calling the result a mismatch.

## Not hypothetical

Three modules carry four endplate records on prod today:

| module | A | B | C | D |
|---|---|---|---|---|
| FMN-0024 | single | single | **double** | **double** |
| FMN-0012 | single | single | single | double |
| FMN-0017 | double | double | double | double |

FMN-0024's axial ends are both **single**, while the two branch plates — a second railroad crossing the module — are **double**. So it reported a mismatch against every single-track neighbour it was placed beside, and the reported "outgoing" config was a plate that faces sideways.

## The fix

`endplate_number` identifies the face (1 = A, 2 = B). It has been in the `modules-full` payload all along — it simply wasn't read, and `EndplateInfo` didn't declare it. It passes through `ModuleRepoSync` verbatim, so **no sync or schema change is needed**.

Falls back to the first two entries when no record carries a number — an older payload, or a fixture written before this. That is exactly the old behaviour in the two-plate case, which is the only case such a payload can meaningfully be in.

## The other half

The imported `endplateCount` is a DB-trigger row tally in modulerepo that under-reports a branch endplate placed on the board. Fixed there; it reaches FD when the `modules-full` edge function is deployed.

## Verification

**176/176 tests pass** (5 new, covering the four-plate case, flip, a real mismatch still being caught, and the unnumbered fallback). `tsc` and `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)